### PR TITLE
Fix #1134: 'TempPasswordThread' object has no attribute 'isAlive' (Python 3.9)

### DIFF
--- a/common/password_ipc.py
+++ b/common/password_ipc.py
@@ -132,7 +132,7 @@ class TempPasswordThread(threading.Thread):
 
     def stop(self):
         self.join(5)
-        if self.isAlive():
+        if self.is_alive():
             #threading does not support signal.alarm
             self.read()
         try:


### PR DESCRIPTION
After some investigation, #1134 seems to be a rather simple problem: The `TempPassThread` object in question calls the method `isAlive` which has been removed (at least in Python 3.9) in favor of `is_alive`. 