### PR TITLE
Add travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# TravisCI (https://travis-ci.org) configuration file
+# https://docs.travis-ci.com/user/languages/python
+
+language: python
+
+python:
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+
+script:
+  # compile all files - ensure that syntax is correct
+  - python -m compileall common common/test common/plugins qt4 qt4/plugins
+  # run unit tests - ensure that functionality is correct
+  - cd common && ./configure && make unittest-v

--- a/common/test/__init__.py
+++ b/common/test/__init__.py
@@ -15,5 +15,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from test import test_applicationinstance
+from test import test_argparser
+from test import test_configfile
+from test import test_snapshots
+from test import test_tools
+
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
This is more of an experiment for fun than anything else! (So you won't make me feel bad if you don't want it for any reason).

I'm a big fan of continuous integration systems for running compilation, tests, etc on every check-in. I've used Cruisecontrol, Hudson, Jenkins, and others for many years and they've been a big help. I've recently been exposed to [TravisCI](https://travis-ci.org/), a free CI service for open-source projects. It's very similar in features to the other big CI systems.

I tried my hand at adding a [TravisCI configuration file](https://docs.travis-ci.com/user/languages/python), and I created a travis CI account and [connected it to my personal BIT fork](https://travis-ci.org/dinoboy197/backintime). So anytime I check in to any of my fork's branches, the CI system builds and runs tests, then emails me if there are any issues.

I've included the travisci configuration file that I'm using.

The one caveat is that the unit tests don't currently pass when executing in TravisCI. I'm not sure if this is because we need to tell travisCI to install some extra library dependencies, or the UnitTest framework isn't picking up the python paths of some of the files correctly, or something else entirely (like me setting something up incorrectly :). It's so close to working! I have the single line which runs unit tests commented out, but am still running the python compiler to verify that the syntax is ok.

Anyway, I thought you might be interested in taking a look. I'm not sure if you'll have access to my travisCI instance, but [here is one of the pages which shows the unit test failures](https://travis-ci.org/dinoboy197/backintime/jobs/99375128). I have the unit tests running in verbose mode to try to debug, but alas I'm not enough of a Python unit test expert to know exactly what might be going on (most of my unit test experience is in Java and Scala!)