### PR TITLE
Local mode mounts over bindfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ python:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y sshfs
+  - sudo apt-get install -y bindfs sshfs
 
 install:
   - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ before installing
 * recomended
     - sshfs
     - encfs
+    - bindfs
 
 * Command
 
@@ -125,7 +126,7 @@ before installing
     first value is default:
     --no-fuse-group | --fuse-group (only COMMON)
         Some distributions require user to be in group 'fuse' to use
-        sshfs and encfs. This toggles the check on or off.
+        sshfs, encfs, and bindfs. This toggles the check on or off.
 
     --python3 | --python (all)
         Use either 'python3' or 'python' to start Python Version 3.x

--- a/common/bindfstools.py
+++ b/common/bindfstools.py
@@ -1,0 +1,72 @@
+#    Copyright (C) 2016 Taylor Raack
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import subprocess
+import gettext
+
+from mount import MountControl
+import logger
+from exceptions import MountException
+
+_=gettext.gettext
+
+class Local(MountControl):
+    """
+    Mount local path with bindfs. This allows for read-only viewing of snapshots stored on a locally mounted filesystem.
+    """
+
+    def __init__(self, *args, **kwargs):
+        #init MountControl
+        super(Local, self).__init__(*args, **kwargs)
+
+        #First we need to map the settings.
+        self.setattr_kwargs('path', self.config.get_local_path(self.profile_id), **kwargs)
+
+        self.set_default_args()
+        
+        self.mountproc = 'bindfs'
+        self.symlink_subfolder = None
+
+        self.log_command = '%s: %s' % (self.mode, self.path)
+
+    def _mount(self):
+        """
+        mount the local filesystem over bind
+        """
+        bindfs = [self.mountproc, '-n']
+
+        # use read only mount if requested
+        if self.read_only:
+            bindfs.extend(['-o', 'ro'])
+
+        bindfs.extend([self.path, self.mountpoint])
+        logger.debug('Call mount command: %s'
+                     %' '.join(bindfs),
+                     self)
+        try:
+            subprocess.check_call(bindfs)
+        except subprocess.CalledProcessError:
+            raise MountException( _('Can\'t mount %s') % ' '.join(bindfs))
+
+    def pre_mount_check(self, first_run = False):
+        """
+        check what ever conditions must be given for the mount to be done successful
+        raise MountException( _('Error description') ) if service can not mount
+        return True if everything is okay
+        all pre|post_[u]mount_check can also be used to prepare things or clean up
+        """
+        self.check_fuse()
+        return True

--- a/common/cli.py
+++ b/common/cli.py
@@ -77,7 +77,7 @@ def checkConfig(cfg, crontab = True):
         #pre_mount_check
         test = 'Run mount tests'
         announceTest()
-        mnt = mount.Mount(cfg = cfg, tmp_mount = True)
+        mnt = mount.Mount(cfg = cfg, tmp_mount = True, read_only = False)
         try:
             mnt.pre_mount_check(mode = mode, first_run = True)
         except MountException as ex:

--- a/common/config.py
+++ b/common/config.py
@@ -32,6 +32,7 @@ import tools
 import configfile
 import logger
 import mount
+import bindfstools
 import sshtools
 import encfstools
 import password
@@ -126,7 +127,7 @@ class Config( configfile.ConfigFileWithProfiles ):
     exp = _(' EXPERIMENTAL!')
     SNAPSHOT_MODES = {
                 #mode           : (<mounttools>,            'ComboBox Text',        need_pw|lbl_pw_1,       need_2_pw|lbl_pw_2 ),
-                'local'         : (None,                    _('Local'),             False,                  False ),
+                'local'         : (bindfstools.Local,       _('Local'),             False,                  False ),
                 'ssh'           : (sshtools.SSH,            _('SSH'),               _('SSH private key'),   False ),
                 'local_encfs'   : (encfstools.EncFS_mount,  _('Local encrypted'),   _('Encryption'),        False ),
                 'ssh_encfs'     : (encfstools.EncFS_SSH,    _('SSH encrypted'),     _('SSH private key'),   _('Encryption') )
@@ -409,6 +410,22 @@ class Config( configfile.ConfigFileWithProfiles ):
     def increment_hash_collision(self):
         value = self.get_hash_collision() + 1
         self.set_int_value( 'global.hash_collision', value )
+
+    # local directory for snapshots
+    def get_local_snapshots_path( self, profile_id = None ):
+        if self.get_snapshots_mode(profile_id) == 'local':
+            return self.get_local_path(profile_id)
+        elif self.get_snapshots_mode(profile_id) == 'local_encfs':
+            return self.get_local_encfs_path(profile_id)
+        else:
+            return self.get_snapshots_path(profile_id)
+
+    # absolute path for 'local' mode
+    def get_local_path( self, profile_id = None ):
+        return self.get_profile_str_value( 'snapshots.path', '', profile_id )
+
+    def set_local_path( self, value, profile_id = None ):
+        self.set_profile_str_value( 'snapshots.path', value, profile_id )
 
     def get_snapshots_path_ssh( self, profile_id = None ):
         #?Snapshot path on remote host. If the path is relative (no leading '/')

--- a/common/mount.py
+++ b/common/mount.py
@@ -770,7 +770,7 @@ class MountControl(object):
             if lock_pid == self.pid:
                 if is_tmp == self.tmp_mount:
                     continue
-            if tools.is_process_alive(lock_pid):
+            if tools.is_process_alive(int(lock_pid)):
                 return True
             else:
                 logger.debug('Remove old and invalid lock %s'

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1992,7 +1992,7 @@ class Snapshots:
         encode = self.config.ENCODE
         ret  = ' --chmod=Du+wx '
         ret += ' --exclude="{}" --exclude="{}" --exclude="{}" '.format(
-                              encode.exclude(self.config.get_snapshots_path()),
+                              encode.exclude(self.config.get_local_snapshots_path()),
                               encode.exclude(self.config._LOCAL_DATA_FOLDER) ,
                               encode.exclude(self.config._MOUNT_ROOT) )
         ret += ' '.join((rsync_include, rsync_exclude, rsync_include2))

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -16,6 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os
+import subprocess
 import sys
 import unittest
 from tempfile import TemporaryDirectory
@@ -23,6 +24,7 @@ from tempfile import TemporaryDirectory
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import logger
 import config
+import mount
 
 class TestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -45,7 +47,12 @@ class SnapshotsTestCase(TestCase):
         self.tmpDir = TemporaryDirectory()
         self.cfg.dict['profile1.snapshots.path'] = self.tmpDir.name
         self.snapshotPath = self.cfg.get_snapshots_full_path()
+        subprocess.getoutput("chmod -R a+rwx " + self.snapshotPath + " && rm -rf " + self.snapshotPath)
+        self.mnt = mount.Mount(cfg = self.cfg, tmp_mount = True, parent = self, read_only = False)
+        self.mnt.pre_mount_check(mode = 'local', first_run = True)
+        self.hash_id = self.mnt.mount(mode = 'local', check = False)
         os.makedirs(self.snapshotPath)
 
     def tearDown(self):
+        self.mnt.umount(hash_id = self.hash_id)
         self.tmpDir.cleanup()

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -19,6 +19,7 @@ import os
 import re
 import subprocess
 import sys
+import unittest
 from test import generic
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -66,9 +67,26 @@ under certain conditions; type `backintime --license' for details.
 
 
  ┌────────────────────────────────┐
+ │        Run mount tests         │
+ └────────────────────────────────┘
+Run mount tests: done
+
+ ┌────────────────────────────────┐
+ │             Mount              │
+ └────────────────────────────────┘
+INFO: mount local: /tmp/snapshots on .*
+Mount: done
+
+ ┌────────────────────────────────┐
  │  Check/prepair snapshot path   │
  └────────────────────────────────┘
 Check/prepair snapshot path: done
+
+ ┌────────────────────────────────┐
+ │            Unmount             │
+ └────────────────────────────────┘
+INFO: unmount local: /tmp/snapshots from .*
+Unmount: done
 
  ┌────────────────────────────────┐
  │          Check config          │
@@ -93,7 +111,20 @@ Back In Time comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions; type `backintime --license' for details.
 
-''', re.MULTILINE))
+INFO: Lock(
+INFO: Inhibit Suspend started. Reason: take snapshot)?
+INFO: mount local: /tmp/snapshots on .*
+INFO: Take a new snapshot. Profile: 1 Main profile
+INFO: Call rsync to take the snapshot
+INFO: Save config file
+INFO: Save permissions
+INFO: Create info file
+INFO: Remove backups older than: .*
+INFO: Keep min free disk space: 1024 MiB
+INFO: Keep min 2% free inodes
+INFO: unmount local: /tmp/snapshots from .*
+INFO: Unlock(
+INFO: Release inhibit Suspend)?''', re.MULTILINE))
 
         # get snapshot id
         subprocess.check_output(["./backintime","--config","test/config","snapshots-list"])
@@ -109,6 +140,7 @@ Back In Time comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions; type `backintime --license' for details.
 
+INFO: mount local: /tmp/snapshots on .*
 
 INFO: Restore: /tmp/test/testfile to: /tmp/restored.*''', re.MULTILINE))
         

--- a/common/test/test_bindfstools.py
+++ b/common/test/test_bindfstools.py
@@ -1,0 +1,79 @@
+# Back In Time
+# Copyright (C) 2016 Taylor Raack, Germar Reitze
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public Licensealong
+# with this program; if not, write to the Free Software Foundation,Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import os
+import sys
+import tempfile
+import unittest
+from test import generic
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import config
+import logger
+import mount
+import tools
+
+HAS_BINDFS = tools.check_command('bindfs')
+
+class TestLocal(generic.TestCase):
+
+    def setUp(self):
+        super(TestLocal, self).setUp()
+        logger.DEBUG = '-v' in sys.argv
+        self.config = config.Config()
+        self.config.set_snapshots_mode('local')
+        self.mount_kwargs = {}
+
+    @unittest.skipIf(not HAS_BINDFS, 'Skip as this test requires bindfs to be installed')
+    def test_can_mount_local_rw(self):
+        self.internal_test(read_only = False, implicit_read_only = False)
+
+    @unittest.skipIf(not HAS_BINDFS, 'Skip as this test requires bindfs to be installed')
+    def test_can_mount_local_ro_implicitly(self):
+        self.internal_test(read_only = True, implicit_read_only = True)
+
+    @unittest.skipIf(not HAS_BINDFS, 'Skip as this test requires bindfs to be installed')
+    def test_can_mount_local_ro_explicitly(self):
+        self.internal_test(read_only = True, implicit_read_only = False)
+ 
+    def internal_test(self, read_only, implicit_read_only):
+        with tempfile.TemporaryDirectory() as dirpath:
+            self.config.set_local_path(dirpath)
+
+            if implicit_read_only:
+                mnt = mount.Mount(cfg = self.config, tmp_mount = True)
+            else:
+                mnt = mount.Mount(cfg = self.config, tmp_mount = True, read_only = read_only)
+            mnt.pre_mount_check(mode = 'local', first_run = True, **self.mount_kwargs)
+
+            hash_id = ''
+            try:
+                hash_id = mnt.mount(mode = 'local', check = False, **self.mount_kwargs)
+                full_path = os.path.expanduser(os.path.join("~",".local","share","backintime","mnt",hash_id,"mountpoint","testfile"))
+
+                # warning - don't use os.access for checking writability
+                # https://github.com/bit-team/backintime/issues/490#issuecomment-156265196
+                if read_only:
+                    with self.assertRaisesRegex(OSError, "Read-only file system"):
+                        with open(full_path, 'wt') as f:
+                            f.write('foo')
+                else:
+                    with open(full_path, 'wt') as f:
+                        f.write('foo')
+            finally:
+                if hash_id != '':
+                    mnt.umount(hash_id = hash_id)

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Homepage: https://github.com/bit-team/backintime
 Package: backintime-common
 Architecture: all
 Depends: rsync, cron-daemon, openssh-client, python3-keyring, python3-dbus, ${python3:Depends}, ${misc:Depends}
-Recommends: sshfs, encfs
+Recommends: sshfs, encfs, bindfs
 Conflicts: backintime
 Replaces: backintime
 Description: Simple backup system (common)

--- a/qt4/settingsdialog.py
+++ b/qt4/settingsdialog.py
@@ -1056,7 +1056,7 @@ class SettingsDialog( QDialog ):
         self.set_combo_value( self.combo_modes, self.config.get_snapshots_mode(), t = 'str' )
 
         #local
-        self.edit_snapshots_path.setText( self.config.get_snapshots_path( mode = 'local') )
+        self.edit_snapshots_path.setText( self.config.get_local_path() )
 
         #ssh
         self.txt_ssh_host.setText( self.config.get_ssh_host() )
@@ -1212,6 +1212,8 @@ class SettingsDialog( QDialog ):
                             }
 
         #snapshots path
+        self.config.set_local_path(self.edit_snapshots_path.text())
+
         self.config.set_host_user_profile(
                 self.txt_host.text(),
                 self.txt_user.text(),


### PR DESCRIPTION
* Added bindfs as an optional dependency
* Changed all local mode usage to bindfs, mounting r/w for snapshotting and r/o for all other operations (same as ssh, local_encfs, ssh_encfs)
* Fixed a couple of bugs which integration tests found
* Added a ```get_local_path``` and ```set_local_path``` method pair in the ```Config``` class for shuttling the snapshot path that the user selects (without it being conflated with the ```get_snapshot_path```, which is overloaded for use with the bindfs mount point)