### PR TITLE
gives more helpful advice if a log file is present that shouldn't be.  (https://github.com/bit-team/backintime/issues/601)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.2.0~alpha0
+* Fix bug: in snapshots.py, gives more helpful advice if a log file is present that shouldn't be.  (https://github.com/bit-team/backintime/issues/601)
 * Fix bug: Fail to create remote snapshot path with spaces (https://github.com/bit-team/backintime/issues/567)
 * Fix bug: broken new_snapshot can run into infinite saveToContinue loop (https://github.com/bit-team/backintime/issues/583)
 * Recognize changes on previous runs while continuing new snapshots

--- a/common/plugins/usercallbackplugin.py
+++ b/common/plugins/usercallbackplugin.py
@@ -32,13 +32,13 @@ class UserCallbackPlugin(pluginmanager.Plugin):
 
     def init(self, snapshots):
         self.config = snapshots.config
-        self.callback = self.config.takeSnapshotUserCallback()
-        if not os.path.exists(self.callback):
+        self.script = self.config.takeSnapshotUserCallback()
+        if not os.path.exists(self.script):
             return False
         return True
 
     def callback(self, *args):
-        cmd = [self.callback, self.config.currentProfile(), self.config.profileName()]
+        cmd = [self.script, self.config.currentProfile(), self.config.profileName()]
         cmd.extend([str(x) for x in args])
         logger.debug('Call user-callback: %s' %' '.join(cmd), self)
         if self.config.userCallbackNoLogging():

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -614,10 +614,13 @@ class Snapshots:
             instance = applicationinstance.ApplicationInstance(self.config.takeSnapshotInstanceFile(), False, flock = True)
             restore_instance = applicationinstance.ApplicationInstance(self.config.restoreInstanceFile(), False)
             if not instance.check():
-                logger.warning('A backup is already running', self)
+                logger.warning('A backup is already running.  The pid of the \
+already running backup is in file %s.  Maybe delete it' % instance.pidFile , self )
                 self.config.PLUGIN_MANAGER.error(2) #a backup is already running
             elif not restore_instance.check():
-                logger.warning('Restore is still running. Stop backup until restore is done.', self)
+                logger.warning('Restore is still running. Stop backup until \
+restore is done. The pid of the already running restore is in %s.  Maybe delete it'\
+                               % restore_instance.pidFile, self)
             else:
                 if self.config.noSnapshotOnBattery () and not tools.powerStatusAvailable():
                     logger.warning('Backups disabled on battery but power status is not available', self)


### PR DESCRIPTION
I modified snapshots.py so that if the lock file ~/.local/share/backintime/worker2.lock still exists when it shouldn't, then the warning message is more helpful: it tells you where the problem is.