### PR TITLE
Fix subprocess call (fixes #728)

### DIFF
--- a/common/backintime.py
+++ b/common/backintime.py
@@ -66,7 +66,7 @@ def take_snapshot_now_async( cfg ):
             del env[i]
         except:
             pass
-    subprocess.Popen(cmd, env = env)
+    subprocess.Popen(cmd, env = env, shell = True)
 
 def take_snapshot( cfg, force = True ):
     '''take a new snapshot.


### PR DESCRIPTION
Popen() requires the optional argument `shell=True` in order to be able to run a shell command with arguments. This fixes #728.