### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 # https://docs.travis-ci.com/user/languages/python
 
 language: python
+arch : 
+ - amd64
+ - ppc64le
 
 # ensures that we have UUID filesystem mounts for proper testing
 sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ before_install:
   - sudo apt-get -qq update
   # install screen, and util-linux (provides flock) for test_sshtools
   - sudo apt-get install -y sshfs screen util-linux
+jobs:
+  exclude:
+    - arch: ppc64le
+      python: 3.4
 
 install:
   - pip install coveralls


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing