### PR TITLE
Fuse mounts for SSH, Local Encrypted, and SSH encrypted are read-only by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,27 @@ language: python
 # ensures that we have UUID filesystem mounts for proper testing
 sudo: true
 
+addons:
+  # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
+  ssh_known_hosts: localhost
+
 python:
   - "3.4"
   - "3.5"
   - "3.5-dev" # 3.5 development branch
   - "nightly" # currently points to 3.6-dev
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y sshfs
+
 install:
   - pip install coveralls
+  # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
+  - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
+  - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+  # start ssh-agent so that we can add private keys
+  - eval `ssh-agent -s`
 
 script:
   # compile all files - ensure that syntax is correct

--- a/common/mount.py
+++ b/common/mount.py
@@ -1,4 +1,4 @@
-#    Copyright (C) 2012-2016 Germar Reitze
+#    Copyright (C) 2012-2016 Germar Reitze, Taylor Raack
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ from exceptions import MountException, HashCollision
 _=gettext.gettext
 
 class Mount(object):
-    def __init__(self, cfg = None, profile_id = None, tmp_mount = False, parent = None):
+    def __init__(self, cfg = None, profile_id = None, tmp_mount = False, parent = None, read_only = True):
         self.config = cfg
         if self.config is None:
             self.config = config.Config()
@@ -41,6 +41,7 @@ class Mount(object):
 
         self.tmp_mount = tmp_mount
         self.parent = parent
+        self.read_only = read_only
 
         if self.config.get_password_use_cache(self.profile_id):
             pw_cache = password.Password_Cache(self.config)
@@ -82,7 +83,7 @@ class Mount(object):
                     mounttools = self.config.SNAPSHOT_MODES[mode][0]
                     tools = mounttools(cfg = self.config, profile_id = self.profile_id,
                                        tmp_mount = self.tmp_mount, mode = mode,
-                                       parent = self.parent, **kwargs)
+                                       parent = self.parent, read_only = self.read_only, **kwargs)
                     return tools.mount(check = check)
                 except HashCollision as ex:
                     logger.warning(str(ex), self)
@@ -128,7 +129,7 @@ class Mount(object):
             mounttools = self.config.SNAPSHOT_MODES[mode][0]
             tools = mounttools(cfg = self.config, profile_id = self.profile_id,
                                tmp_mount = self.tmp_mount, mode = mode,
-                               parent = self.parent, **kwargs)
+                               parent = self.parent, read_only = self.read_only, **kwargs)
             return tools.pre_mount_check(first_run)
 
     def remount(self, new_profile_id, mode = None, hash_id = None, **kwargs):
@@ -156,7 +157,7 @@ class Mount(object):
         mounttools = self.config.SNAPSHOT_MODES[mode][0]
         tools = mounttools(cfg = self.config, profile_id = new_profile_id,
                            tmp_mount = self.tmp_mount, mode = mode,
-                           parent = self.parent, **kwargs)
+                           parent = self.parent, read_only = self.read_only, **kwargs)
         if tools.compare_remount(hash_id):
             #profiles uses the same settings. just swap the symlinks
             tools.remove_symlink(profile_id = self.profile_id)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -725,7 +725,7 @@ class Snapshots:
 
                 #mount
                 try:
-                    hash_id = mount.Mount(cfg = self.config).mount()
+                    hash_id = mount.Mount(cfg = self.config, read_only = False).mount()
                 except MountException as ex:
                     logger.error(str(ex), self)
                     instance.exit_application()

--- a/common/test/test_encfstools.py
+++ b/common/test/test_encfstools.py
@@ -1,0 +1,37 @@
+# Back In Time
+# Copyright (C) 2016 Taylor Raack, Germar Reitze
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public Licensealong
+# with this program; if not, write to the Free Software Foundation,Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import os
+import sys
+from test import generic
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+class TestEncFS_mount(generic.TestCase):
+
+# encrypted filesystem verification seems quite complex to unit test at the moment, partially due to
+# UI elements being created and expecting input, without tests for pre-prepared unit test fixture data
+
+# TODO - perhaps pass encrypted fs class object which can be queried for passwords when necessary (so runtime
+# can pass UI classes which can bring up actual UI elements and return credentials or unit tests can pass
+# objects which can return hard coded passwords to prevent UI popups in Travis)
+
+# TODO - then - code actual tests and remove this one
+    def setUp(self):
+        super(TestEncFS_mount, self).setUp()
+
+    def test_dummy(self):
+        self.assertTrue(True)

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -1,0 +1,79 @@
+# Back In Time
+# Copyright (C) 2016 Taylor Raack, Germar Reitze
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public Licensealong
+# with this program; if not, write to the Free Software Foundation,Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import os
+import sys
+import tempfile
+import unittest
+from test import generic
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import config
+import logger
+import mount
+
+ON_TRAVIS = os.environ.get('TRAVIS', 'None').lower() == 'true'
+            
+class TestSSH(generic.TestCase):
+    # running this test requires that user has public / private key pair created and ssh server running
+
+    def setUp(self):
+        super(TestSSH, self).setUp()
+        logger.DEBUG = '-v' in sys.argv
+        self.config = config.Config()
+        self.config.set_snapshots_mode('ssh')
+        self.config.set_ssh_host('localhost')
+        self.config.set_ssh_private_key_file(os.path.expanduser(os.path.join("~",".ssh","id_rsa")))
+        self.mount_kwargs = {}
+
+    @unittest.skipIf(not ON_TRAVIS, 'Skip as this test requires a local ssh server, public and private keys installed')
+    def test_can_mount_ssh_rw(self):
+        self.internal_test(read_only = False, implicit_read_only = False)
+
+    @unittest.skipIf(not ON_TRAVIS, 'Skip as this test requires a local ssh server, public and private keys installed')   
+    def test_can_mount_ssh_ro_implicitly(self):
+        self.internal_test(read_only = True, implicit_read_only = True)
+
+    @unittest.skipIf(not ON_TRAVIS, 'Skip as this test requires a local ssh server, public and private keys installed')
+    def test_can_mount_ssh_ro_explicitly(self):
+        self.internal_test(read_only = True, implicit_read_only = False)
+ 
+    def internal_test(self, read_only, implicit_read_only):
+        with tempfile.TemporaryDirectory() as dirpath:
+            self.config.set_snapshots_path_ssh(dirpath)
+
+            if implicit_read_only:
+                mnt = mount.Mount(cfg = self.config, tmp_mount = True)
+            else:
+                mnt = mount.Mount(cfg = self.config, tmp_mount = True, read_only = read_only)
+            mnt.pre_mount_check(mode = 'ssh', first_run = True, **self.mount_kwargs)
+
+            try:
+                hash_id = mnt.mount(mode = 'ssh', check = False, **self.mount_kwargs)
+                full_path = os.path.expanduser(os.path.join("~",".local","share","backintime","mnt",hash_id,"mountpoint","testfile"))
+
+                # warning - don't use os.access for checking writability
+                # https://github.com/bit-team/backintime/issues/490#issuecomment-156265196
+                if read_only:
+                    with self.assertRaisesRegex(OSError, "Read-only file system"):
+                        with open(full_path, 'wt') as f:
+                            f.write('foo')
+                else:
+                    with open(full_path, 'wt') as f:
+                        f.write('foo')
+            finally:
+                mnt.umount(hash_id = hash_id)

--- a/qt4/settingsdialog.py
+++ b/qt4/settingsdialog.py
@@ -1320,9 +1320,18 @@ class SettingsDialog( QDialog ):
         self.config.set_ssh_prefix_enabled(self.cb_ssh_prefix.isChecked() )
         self.config.set_ssh_prefix(self.txt_ssh_prefix.text() )
 
+        # TODO - consider a single API method to bridge the UI layer (settings dialog) and backend layer (config)
+        # when setting snapshots path rather than having to call the mount module from the UI layer
+        # 
+        # currently, setting snapshots path requires the path to be mounted. it seems that it might be nice,
+        # since the config object is more than a data structure, but has side-effect logic as well, to have the
+        # config.set_snapshots_path() method take care of everything it needs to perform its job
+        # (mounting and unmounting the fuse filesystem if necessary).
+        # https://en.wikipedia.org/wiki/Single_responsibility_principle
+
         if not self.config.SNAPSHOT_MODES[mode][0] is None:
             #pre_mount_check
-            mnt = mount.Mount(cfg = self.config, tmp_mount = True, parent = self)
+            mnt = mount.Mount(cfg = self.config, tmp_mount = True, parent = self, read_only = False)
             try:
                 mnt.pre_mount_check(mode = mode, first_run = True, **mount_kwargs)
             except MountException as ex:


### PR DESCRIPTION
@Germar , per our email discussion this is part of the precursor work to moving towards full-rsync mode for all backup modes.

I thought it would be prudent to add read-only for mounts through fuse as a default constructor argument to the ```Mount``` object, in case there is a time in the future when mounting in non-read-only mode is desired. The UI or some other method calling into the ```Mount``` class could pass the read-only flag as they desire.

On testing - I'm not sure what the best way to unit-test or end-to-end test this is at the moment. I think I'd have to set up ssh for the test rig, which I think could be a bigger effort which might be better isolated in a different piece of work? What do you think?

