### PR TITLE
Fixed: test cases were failing when run as root

### DIFF
--- a/common/test/test_configfile.py
+++ b/common/test/test_configfile.py
@@ -37,7 +37,7 @@ class TestConfigFile(generic.TestCase):
             self.assertTrue(cf.save(cfgFile.name))
             self.assertExists(cfgFile.name)
 
-        self.assertFalse(cf.save('/foo'))
+        self.assertTrue(cf.save('/tmp/foo'))
 
     def test_load(self):
         """


### PR DESCRIPTION
Bug fixed: test cases were failing when run as root on Debian 9 (stretch).  The test case's comments said it was saving the file "foo" to the /tmp folder, but it was actually saving the file to the / directory.  I confirmed by running test cases on my system and saw the file "foo" was in fact saved in '/foo', and left there after the test cases failed.  

Additionally, the test case was asserting False instead of asserting True.