### PR TITLE
Fix file info persistence errors

### DIFF
--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -700,9 +700,9 @@ class TestSID(GenericSnapshotsTestCase):
                                 '20151219-010324-123',
                                 'fileinfo.bz2')
 
-        d = {}
-        d['/tmp']     = (123, 'foo', 'bar')
-        d['/tmp/foo'] = (456, 'asdf', 'qwer')
+        d = snapshots.FileInfoDict()
+        d[b'/tmp']     = (123, b'foo', b'bar')
+        d[b'/tmp/foo'] = (456, b'asdf', b'qwer')
         sid1.fileInfo = d
 
         self.assertTrue(os.path.isfile(infoFile))


### PR DESCRIPTION
Fixes #523:
1) [```path``` is bytes (and is asserted to be so) when it is set as the key to the fileinfodict](https://github.com/bit-team/backintime/blob/master/common/snapshots.py#L811)
2) [```path``` is still bytes when it's getting ready to be saved, but is now asserted to be a string - which fails instantly](https://github.com/bit-team/backintime/blob/master/common/snapshots.py#L2167).

I fixed a unit test which made an incorrect assumption about the ```fileInfoDict``` keys - it assumed they would be ```String```s from upstream in code in ```_take_snapshot()```, when in fact they are ```Byte``` arrays. Also verified that this fix allows snapshots to complete successfully.

@Germar - Seems like having a big end-to-end test of the snapshot and restore functionality would be good to ensure that the full behavior of BIT (at least the main success cases) always pass. Should we work on building one?