### PR TITLE
Removed new permissions handling

### DIFF
--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -444,7 +444,7 @@ class Snapshots:
 
         info = sid.info
 
-        cmd_prefix = tools.rsyncPrefix(self.config, no_perms = False, use_mode = ['ssh'])
+        cmd_prefix = tools.rsyncPrefix(self.config, use_mode = ['ssh'])
         cmd_prefix.extend(('-R', '-v'))
         if backup:
             cmd_prefix.extend(('--backup', '--suffix=%s' %self.backupSuffix()))
@@ -845,7 +845,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                 with open(os.path.join(self.config.localEncfsPath(), 'config'), 'wb') as dst2:
                     dst2.write(src.read())
             elif self.config.snapshotsMode() == 'ssh_encfs':
-                cmd = tools.rsyncPrefix(self.config, no_perms = False)
+                cmd = tools.rsyncPrefix(self.config)
                 cmd.append(self.config._LOCAL_CONFIG_PATH)
                 cmd.append(self.rsyncRemotePath(self.config.sshSnapshotsPath()))
                 tools.Execute(cmd, parent = self).run()
@@ -1003,7 +1003,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             prev_sid = snapshots[0]
 
         #rsync prefix & suffix
-        rsync_prefix = tools.rsyncPrefix(self.config, no_perms = False)
+        rsync_prefix = tools.rsyncPrefix(self.config)
         if self.config.excludeBySizeEnabled():
             rsync_prefix.append('--max-size=%sM' %self.config.excludeBySize())
         rsync_suffix = self.rsyncSuffix(include_folders)

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -552,14 +552,14 @@ class SSH(MountControl):
                 f.write('foo')
 
             #check rsync
-            rsync1 =  tools.rsyncPrefix(self.config, no_perms = False, progress = False)
+            rsync1 =  tools.rsyncPrefix(self.config, progress = False)
             rsync1.append(tmp_file)
             rsync1.append('%s@%s:"%s"/' %(self.user,
                                         tools.escapeIPv6Address(self.host),
                                         remote_tmp_dir_1))
 
             #check remote rsync hard-link support
-            rsync2 =  tools.rsyncPrefix(self.config, no_perms = False, progress = False)
+            rsync2 =  tools.rsyncPrefix(self.config, progress = False)
             rsync2.append('--link-dest=../%s' %os.path.basename(remote_tmp_dir_1))
             rsync2.append(tmp_file)
             rsync2.append('%s@%s:"%s"/' %(self.user,


### PR DESCRIPTION
This PR is about reverting the change of permissions handling introduced in 1.2. The permissions handling implemented in 1.2 leads to
- backing up of files that have not changed (if only their permissions have changed)
- not recognizing of pre-1.2 backups
