### PR TITLE
fix spelling and typos throughout

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -675,7 +675,7 @@ Version 0.8
 * add English help (docbook)
 * add help button in main toolbar
 * the application can be started with a 'path' to a folder or file as command line parameter
-* when the application start, if it is already runnig pass it's command line to the first instance (this allow a basic integration with file-managers - see README)
+* when the application start, if it is already runnig pass its command line to the first instance (this allow a basic integration with file-managers - see README)
 * bug fix: when the application was started a second time it raise the first application's window but not always focused
 
 Version 0.7.4

--- a/common/applicationinstance.py
+++ b/common/applicationinstance.py
@@ -100,7 +100,7 @@ class ApplicationInstance:
 
     def startApplication(self):
         """
-        Called when the single instance starts to save it's pid
+        Called when the single instance starts to save its pid
         """
         pid = os.getpid()
         procname = tools.processName(pid)
@@ -136,7 +136,7 @@ class ApplicationInstance:
     def flockUnlock(self):
         """
         Remove the exclusive lock. Second instance can now continue
-        but should find it self to be obsolet.
+        but should find it self to be obsolete.
         """
         if self.flock:
             fcntl.fcntl(self.flock, fcntl.LOCK_UN)

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -68,7 +68,7 @@ def takeSnapshotAsync(cfg, checksum = False):
         cmd.append('--checksum')
     cmd.append('backup')
 
-    # child process need to start it's own ssh-agent because otherwise
+    # child process need to start its own ssh-agent because otherwise
     # it would be lost without ssh-agent if parent will close
     env = os.environ.copy()
     for i in ('SSH_AUTH_SOCK', 'SSH_AGENT_PID'):
@@ -273,7 +273,7 @@ def createParsers(app_name = 'backintime'):
     command = 'decode'
     nargs = '*'
     aliases.append((command, nargs))
-    description = "Decode pathes with 'encfsctl decode'"
+    description = "Decode paths with 'encfsctl decode'"
     decodeCP =             subparsers.add_parser(command,
                                                  epilog = epilogCommon,
                                                  help = description,
@@ -379,7 +379,7 @@ def createParsers(app_name = 'backintime'):
                                                  action = 'store',
                                                  nargs = '?',
                                                  help = 'Which SNAPSHOT_ID should be used. This can be a snapshot ID or ' +\
-                                                 'an integer starting with 0 for the last snapshot, 1 for the overlast, ... ' +\
+                                                 'an integer starting with 0 for the last snapshot, 1 for the second to last, ... ' +\
                                                  'the very first snapshot is -1')
 
     restoreCP.add_argument                      ('--delete',
@@ -559,7 +559,7 @@ def argParse(args):
                 mainParser._remove_action(i)
                 sub.append(i)
     args, unknownArgs = mainParser.parse_known_args(args)
-    #readd subparsers again
+    #read subparsers again
     if sub:
         [mainParser._add_action(i) for i in sub]
 
@@ -689,7 +689,7 @@ def getConfig(args, check = True):
 def setQuiet(args):
     """
     Redirect :py:data:`sys.stdout` to ``/dev/null`` if ``--quiet`` was set on
-    commandline. Return the original :py:data:`sys.stdout` fileobject which can
+    commandline. Return the original :py:data:`sys.stdout` file object which can
     be used to print absolute necessary information.
 
     Args:
@@ -952,7 +952,7 @@ def unmount(args):
 
 def benchmarkCipher(args):
     """
-    Command for transfering a file with scp to remote host with all
+    Command for transferring a file with scp to remote host with all
     available ciphers and print its speed and time.
 
     Args:
@@ -1005,7 +1005,7 @@ def pwCache(args):
 
 def decode(args):
     """
-    Command for decoding pathes given pathes with 'encfsctl'.
+    Command for decoding paths given paths with 'encfsctl'.
     Will listen on stdin if no path was given.
 
     Args:

--- a/common/config.py
+++ b/common/config.py
@@ -609,7 +609,7 @@ class Config(configfile.ConfigFileWithProfiles):
             profile_id (str):   profile ID that should  be used in config
 
         Returns:
-            list:               ssh command with choosen arguments
+            list:               ssh command with chosen arguments
         """
         assert cmd is None or isinstance(cmd, list), "cmd '{}' is not list instance".format(cmd)
         assert custom_args is None or isinstance(custom_args, list), "custom_args '{}' is not list instance".format(custom_args)
@@ -1022,7 +1022,7 @@ class Config(configfile.ConfigFileWithProfiles):
 
     def niceOnCron(self, profile_id = None):
         #?Run cronjobs with 'nice \-n 19'. This will give BackInTime the
-        #?lowest CPU priority to not interupt any other working process.
+        #?lowest CPU priority to not interrupt any other working process.
         return self.profileBoolValue('snapshots.cron.nice', self.DEFAULT_RUN_NICE_FROM_CRON, profile_id)
 
     def setNiceOnCron(self, value, profile_id = None):
@@ -1030,7 +1030,7 @@ class Config(configfile.ConfigFileWithProfiles):
 
     def ioniceOnCron(self, profile_id = None):
         #?Run cronjobs with 'ionice \-c2 \-n7'. This will give BackInTime the
-        #?lowest IO bandwidth priority to not interupt any other working process.
+        #?lowest IO bandwidth priority to not interrupt any other working process.
         return self.profileBoolValue('snapshots.cron.ionice', self.DEFAULT_RUN_IONICE_FROM_CRON, profile_id)
 
     def setIoniceOnCron(self, value, profile_id = None):
@@ -1039,7 +1039,7 @@ class Config(configfile.ConfigFileWithProfiles):
     def ioniceOnUser(self, profile_id = None):
         #?Run BackInTime with 'ionice \-c2 \-n7' when taking a manual snapshot.
         #?This will give BackInTime the lowest IO bandwidth priority to not
-        #?interupt any other working process.
+        #?interrupt any other working process.
         return self.profileBoolValue('snapshots.user_backup.ionice', self.DEFAULT_RUN_IONICE_FROM_USER, profile_id)
 
     def setIoniceOnUser(self, value, profile_id = None):

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -37,7 +37,7 @@ class ConfigFile(object):
         """
         Register a function that should be called for notifying errors.
 
-        handler (metod):    callable function
+        handler (method):   callable function
         """
         self.errorHandler = handler
 
@@ -45,7 +45,7 @@ class ConfigFile(object):
         """
         Register a function that should be called for asking questions.
 
-        handler (metod):    callable function
+        handler (method):   callable function
         """
         self.questionHandler = handler
 
@@ -273,7 +273,7 @@ class ConfigFile(object):
             key (str):              used base-key
             type_key (str):         pattern of 'value-type:value-name'.
                                     See examples below.
-            default (list):         defualt value
+            default (list):         default value
 
         Returns:
             list:                   value of ``key`` or ``default``
@@ -473,7 +473,7 @@ class ConfigFileWithProfiles(ConfigFile):
 
     def profilesSortedByName(self):
         """
-        List of available profile IDs alphabetical sorted by their names.
+        List of available profile IDs alphabetically sorted by their names.
         Profile IDs are strings!
 
         Returns:

--- a/common/mount.py
+++ b/common/mount.py
@@ -288,7 +288,7 @@ class MountControl(object):
     """
     This is the low-level mount API. This should be subclassed by backends.
 
-    Subclasses should have it's own ``__init__`` but **must** also call the
+    Subclasses should have its own ``__init__`` but **must** also call the
     inherited ``__init__``.
 
     You **must** overwrite methods:\n

--- a/common/po/ar.po
+++ b/common/po/ar.po
@@ -558,7 +558,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/bg.po
+++ b/common/po/bg.po
@@ -550,7 +550,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/bs.po
+++ b/common/po/bs.po
@@ -540,7 +540,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/ca.po
+++ b/common/po/ca.po
@@ -555,7 +555,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/cs.po
+++ b/common/po/cs.po
@@ -590,7 +590,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Do vzdáleného umístění nelze zapisovat:\n"

--- a/common/po/da.po
+++ b/common/po/da.po
@@ -565,7 +565,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/de.po
+++ b/common/po/de.po
@@ -581,7 +581,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Der Pfad auf dem entfernten Rechner ist nicht beschreibbar:\n"

--- a/common/po/el.po
+++ b/common/po/el.po
@@ -548,7 +548,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/en_CA.po
+++ b/common/po/en_CA.po
@@ -546,7 +546,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/en_GB.po
+++ b/common/po/en_GB.po
@@ -568,10 +568,10 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 
 #: ../../common/sshtools.py:432

--- a/common/po/eo.po
+++ b/common/po/eo.po
@@ -539,7 +539,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/es.po
+++ b/common/po/es.po
@@ -630,7 +630,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "No tiene permisos de escritura en la ruta remota:\n"

--- a/common/po/et.po
+++ b/common/po/et.po
@@ -543,7 +543,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/eu.po
+++ b/common/po/eu.po
@@ -581,7 +581,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Urrutiko bide-izena ez dauka idazteko baimenik:\n"

--- a/common/po/fi.po
+++ b/common/po/fi.po
@@ -546,7 +546,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/fo.po
+++ b/common/po/fo.po
@@ -544,7 +544,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/fr.po
+++ b/common/po/fr.po
@@ -574,7 +574,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Le chemin d'accès distant n'est pas ouvert en écriture :\n"

--- a/common/po/gl.po
+++ b/common/po/gl.po
@@ -577,7 +577,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "A ruta remota non permite a escritura:\n"

--- a/common/po/he.po
+++ b/common/po/he.po
@@ -546,7 +546,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/hr.po
+++ b/common/po/hr.po
@@ -548,7 +548,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/hu.po
+++ b/common/po/hu.po
@@ -573,7 +573,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "A távoli útvonal nem írható:\n"

--- a/common/po/id.po
+++ b/common/po/id.po
@@ -569,7 +569,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Jalur yang dipantau tidak dapat ditulisi:\n"

--- a/common/po/is.po
+++ b/common/po/is.po
@@ -554,7 +554,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/it.po
+++ b/common/po/it.po
@@ -574,7 +574,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Il percorso remoto non è scrivibile:\n"

--- a/common/po/ja.po
+++ b/common/po/ja.po
@@ -545,7 +545,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/jv.po
+++ b/common/po/jv.po
@@ -539,7 +539,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/ko.po
+++ b/common/po/ko.po
@@ -545,7 +545,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "다음 원격 패스에 쓸 수 없습니다.\n"

--- a/common/po/lt.po
+++ b/common/po/lt.po
@@ -541,7 +541,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/messages.pot
+++ b/common/po/messages.pot
@@ -539,7 +539,7 @@ msgstr ""
 #: ../../common/sshtools.py:469
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/nb.po
+++ b/common/po/nb.po
@@ -546,7 +546,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/nl.po
+++ b/common/po/nl.po
@@ -584,7 +584,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Pad op afstand is niet beschrijfbaar:\n"

--- a/common/po/nn.po
+++ b/common/po/nn.po
@@ -546,7 +546,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/pl.po
+++ b/common/po/pl.po
@@ -549,7 +549,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/pt.po
+++ b/common/po/pt.po
@@ -563,7 +563,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/pt_BR.po
+++ b/common/po/pt_BR.po
@@ -576,7 +576,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "O caminho remoto não é gravável:\n"

--- a/common/po/ro.po
+++ b/common/po/ro.po
@@ -540,7 +540,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/ru.po
+++ b/common/po/ru.po
@@ -589,7 +589,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "Удаленный путь не доступен для записи:\n"

--- a/common/po/sk.po
+++ b/common/po/sk.po
@@ -549,7 +549,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/sl.po
+++ b/common/po/sl.po
@@ -537,7 +537,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/sr.po
+++ b/common/po/sr.po
@@ -548,7 +548,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/sv.po
+++ b/common/po/sv.po
@@ -548,7 +548,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/th.po
+++ b/common/po/th.po
@@ -539,7 +539,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/tr.po
+++ b/common/po/tr.po
@@ -543,7 +543,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/uk.po
+++ b/common/po/uk.po
@@ -548,7 +548,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/po/zh_CN.po
+++ b/common/po/zh_CN.po
@@ -552,7 +552,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 "远程路径不可写：\n"

--- a/common/po/zh_TW.po
+++ b/common/po/zh_TW.po
@@ -545,7 +545,7 @@ msgstr ""
 #: ../../common/sshtools.py:430
 #, python-format
 msgid ""
-"Remote path is not writeable:\n"
+"Remote path is not writable:\n"
 " %s"
 msgstr ""
 

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -122,7 +122,7 @@ class SnapshotLog(object):
 
     def get(self, mode = None, decode = None, skipLines = 0):
         """
-        Read the log, filter and decode it and yield it's lines.
+        Read the log, filter and decode it and yield its lines.
 
         Args:
             mode (int):                 Mode used for filtering. Take a look at

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2143,7 +2143,7 @@ class SID(object):
     def name(self, name):
         nameFile = self.path(self.NAME)
 
-        self.makeWriteable()
+        self.makewritable()
         try:
             with open(nameFile, 'wt') as f:
                 f.write(name)
@@ -2195,7 +2195,7 @@ class SID(object):
     def failed(self, enable):
         failedFile = self.path(self.FAILED)
         if enable:
-            self.makeWriteable()
+            self.makewritable()
             try:
                 with open(failedFile, 'wt') as f:
                     f.write('')
@@ -2322,9 +2322,9 @@ class SID(object):
                          logFile, str(e)),
                          self)
 
-    def makeWriteable(self):
+    def makewritable(self):
         """
-        Make the snapshot path writeable so we can change files inside
+        Make the snapshot path writable so we can change files inside
 
         Returns:
             bool:   ``True`` if successful

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -442,7 +442,7 @@ class SSH(MountControl):
         cmd += 'test $d -eq 1 && mkdir "%s"; err=$?;' % self.path #create path, get errorcode from mkdir
         cmd += 'test $d -eq 1 && exit $err;'                      #return errorcode from mkdir
         cmd += 'test -d "%s" || exit 11;' % self.path #path is no directory
-        cmd += 'test -w "%s" || exit 12;' % self.path #path is not writeable
+        cmd += 'test -w "%s" || exit 12;' % self.path #path is not writable
         cmd += 'test -x "%s" || exit 13;' % self.path #path is not executable
         cmd += 'exit 20'                              #everything is fine
         ssh = self.config.sshCommand(cmd = [cmd],
@@ -466,7 +466,7 @@ class SSH(MountControl):
             elif proc.returncode == 11:
                 raise MountException(_('Remote path exists but is not a directory:\n %s') % self.path)
             elif proc.returncode == 12:
-                raise MountException(_('Remote path is not writeable:\n %s') % self.path)
+                raise MountException(_('Remote path is not writable:\n %s') % self.path)
             elif proc.returncode == 13:
                 raise MountException(_('Remote path is not executable:\n %s') % self.path)
             else:

--- a/common/test/test_applicationinstance.py
+++ b/common/test/test_applicationinstance.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
@@ -270,6 +270,6 @@ class TestApplicationInstance(generic.TestCase):
         mock_open.side_effect = OSError()
         self.assertEqual(self.inst.readPidFile(), (0, ''))
 
-# Execute tests if this programm is call with python TestApplicationInstance.py
+# Execute tests if this program is called with python TestApplicationInstance.py
 if __name__ == '__main__':
     unittest.main()

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 

--- a/common/test/test_backup.py
+++ b/common/test/test_backup.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 

--- a/common/test/test_config.py
+++ b/common/test/test_config.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 

--- a/common/test/test_configfile.py
+++ b/common/test/test_configfile.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
@@ -30,7 +30,7 @@ class TestConfigFile(generic.TestCase):
     """
     def test_save(self):
         """
-        Saves the config file  in the tmp direcory
+        Saves the config file in the tmp directory
         """
         with NamedTemporaryFile() as cfgFile:
             cf = configfile.ConfigFile()

--- a/common/test/test_encfstools.py
+++ b/common/test/test_encfstools.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
@@ -27,7 +27,7 @@ class TestEncFS_mount(generic.TestCase):
 
 # TODO - perhaps pass encrypted fs class object which can be queried for passwords when necessary (so runtime
 # can pass UI classes which can bring up actual UI elements and return credentials or unit tests can pass
-# objects which can return hard coded passwords to prevent UI popups in Travis)
+# objects which can return hard coded passwords to prevent UI pop-ups in Travis)
 
 # TODO - then - code actual tests and remove this one
     def setUp(self):

--- a/common/test/test_restore.py
+++ b/common/test/test_restore.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 

--- a/common/test/test_sid.py
+++ b/common/test/test_sid.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
@@ -194,13 +194,13 @@ class TestSID(generic.SnapshotsTestCase):
         self.assertTrue(sid.canOpenPath('/foo'))
         self.assertFalse(sid.canOpenPath('/tmp'))
 
-        #test valid absolut symlink inside snapshot
+        #test valid absolute symlink inside snapshot
         os.symlink(os.path.join(backupPath, 'foo'),
                    os.path.join(backupPath, 'bar'))
         self.assertTrue(os.path.islink(os.path.join(backupPath, 'bar')))
         self.assertTrue(sid.canOpenPath('/bar'))
 
-        #test valid relativ symlink inside snapshot
+        #test valid relative symlink inside snapshot
         os.symlink('./foo',
                    os.path.join(backupPath, 'baz'))
         self.assertTrue(os.path.islink(os.path.join(backupPath, 'baz')))
@@ -341,19 +341,19 @@ class TestSID(generic.SnapshotsTestCase):
 
         self.assertEqual('\n'.join(sid.log()), 'foo bar\nbaz')
 
-    def test_makeWriteable(self):
+    def test_makewritable(self):
         sid = snapshots.SID('20151219-010324-123', self.cfg)
         os.makedirs(os.path.join(self.snapshotPath, '20151219-010324-123'))
         sidPath = os.path.join(self.snapshotPath, '20151219-010324-123')
         testFile = os.path.join(self.snapshotPath, '20151219-010324-123', 'test')
 
-        #make only read and exploreable
+        #make only read and explorable
         os.chmod(sidPath, stat.S_IRUSR | stat.S_IXUSR)
         with self.assertRaises(PermissionError):
             with open(testFile, 'wt') as f:
                 f.write('foo')
 
-        sid.makeWriteable()
+        sid.makewritable()
 
         self.assertEqual(os.stat(sidPath).st_mode & stat.S_IWUSR, stat.S_IWUSR)
         try:
@@ -451,7 +451,7 @@ class TestIterSnapshots(generic.SnapshotsTestCase):
         self.assertIsInstance(l2[-1], snapshots.SID)
 
     def test_list_snapshot_without_backup(self):
-        #new snapshot without backup folder should't be added
+        #new snapshot without backup folder shouldn't be added
         os.makedirs(os.path.join(self.snapshotPath, '20151219-050324-123'))
         l3 = snapshots.listSnapshots(self.cfg)
         self.assertListEqual(l3, ['20151219-040324-123',

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
@@ -123,7 +123,7 @@ class TestSSH(generic.SSHTestCase):
 
         #make folder read-only
         os.chmod(self.remotePath, stat.S_IRUSR | stat.S_IXUSR)
-        with self.assertRaisesRegex(MountException, r"Remote path is not writeable.+"):
+        with self.assertRaisesRegex(MountException, r"Remote path is not writable.+"):
             ssh.checkRemoteFolder()
 
         #make folder not executable
@@ -131,7 +131,7 @@ class TestSSH(generic.SSHTestCase):
         with self.assertRaisesRegex(MountException, r"Remote path is not executable.+"):
             ssh.checkRemoteFolder()
 
-        #make it writeable again otherwise cleanup will fail
+        #make it writable again otherwise cleanup will fail
         os.chmod(self.remotePath, stat.S_IRWXU)
 
     def test_checkRemoteFolder_fail_not_a_folder(self):
@@ -151,7 +151,7 @@ class TestSSH(generic.SSHTestCase):
         os.chmod(self.tmpDir.name, stat.S_IRUSR | stat.S_IXUSR)
         with self.assertRaisesRegex(MountException, r"Couldn't create remote path.+"):
             ssh.checkRemoteFolder()
-        #make it writeable again otherwise cleanup will fail
+        #make it writable again otherwise cleanup will fail
         os.chmod(self.tmpDir.name, stat.S_IRWXU)
 
     def test_checkRemoteFolder_with_spaces(self):

--- a/common/test/test_takeSnapshot.py
+++ b/common/test/test_takeSnapshot.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
@@ -228,7 +228,7 @@ class TestTakeSnapshot(generic.SnapshotsTestCase):
 
         self.assertListEqual([False, True], self.sn.takeSnapshot(sid1, now, [(self.include.name, 0),]))
 
-        # fix permissions because cleanup would fial otherwise
+        # fix permissions because cleanup would fail otherwise
         os.chmod(self.snapshotPath, 0o700)
 
 @unittest.skipIf(not generic.LOCAL_SSH, 'Skip as this test requires a local ssh server, public and private keys installed')

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public Licensealong
+# You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
@@ -55,7 +55,7 @@ Capabilities:
 
 rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
-General Public Licence for details.
+General Public License for details.
 """
 RSYNC_310_VERSION = """rsync  version 3.1.0  protocol version 31
 Copyright (C) 1996-2013 by Andrew Tridgell, Wayne Davison, and others.
@@ -67,12 +67,12 @@ Capabilities:
 
 rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
-General Public Licence for details.
+General Public License for details.
 """
 
 class TestTools(generic.TestCase):
     """
-    All funtions test here come from tools.py
+    All functions test here come from tools.py
     """
     def setUp(self):
         super(TestTools, self).setUp()
@@ -210,7 +210,7 @@ class TestTools(generic.TestCase):
             path = os.path.join(d, 'foo', 'bar')
             self.assertTrue(tools.makeDirs(path))
 
-    def test_makeDirs_not_writeable(self):
+    def test_makeDirs_not_writable(self):
         with TemporaryDirectory() as d:
             os.chmod(d, stat.S_IRUSR)
             path = os.path.join(d, 'foobar{}'.format(random.randrange(100, 999)))

--- a/common/tools.py
+++ b/common/tools.py
@@ -307,7 +307,7 @@ def mkdir(path, mode = 0o755):
     else:
         os.mkdir(path, mode)
         if mode & 0o002 == 0o002:
-            #make file world (other) writeable was requested
+            #make file world (other) writable was requested
             #debian and ubuntu won't set o+w with os.mkdir
             #this will fix it
             os.chmod(path, mode)
@@ -849,7 +849,7 @@ def mountpoint(path):
 
 def decodeOctalEscape(s):
     """
-    Decode octal-escaped characters with it's ASCII dependance.
+    Decode octal-escaped characters with its ASCII dependance.
     For example '\040' will be a space ' '
 
     Args:

--- a/qt/app.py
+++ b/qt/app.py
@@ -572,7 +572,7 @@ class MainWindow(QMainWindow):
 
         self.config.save()
 
-        # cleanup temporary local copys of files which where opend in GUI
+        # cleanup temporary local copies of files which were opened in GUI
         for d in self.tmpDirs:
             d.cleanup()
 
@@ -703,7 +703,7 @@ class MainWindow(QMainWindow):
                         self.btnStopTakeSnapshot):
                 btn.setVisible(False)
 
-            #TODO: check if there is a more elegant way than always get a new snapshot list which is very expencive (time)
+            #TODO: check if there is a more elegant way than always get a new snapshot list which is very expensive (time)
             snapshotsList = snapshots.listSnapshots(self.config)
 
             if snapshotsList != self.snapshotsList:
@@ -1242,7 +1242,7 @@ class MainWindow(QMainWindow):
                 self.path_history.append(rel_path)
                 self.updateFilesView(0)
             else:
-                # prevent backup data from being accidentaly overwritten
+                # prevent backup data from being accidentally overwritten
                 # by create a temporary local copy and only open that one
                 if not isinstance(self.sid, snapshots.RootSnapshot):
                     full_path = self.tmpCopy(full_path, self.sid)

--- a/qt/man/C/backintime-qt.1
+++ b/qt/man/C/backintime-qt.1
@@ -132,7 +132,7 @@ will start in foreground.
 remove[\-and\-do\-not\-ask\-again] | \-\-remove[\-and\-do\-not\-ask\-again] [SNAPSHOT_ID]
 Remove the snapshot. If SNAPSHOT_ID is missing it will be prompted. SNAPSHOT_ID
 can be an index (starting with 0 for the last snapshot) or the exact SnapshotID
-(19 caracters like '20130606-230501-984').
+(19 characters like '20130606-230501-984').
 \fIremove\-and\-do\-not\-ask\-again\fR will remove the snapshot immediately.
 Be careful with this!
 .TP
@@ -141,7 +141,7 @@ Restore file WHAT to path WHERE from snapshot SNAPSHOT_ID. If arguments are
 missing they will be prompted. To restore to the original path WHERE can be an
 empty string '' or just press Enter at the prompt. SNAPSHOT_ID can be an index
 (starting with 0 for the last snapshot) or the exact SnapshotID
-(19 caracters like '20130606-230501-984')
+(19 characters like '20130606-230501-984')
 .TP
 shutdown
 Shutdown the computer after the snapshot is done.

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -360,7 +360,7 @@ class SortedComboBox(QComboBox):
     def addItem(self, text, userData = None):
         """
         QComboBox doesn't support sorting
-        so this litle hack is used to insert
+        so this little hack is used to insert
         items in sorted order.
         """
         if self.sortRole == Qt.UserRole:

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -869,11 +869,11 @@ class SettingsDialog(QDialog):
         self.cbSshCheckPing = QCheckBox(_('Check if remote host is online'))
         self.cbSshCheckPing.setToolTip(_('Warning: if disabled and the remote host\n'
                                          'is not available, this could lead to some\n'
-                                         'wired errors.'))
+                                         'weird errors.'))
         self.cbSshCheckCommands = QCheckBox(_('Check if remote host support all necessary commands'))
-        self.cbSshCheckCommands.setToolTip(_('Warning: if disabled and the remore host\n'
+        self.cbSshCheckCommands.setToolTip(_('Warning: if disabled and the remote host\n'
                                              'does not support all necessary commands,\n'
-                                             'this could lead to some wired errors.'))
+                                             'this could lead to some weird errors.'))
         layout.addWidget(self.cbSshCheckPing)
         layout.addWidget(self.cbSshCheckCommands)
 
@@ -1194,7 +1194,7 @@ class SettingsDialog(QDialog):
     def saveProfile(self):
         if self.comboSchedule.itemData(self.comboSchedule.currentIndex()) == self.config.CUSTOM_HOUR:
             if not tools.checkCronPattern(self.txtScheduleCronPatern.text()):
-                self.errorHandler(_('Custom Hours can only be a comma seperate list of hours (e.g. 8,12,18,23) or */3 for periodic backups every 3 hours'))
+                self.errorHandler(_('Custom Hours can only be a comma separated list of hours (e.g. 8,12,18,23) or */3 for periodic backups every 3 hours'))
                 return False
 
         #mode
@@ -1368,7 +1368,7 @@ class SettingsDialog(QDialog):
                 if not fingerprint:
                     self.errorHandler(str(ex))
                     return False
-                msg = _('The authenticity of host "%(host)s" can\'t be stablished.\n\n%(keytype)s key fingerprint is:')
+                msg = _('The authenticity of host "%(host)s" can\'t be established.\n\n%(keytype)s key fingerprint is:')
                 msg = msg %{'host': self.config.sshHost(),
                             'keytype': keyType}
                 options = []

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -305,7 +305,7 @@ class SnapshotsDialog(QDialog):
         if not os.path.exists(full_path):
             return
 
-        # prevent backup data from being accidentaly overwritten
+        # prevent backup data from being accidentally overwritten
         # by create a temporary local copy and only open that one
         if not isinstance(self.sid, snapshots.RootSnapshot):
             full_path = self.parent.tmpCopy(full_path, sid)
@@ -333,7 +333,7 @@ class SnapshotsDialog(QDialog):
             messagebox.critical(self, _('Command not found: %s') % diffCmd)
             return
 
-        # prevent backup data from being accidentaly overwritten
+        # prevent backup data from being accidentally overwritten
         # by create a temporary local copy and only open that one
         if not isinstance(sid1, snapshots.RootSnapshot):
             path1 = self.parent.tmpCopy(path1, sid1)


### PR DESCRIPTION
I noticed some spelling issues while I was spelunking yesterday and thought I thank you for fixing my issue by going over the code for English spelling.

I have left some spelling in the form it is (cases where English would not normally use compounded word as German does, e.g. "commandline", though see PR code comment).

@Germar Please take a look.