### PR TITLE
QT4 UI should send relative path to SID.canOpenPath, not fullPath

### DIFF
--- a/qt4/app.py
+++ b/qt4/app.py
@@ -1062,14 +1062,14 @@ class MainWindow( QMainWindow ):
     def on_btn_folder_history_previous_clicked(self):
         path = self.path_history.previous()
         full_path = self.sid.pathBackup(path)
-        if os.path.isdir(full_path) and self.sid.canOpenPath(full_path):
+        if os.path.isdir(full_path) and self.sid.canOpenPath(path):
             self.path = path
             self.update_files_view(0)
 
     def on_btn_folder_history_next_clicked(self):
         path = self.path_history.next()
         full_path = self.sid.pathBackup(path)
-        if os.path.isdir(full_path) and self.sid.canOpenPath(full_path):
+        if os.path.isdir(full_path) and self.sid.canOpenPath(path):
             self.path = path
             self.update_files_view(0)
 
@@ -1121,7 +1121,7 @@ class MainWindow( QMainWindow ):
         rel_path = os.path.join( self.path, rel_path )
         full_path = self.sid.pathBackup(rel_path)
 
-        if os.path.exists(full_path) and self.sid.canOpenPath(full_path):
+        if os.path.exists(full_path) and self.sid.canOpenPath(rel_path):
             if os.path.isdir( full_path ):
                 self.path = rel_path
                 self.path_history.append(rel_path)


### PR DESCRIPTION
Bug appearing after 1.1.12 - cannot use the UI to navigate the filesystem of a snapshot.

Turns out that the ```open_path()``` method of the app.py is calling ```SID.canOpenPath()``` with a full snapshot path, rather than a path relative to the snapshot itself. ```SID.canOpenPath()```'s contract is that it takes a relative path.

I fixed the three instances where ```SID.canOpenPath()``` is called, to ensure that relative paths are used.

Note that I don't have a mouse with buttons 4 and 5, so I can't test the fix in those two areas (navigating backward and forward in history).

At the moment, I can't create a regression test to prevent this from re-occuring (because this is a problem of the UI module not adhering to the API contract of the backend module), but I am looking into PyQT's ```QTest``` class for [a prototype test framework for the QT UI](http://johnnado.com/pyqt-qtest-example/) to build some basic UI tests. Stay tuned.