### PR TITLE
Added basic local snapshot end to end test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ addons:
 
 python:
   - "3.4"
-  - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
 
 before_install:
   - sudo apt-get -qq update

--- a/common/cli.py
+++ b/common/cli.py
@@ -35,7 +35,7 @@ def restore(cfg, snapshot_id = None, what = None, where = None, **kwargs):
 
     snapshots_list = snapshots.listSnapshots(cfg)
 
-    sid = selectSnapshot(snapshots_list, snapshot_id, 'SnapshotID to restore')
+    sid = selectSnapshot(snapshots_list, cfg, snapshot_id, 'SnapshotID to restore')
     print('')
     RestoreDialog(cfg, sid, what, where, **kwargs).run()
 
@@ -43,7 +43,7 @@ def remove(cfg, snapshot_ids = None, force = None):
     snapshots_list = snapshots.listSnapshots(cfg)
     if not snapshot_ids:
         snapshot_ids = (None,)
-    sids = [selectSnapshot(snapshots_list, sid, 'SnapshotID to remove') for sid in snapshot_ids]
+    sids = [selectSnapshot(snapshots_list, cfg, sid, 'SnapshotID to remove') for sid in snapshot_ids]
 
     if not force:
         print('Do you really want to remove this snapshots?')
@@ -135,24 +135,24 @@ def checkConfig(cfg, crontab = True):
 
     return True
 
-def selectSnapshot(snapshots_list, snapshot_id = None, msg = 'SnapshotID'):
+def selectSnapshot(snapshots_list, cfg, snapshot_id = None, msg = 'SnapshotID'):
     """
     check if given snapshot is valid. If not print a list of all
     snapshots and ask to choose one
     """
-    len_snapshots = len(snapshot_list)
+    len_snapshots = len(snapshots_list)
 
     if not snapshot_id is None:
         try:
-            sid = snapshots.SID(snapshot_id)
-            if sid in snapshot_list:
+            sid = snapshots.SID(snapshot_id, cfg)
+            if sid in snapshots_list:
                 return sid
             else:
                 print('SnapshotID %s not found.' % snapshot_id)
         except ValueError:
             try:
                 index = int(snapshot_id)
-                return snapshot_list[index]
+                return snapshots_list[index]
             except (ValueError, IndexError):
                 print('Invalid SnaphotID index: %s' % snapshot_id)
     snapshot_id = None
@@ -169,13 +169,13 @@ def selectSnapshot(snapshots_list, snapshot_id = None, msg = 'SnapshotID'):
             index = row + column * rows
             if index > len_snapshots - 1:
                 continue
-            line.append('{i:>4}: {s}'.format(i = index, s = snapshot_list[index]))
+            line.append('{i:>4}: {s}'.format(i = index, s = snapshots_list[index]))
         print(' '.join(line))
     print('')
     while snapshot_id is None:
         try:
             index = int(input(msg + ' ( 0 - %d ): ' % (len_snapshots - 1) ))
-            snapshot_id = snapshot_list[index]
+            snapshot_id = snapshots_list[index]
         except (ValueError, IndexError):
             print('Invalid Input')
             continue

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -16,6 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os
+import re
 import subprocess
 import sys
 from test import generic
@@ -30,3 +31,86 @@ class TestBackInTime(generic.TestCase):
 
     def test_quiet_mode(self):
         self.assertEquals("", subprocess.getoutput("python3 backintime.py --quiet"))
+    
+    # end to end test - from BIT initialization all the way through successful snapshot on a local mount
+    # test one of the highest level interfaces a user could work with - the command line
+    # ensures that argument parsing, functionality, and output all work as expected
+    # is NOT intended to replace individual method tests, which are incredibly useful as well
+    def test_local_snapshot_is_successful(self):
+        # ensure that we see full diffs of assert output if there are any
+        self.maxDiff = None
+
+        # create pristine source directory with single file
+        subprocess.getoutput("chmod -R a+rwx /tmp/test && rm -rf /tmp/test")
+        os.mkdir('/tmp/test')
+        with open('/tmp/test/testfile', 'w') as f:
+            f.write('some data')
+
+        # create pristine snapshot directory
+        subprocess.getoutput("chmod -R a+rwx /tmp/snapshots && rm -rf /tmp/snapshots")
+        os.mkdir('/tmp/snapshots')
+
+        # remove restored directory
+        subprocess.getoutput("rm -rf /tmp/restored")
+        
+        # install proper destination filesystem structure and verify output
+        output = subprocess.check_output(["./backintime","--config","test/config","check-config"])
+
+        self.assertRegex(output.decode(), re.compile('''
+Back In Time
+Version: \d+.\d+.\d+ .*
+
+Back In Time comes with ABSOLUTELY NO WARRANTY.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `backintime --license' for details.
+
+
+ ┌────────────────────────────────┐
+ │  Check/prepair snapshot path   │
+ └────────────────────────────────┘
+Check/prepair snapshot path: done
+
+ ┌────────────────────────────────┐
+ │          Check config          │
+ └────────────────────────────────┘
+Check config: done
+
+ ┌────────────────────────────────┐
+ │        Install crontab         │
+ └────────────────────────────────┘
+Install crontab: done
+
+Config test/config profile 'Main profile' is fine.''', re.MULTILINE))
+        
+        # execute backup and verify output
+        # TODO - verify exit code is 0. using check_output() hangs, not sure why. tried shell=True which doesn't help
+        output = subprocess.getoutput("./backintime --config test/config backup")
+        self.assertRegex(output, re.compile('''
+Back In Time
+Version: \d+.\d+.\d+ .*
+
+Back In Time comes with ABSOLUTELY NO WARRANTY.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `backintime --license' for details.
+
+''', re.MULTILINE))
+
+        # get snapshot id
+        subprocess.check_output(["./backintime","--config","test/config","snapshots-list"])
+        
+        # execute restore and verify output
+        # TODO - verify exit code is 0. using check_output() hangs, not sure why. tried shell=True which doesn't help
+        output = subprocess.getoutput("./backintime --config test/config restore /tmp/test/testfile /tmp/restored 0")
+        self.assertRegex(output, re.compile('''
+Back In Time
+Version: \d+.\d+.\d+ .*
+
+Back In Time comes with ABSOLUTELY NO WARRANTY.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `backintime --license' for details.
+
+
+INFO: Restore: /tmp/test/testfile to: /tmp/restored.*''', re.MULTILINE))
+        
+        # verify that files restored are the same as those backed up
+        subprocess.check_output(["diff","-r","/tmp/test","/tmp/restored"])

--- a/common/tools.py
+++ b/common/tools.py
@@ -1105,6 +1105,9 @@ def inhibitSuspend( app_id = sys.argv[0],
     Prevent machine to go to suspend or hibernate.
     Returns the inhibit cookie which is used to end the inhibitor.
     """
+    if ON_TRAVIS:
+        # no suspend on travis (no dbus either)
+        return
     if not app_id:
         app_id = 'backintime'
     if not toplevel_xid:


### PR DESCRIPTION
I took the time to write the first end-to-end test of BIT :)

It's certainly not a full test suite, but we can build on this going forward. It gives us a place to start. I've written many such end-to-end tests for other software that I maintain professionally and I think approaching end-to-end tests as coded here are incredibly valuable for hard-to-spot regressions.

Ideas:
* test one of highest level interfaces - in this case, the command line - to ensure that everything from argument parsing, functionality, and output works as expected.
 * Maybe in the future we can think about testing the GUI in an automated way (though that is out of my area of expertise)
* don't call python functions directly; instead, test what a command line user would use - the command line itself in a shell, by exec'ing the python interpreter
* can signal subtle bugs not covered in method unit tests, which can go a long way towards preventing regressions during major refactors. this can happen when individual unit tests might pass due to API compatibility but mismatched expectations between semantics of module inputs and outputs

Example of immediate effectiveness: This extremely basic test, which doesn't even cover advanced configuration, nor ssh or encrypted mode, already uncovered some CLI bugs. Seems like a win!