### PR TITLE
FIX: Workaround for #912: Backup operation broke older permissions

### DIFF
--- a/common/tools.py
+++ b/common/tools.py
@@ -660,7 +660,10 @@ def rsyncRemove(config, run_local = True):
     Returns:
         list:                   rsync command with all args
     """
-    cmd = ['rsync', '-a', '--delete']
+    # '--super' is needed as a workaround for rsync's bug #12806:
+    # https://bugzilla.samba.org/show_bug.cgi?id=12806
+    # The option can probably be dropped after that bug has been fixed.
+    cmd = ['rsync', '-a', '--delete', '--super']
     if run_local:
         cmd.extend(rsyncSshArgs(config))
     return cmd


### PR DESCRIPTION
Attempting a backup when there are no changes to be submitted added the u+w
permission bit for all files.  I am not certain if this workaround works for
read-only directories (maybe it only works for normal files).

Fixes #912 