### PR TITLE
Keep permissions of an existing mountpoint from being overridden

### DIFF
--- a/common/mount.py
+++ b/common/mount.py
@@ -648,7 +648,7 @@ class MountControl(object):
         """
         tools.mkdir(self.mount_root, 0o700)
         tools.mkdir(self.hash_id_path, 0o700)
-        tools.mkdir(self.currentMountpoint, 0o700)
+        tools.mkdir(self.currentMountpoint, 0o700, False)
         tools.mkdir(self.lock_path, 0o700)
 
     def mountProcessLockAcquire(self, timeout = 60):

--- a/common/tools.py
+++ b/common/tools.py
@@ -287,7 +287,7 @@ def makeDirs(path):
                          %(path, str(e)), traceDepth = 1)
     return os.path.isdir(path)
 
-def mkdir(path, mode = 0o755):
+def mkdir(path, mode = 0o755, enforce_permissions = True):
     """
     Create directory ``path``.
 
@@ -300,7 +300,8 @@ def mkdir(path, mode = 0o755):
     """
     if os.path.isdir(path):
         try:
-            os.chmod(path, mode)
+            if enforce_permissions:
+                os.chmod(path, mode)
         except:
             return False
         return True


### PR DESCRIPTION
Github merge request port of path supplied in 
   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=946349

This measure especially protects the root of a already mounted file system
(ssh or encfs) from getting its access permissions altered.

Should fix #974 and #954