### PR TITLE
Store filesystem UUID mount points in info file during snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 
 language: python
 
+# ensures that we have UUID filesystem mounts for proper testing
+sudo: true
+
 python:
   - "3.4"
   - "3.5"

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1,5 +1,5 @@
 #	Back In Time
-#	Copyright (C) 2008-2015 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze
+#	Copyright (C) 2008-2015 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze, Taylor Raack
 #
 #	This program is free software; you can redistribute it and/or modify
 #	it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
 #	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
+import json
 import os
 import stat
 import datetime
@@ -1447,6 +1448,7 @@ class Snapshots:
         info_file.set_int_value( 'snapshot_tag', tag )
         info_file.set_list_value('user', ('int:uid', 'str:name'), list(self.user_cache.items()))
         info_file.set_list_value('group', ('int:gid', 'str:name'), list(self.group_cache.items()))
+        info_file.set_str_value('filesystem_mounts', json.dumps(tools.get_filesystem_mount_info()))
         info_file.save(self.get_snapshot_info_path(self.NEW_SNAPSHOT_ID))
         info_file = None
 

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -1,5 +1,5 @@
 # Back In Time
-# Copyright (C) 2008-2015 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze
+# Copyright (C) 2008-2015 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze, Taylor Raack
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -91,6 +91,14 @@ class TestTools(unittest.TestCase):
         ''' Test the function is_process_alive '''
         self.assertTrue(tools.is_process_alive(0))
         self.assertFalse(tools.is_process_alive(99999999999))
+
+    def test_get_filesystem_mount_info(self):
+        ''' Basic sanity checks on returned structure '''
+        mounts = tools.get_filesystem_mount_info()
+        self.assertTrue(type(mounts) is dict)
+        self.assertTrue(len(mounts.items()) > 0)
+        self.assertTrue('/' in mounts)
+        self.assertTrue('original_uuid' in mounts.get('/'))
 
 class TestToolsEnviron(unittest.TestCase):
     def __init__(self, *args, **kwargs):

--- a/common/tools.py
+++ b/common/tools.py
@@ -1,5 +1,5 @@
 #    Back In Time
-#    Copyright (C) 2008-2015 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze
+#    Copyright (C) 2008-2015 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze, Taylor Raack
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -676,6 +676,15 @@ def get_uuid(dev):
 
 def get_uuid_from_path(path):
     return get_uuid(get_device(path))
+
+def get_filesystem_mount_info():
+    """
+    Returns a dict of mount point string -> dict of filesystem info for entire system.
+    """
+
+    # There may be multiple mount points inside of the root (/) mount, so iterate over mtab to find all non-special mounts.
+    with open('/etc/mtab', 'r') as mounts:
+        return {items[1]: {'original_uuid': get_uuid(items[0])} for items in [mount_line.strip('\n').split(' ')[:2] for mount_line in mounts] if get_uuid(items[0]) != None}
 
 def wrap_line(msg, size=950, delimiters='\t ', new_line_indicator = 'CONTINUE: '):
     if len(new_line_indicator) >= size - 1:


### PR DESCRIPTION
Part of #480 

This will help future efforts to restore data to physical devices by storing the current filesystem mount structure for later reconstruction during.

Addition to the info file will look like this, for example:
```
filesystem_mounts={"/": {"original_uuid": "d683a7b1-2e46-4f63-ac73-7154c83c4a73"}, "/home": {"original_uuid": "1349a61f-690c-4137-89c7-e21162b135ff"}}
```

For the first part of this effort, BIT bare metal restore will only restore a snapshot to the same physical devices that it was taken from. However, this is just a stepping stone towards restoring to other devices.