### PR TITLE
Retrieve path device and filesystem via df command

### DIFF
--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -408,17 +408,15 @@ class TestTools(generic.TestCase):
         proc = os.path.join('/proc', str(os.getpid()), 'fd')
         self.assertEqual(tools.mountpoint(proc), '/proc')
 
-    def test_mountArgs(self):
-        rootArgs = tools.mountArgs('/')
-        self.assertIsInstance(rootArgs, list)
-        self.assertGreaterEqual(len(rootArgs), 3)
-        self.assertEqual(rootArgs[1], '/')
+    def test_get_df_output(self):
+        df_root = tools.get_df_output('/')
+        self.assertIsInstance(df_root, list)
+        self.assertGreaterEqual(len(df_root), 2)
 
-        procArgs = tools.mountArgs('/proc')
-        self.assertGreaterEqual(len(procArgs), 3)
-        self.assertEqual(procArgs[0], 'proc')
-        self.assertEqual(procArgs[1], '/proc')
-        self.assertEqual(procArgs[2], 'proc')
+        df_proc = tools.get_df_output('/proc')
+        self.assertGreaterEqual(len(df_root), 2)
+        self.assertEqual(df_proc[0], 'proc')
+        self.assertEqual(df_proc[1], 'proc')
 
     def test_device(self):
         self.assertEqual(tools.device('/proc'), 'proc')


### PR DESCRIPTION
So, I finally decided to automate my backups and use backintime. I tested scheduled udev-triggered backups on a flash drive few days ago, everything worked fine. So I decided to configure backups on my external HDD today, but it didn't work, plugging in the drive didn't trigger backintime.

After a short investigation, I found out my udev file was set up to trigger on some unknown UUID, even `blkid` wouldn't list it. So, I dug in source code and figured out that the `tools.device` function returned `None` for my drive.

The reason was: its label ('karlicoss hdd') contained a space, so it was mounted to `/media/karlicos/karlicoss hdd/`, however, `/etc/mtab` treats spaces as separators, so he escapes paths like

    `/dev/sdb1 /media/karlicos/karlicoss\040hdd fuseblk rw,nosuid,nodev,....`

As you can see, spaces map to `\040`. So, probably a good idea is, instead of manually parsing `/etc/mtab`, use the [`df` command from coreutils](https://www.gnu.org/software/coreutils/manual/html_node/df-invocation.html), which does all the job for us.

A followup question, what is the rationale behind [this](https://github.com/bit-team/backintime/blob/master/common/config.py#L1537) UUID fallback logic? In my case, it seemed to have cached the flash drives' UUID, and silently used it instead my HDD's UUID. Maybe, we should at list show some warning/notification to user so he knows something went not as expected?

P.S. I messed with [previous](https://github.com/bit-team/backintime/pull/606) PR and apparently github doesn't let to reopen branch which you force pushed so I made a new PR.