### PR TITLE
Fix file info reading

### DIFF
--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -405,12 +405,11 @@ class Snapshots:
             key_path (bytes):       original path during backup.
                                     Same as in fileInfoDict.
             path (bytes):           current path of file that should be changed.
-            fileInfoDict (dict):    dict with key_path as key (bytes) and
-                                    value of tuple
-                                    (mode(int), username(bytes), groupname(bytes))
+            fileInfoDict (FileInfoDict):    FileInfoDict
         """
         assert isinstance(key_path, bytes), 'key_path is not bytes type: %s' % key_path
         assert isinstance(path, bytes), 'path is not bytes type: %s' % path
+        assert isinstance(fileInfoDict, FileInfoDict), 'fileInfoDict is not FileInfoDict type: %s' % fileInfoDict
         if key_path not in fileInfoDict or not os.path.exists(path):
             return
         info = fileInfoDict[key_path]
@@ -2141,12 +2140,12 @@ class SID(object):
         Load/save "fileinfo.bz2"
 
         Args:
-            d (dict):   dict of: {path: (permission, user, group)}
+            d (FileInfoDict): dict of: {path: (permission, user, group)}
 
         Returns:
-            dict:       dict of: {path: (permission, user, group)}
+            FileInfoDict:     dict of: {path: (permission, user, group)}
         """
-        d = {}
+        d = FileInfoDict()
         infoFile = self.path(self.FILEINFO)
         if not os.path.isfile(infoFile):
             return d
@@ -2154,16 +2153,16 @@ class SID(object):
         try:
             with bz2.BZ2File(infoFile, 'rb') as fileinfo:
                 for line in fileinfo:
-                    line = line.strip(b'\n').decode('utf-8')
+                    line = line.strip(b'\n')
                     if not line:
                         continue
-                    index = line.find('/')
+                    index = line.find(b'/')
                     if index < 0:
                         continue
                     f = line[index:]
                     if not f:
                         continue
-                    info = line[:index].strip().split(' ')
+                    info = line[:index].strip().split(b' ')
                     if len(info) == 3:
                         d[f] = (int(info[0]), info[1], info[2]) #perms, user, group
         except Exception as e:

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -311,8 +311,9 @@ class TestRestorePathInfo(GenericSnapshotsTestCase):
         self.run = True
 
     def test_no_changes(self):
-        d = {b'foo': (self.modeFolder, CURRENTUSER, CURRENTGROUP),
-             b'bar': (self.modeFile, CURRENTUSER, CURRENTGROUP)}
+        d = snapshots.FileInfoDict()
+        d[b'foo'] = (self.modeFolder, CURRENTUSER.encode('utf-8','replace'), CURRENTGROUP.encode('utf-8','replace'))
+        d[b'bar'] = (self.modeFile, CURRENTUSER.encode('utf-8','replace'), CURRENTGROUP.encode('utf-8','replace'))
 
         callback = lambda x: self.callback(self.fail,
                              'callback function was called unexpectedly')
@@ -332,8 +333,9 @@ class TestRestorePathInfo(GenericSnapshotsTestCase):
     #TODO: add fakeroot tests with https://github.com/yaybu/fakechroot
     @unittest.skipIf(IS_ROOT, "We're running as root. So this test won't work.")
     def test_change_owner_without_root(self):
-        d = {b'foo': (self.modeFolder, 'root', CURRENTGROUP),
-             b'bar': (self.modeFile, 'root', CURRENTGROUP)}
+        d = snapshots.FileInfoDict()
+        d[b'foo'] = (self.modeFolder, 'root'.encode('utf-8','replace'), CURRENTGROUP.encode('utf-8','replace'))
+        d[b'bar'] = (self.modeFile, 'root'.encode('utf-8','replace'), CURRENTGROUP.encode('utf-8','replace'))
 
         callback = lambda x: self.callback(self.assertRegex, x,
                              r'^chown /tmp/test/(?:foo|bar) 0 : {} : \w+$'.format(CURRENTGID))
@@ -360,8 +362,9 @@ class TestRestorePathInfo(GenericSnapshotsTestCase):
     def test_change_group(self):
         newGroup = GROUPS[0]
         newGID = grp.getgrnam(newGroup).gr_gid
-        d = {b'foo': (self.modeFolder, CURRENTUSER, newGroup),
-             b'bar': (self.modeFile, CURRENTUSER, newGroup)}
+        d = snapshots.FileInfoDict()
+        d[b'foo'] = (self.modeFolder, CURRENTUSER.encode('utf-8','replace'), newGroup.encode('utf-8','replace'))
+        d[b'bar'] = (self.modeFile, CURRENTUSER.encode('utf-8','replace'), newGroup.encode('utf-8','replace'))
 
         callback = lambda x: self.callback(self.assertRegex, x,
                              r'^chgrp /tmp/test/(?:foo|bar) {}$'.format(newGID))
@@ -387,8 +390,9 @@ class TestRestorePathInfo(GenericSnapshotsTestCase):
     def test_change_permissions(self):
         newModeFolder = 16832 #rwx------
         newModeFile   = 33152 #rw-------
-        d = {b'foo': (newModeFolder, CURRENTUSER, CURRENTGROUP),
-             b'bar': (newModeFile, CURRENTUSER, CURRENTGROUP)}
+        d = snapshots.FileInfoDict()
+        d[b'foo'] = (newModeFolder, CURRENTUSER.encode('utf-8','replace'), CURRENTGROUP.encode('utf-8','replace'))
+        d[b'bar'] = (newModeFile, CURRENTUSER.encode('utf-8','replace'), CURRENTGROUP.encode('utf-8','replace'))
 
         callback = lambda x: self.callback(self.assertRegex, x,
                              r'^chmod /tmp/test/(?:foo|bar) \d+$')
@@ -708,9 +712,8 @@ class TestSID(GenericSnapshotsTestCase):
         self.assertTrue(os.path.isfile(infoFile))
 
         #load fileInfo in a new snapshot
-        sid2 = snapshots.SID('20151219-010324-123', self.cfg)
-        self.assertDictEqual(sid2.fileInfo, {'/tmp':     (123, 'foo', 'bar'),
-                                             '/tmp/foo': (456, 'asdf', 'qwer')})
+        sid2 = snapshots.SID('20151219-010324-123', self.cfg)        
+        self.assertDictEqual(sid2.fileInfo, d)
 
     def test_log(self):
         sid = snapshots.SID('20151219-010324-123', self.cfg)


### PR DESCRIPTION
Issue #523 :

Reading fileinfo currently doesn't read the path back in as binary, which is expected by downstream restore code. As a result, when files are restored they don't get their uid / gid / perms set because the paths restored don't exist as keys in the fileinfo dict (the dict keys are strings, but the path checked is bytes).

I've verified that this fix actually works - restored files now get their uid / gid / perms set correctly.