### PR TITLE
using long versions of rsync options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Back In Time is available through AUR. You need to import a public key once
 before installing
 
     gpg --keyserver pgp.mit.edu --recv-keys 615F366D944B4826
+    # Fingerprint: 3E70 692E E3DB 8BDD A599  1C90 615F 366D 944B 4826
     wget https://aur.archlinux.org/cgit/aur.git/snapshot/backintime.tar.gz
     tar xvzf backintime.tar.gz
     cd backintime

--- a/common/tools.py
+++ b/common/tools.py
@@ -565,7 +565,12 @@ def rsyncPrefix(config,
     if config.nocacheOnLocal():
         cmd.append('nocache')
     cmd.append('rsync')
-    cmd.append('-rtDHh')
+    cmd.extend(('--recursive ',     # recurse into directories
+                '--times',          # preserve modification times
+                '--devices',        # preserve device files (super-user only)
+                '--specials',       # preserve special files
+                '--hard-links',     # preserve hard links
+                '--human-readable'))# numbers in a human-readable format
 
     if config.useChecksum() or config.forceUseChecksum:
         cmd.append('--checksum')
@@ -579,20 +584,24 @@ def rsyncPrefix(config,
         cmd.append('--links')
 
     if config.preserveAcl() and "ACLs" in caps:
-        cmd.append('-A')
+        cmd.append('--acls')  # preserve ACLs (implies --perms)
         no_perms = False
 
     if config.preserveXattr() and "xattrs" in caps:
-        cmd.append('-X')
+        cmd.append('--xattrs')  # preserve extended attributes
         no_perms = False
 
     if no_perms:
-        cmd.extend(('--no-p', '--no-g', '--no-o'))
+        cmd.extend(('--no-perms', '--no-group', '--no-owner'))
     else:
-        cmd.append('-pEgo')
+        cmd.extend(('--perms',          # preserve permissions
+                    '--executability',  # preserve executability
+                    '--ggroup',         # preserve group
+                    '--owner'))         # preserve owner (super-user only)
 
     if progress and 'progress2' in caps:
-        cmd.extend(('--info=progress2', '--no-i-r'))
+        cmd.extend(('--info=progress2',
+                    '--no-inc-recursive'))
 
     if config.rsyncOptionsEnabled():
         cmd.extend(shlex.split(config.rsyncOptions()))

--- a/common/tools.py
+++ b/common/tools.py
@@ -565,7 +565,7 @@ def rsyncPrefix(config,
     if config.nocacheOnLocal():
         cmd.append('nocache')
     cmd.append('rsync')
-    cmd.extend(('--recursive ',     # recurse into directories
+    cmd.extend(('--recursive',     # recurse into directories
                 '--times',          # preserve modification times
                 '--devices',        # preserve device files (super-user only)
                 '--specials',       # preserve special files


### PR DESCRIPTION
Use long versions of the rsync options. E.g. `--perms` instead of `-p`.

This make it easier to understand the code, the debug messages and doing diagnosis.

btw: unitest on my own machine is not possible currently because of problems in the test-suite. Germar knows about it and work on it.