### PR TITLE
improved debug output to identify profiles

### DIFF
--- a/common/backintime.py
+++ b/common/backintime.py
@@ -649,7 +649,11 @@ def getConfig(args, check = True):
     cfg = config.Config(config_path = args.config, data_path = args.share_path)
     logger.debug('config file: %s' % cfg._LOCAL_CONFIG_PATH)
     logger.debug('share path: %s' % cfg._LOCAL_DATA_FOLDER)
-    logger.debug('profiles: %s' % cfg.profiles())
+    dbgProfileIdNames = ''
+    for profileId in cfg.profiles():
+        dbgProfileIdNames += '{}={} '.format(profileId,
+                                          cfg.profileName(profileId))
+    logger.debug('profiles: %s' % dbgProfileIdNames.strip())
     if 'profile_id' in args and args.profile_id:
         if not cfg.setCurrentProfile(args.profile_id):
             logger.error('Profile-ID not found: %s' % args.profile_id)

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -649,11 +649,9 @@ def getConfig(args, check = True):
     cfg = config.Config(config_path = args.config, data_path = args.share_path)
     logger.debug('config file: %s' % cfg._LOCAL_CONFIG_PATH)
     logger.debug('share path: %s' % cfg._LOCAL_DATA_FOLDER)
-    dbgProfileIdNames = ''
-    for profileId in cfg.profiles():
-        dbgProfileIdNames += '{}={} '.format(profileId,
-                                          cfg.profileName(profileId))
-    logger.debug('profiles: %s' % dbgProfileIdNames.strip())
+    logger.debug('profiles: %s' % ', '.join('%s=%s' % (x, cfg.profileName(x))
+                                                        for x in cfg.profiles()))
+
     if 'profile_id' in args and args.profile_id:
         if not cfg.setCurrentProfile(args.profile_id):
             logger.error('Profile-ID not found: %s' % args.profile_id)

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -475,7 +475,7 @@ class ConfigFileWithProfiles(ConfigFile):
         profiles_sorted = collections.OrderedDict(sorted(profiles_dict.items()))
 
         # return the names as a list
-        return list(profiles_sorted.keys())
+        return list(profiles_sorted.values())
 
     def currentProfile(self):
         """
@@ -503,7 +503,9 @@ class ConfigFileWithProfiles(ConfigFile):
         for i in profiles:
             if i == profile_id:
                 self.current_profile_id = profile_id
-                logger.debug('change current profile: %s' %profile_id, self)
+                logger.debug('change current profile: %s=%s'
+                             % (profile_id, self.profileName(profile_id)),
+                             self)
                 logger.changeProfile(profile_id)
                 return True
 

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -16,6 +16,7 @@
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import os
+import collections
 
 import gettext
 import logger
@@ -470,14 +471,11 @@ class ConfigFileWithProfiles(ConfigFile):
         for profile_id in profiles_unsorted:
             profiles_dict[self.profileName(profile_id).upper()] = profile_id
 
-        keys = list(profiles_dict.keys())
-        keys.sort()
+        # sort the dictionary by key (the profile name)
+        profiles_sorted = collections.OrderedDict(sorted(profiles_dict.items()))
 
-        profiles_sorted = []
-        for key in keys:
-            profiles_sorted.append(profiles_dict[key])
-
-        return profiles_sorted
+        # return the names as a list
+        return list(profiles_sorted.keys())
 
     def currentProfile(self):
         """


### PR DESCRIPTION
This is my first PR here. So it is kind of a practice for me. ;)
Sorry for promoting two modifications in one PR. This is uncommon an I will do it better next time. Hope this is ok today.

1.
In `configfile.py`: `profilesSortedByName()`
The dictionary there now is ordered a more pythonic way. It depends on the offical documentation.

2.
In `backintime.py`:
This is the main reason for this PR.
In the debug output not the ProfileID is "connected" with the ProfileName.
I am not sure if this is the best solution. Maybe I should add a new methode to `class ConfigFileWithProfiles` like `def profilesIdNames()` returning a dictionary?