### PR TITLE
Shortcuts for menu bar and tabs, toolbar items and remove exit from toolbar

### DIFF
--- a/qt/app.py
+++ b/qt/app.py
@@ -151,8 +151,9 @@ class MainWindow(QMainWindow):
         self.btnShutdown.setEnabled(self.shutdown.canShutdown())
         self.btnShutdown.toggled.connect(self.btnShutdownToggled)
 
-        self.btnQuit = self.mainToolbar.addAction(icon.EXIT, _('Exit'))
-        self.btnQuit.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_W))
+        self.menuSnapshot = self.menuBar().addMenu(_('&Snapshot'))
+        self.btnQuit = self.menuSnapshot.addAction(icon.EXIT, _('Exit'))
+        self.btnQuit.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_Q))
         self.btnQuit.triggered.connect(self.close)
 
         empty = QWidget(self)
@@ -262,8 +263,6 @@ class MainWindow(QMainWindow):
 
         filesLayout.addWidget(self.filesViewToolbar)
 
-        #menubar
-        self.menuSnapshot = self.menuBar().addMenu(_('&Snapshot'))
         self.menuSnapshot.addAction(self.btnTakeSnapshot)
         self.menuSnapshot.addAction(self.btnUpdateSnapshots)
         self.menuSnapshot.addAction(self.btnNameSnapshot)

--- a/qt/app.py
+++ b/qt/app.py
@@ -85,6 +85,7 @@ class MainWindow(QMainWindow):
 
         # take_snapshot button
         self.btnTakeSnapshot = self.mainToolbar.addAction(icon.TAKE_SNAPSHOT, _('Take snapshot'))
+        self.btnTakeSnapshot.setShortcuts(QKeySequence(Qt.CTRL + Qt.Key_S))
         self.btnTakeSnapshot.triggered.connect(self.btnTakeSnapshotClicked)
 
         takeSnapshotMenu = qttools.Menu()
@@ -92,6 +93,7 @@ class MainWindow(QMainWindow):
         action.triggered.connect(self.btnTakeSnapshotClicked)
         self.btnTakeSnapshotChecksum = takeSnapshotMenu.addAction(icon.TAKE_SNAPSHOT, _('Take snapshot with checksums'))
         self.btnTakeSnapshotChecksum.setToolTip(_('Use checksum to detect changes'))
+        self.btnTakeSnapshotChecksum.setShortcuts(QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_S))
         self.btnTakeSnapshotChecksum.triggered.connect(self.btnTakeSnapshotChecksumClicked)
         self.btnTakeSnapshot.setMenu(takeSnapshotMenu)
 
@@ -121,9 +123,11 @@ class MainWindow(QMainWindow):
         self.btnUpdateSnapshots.triggered.connect(self.btnUpdateSnapshotsClicked)
 
         self.btnNameSnapshot = self.mainToolbar.addAction(icon.SNAPSHOT_NAME, _('Snapshot Name'))
+        self.btnNameSnapshot.setShortcuts([Qt.Key_F2])
         self.btnNameSnapshot.triggered.connect(self.btnNameSnapshotClicked)
 
         self.btnRemoveSnapshot = self.mainToolbar.addAction(icon.REMOVE_SNAPSHOT, _('Remove Snapshot'))
+        self.btnRemoveSnapshot.setShortcuts([Qt.Key_Delete])
         self.btnRemoveSnapshot.triggered.connect(self.btnRemoveSnapshotClicked)
 
         self.btnSnapshotLogView = self.mainToolbar.addAction(icon.VIEW_SNAPSHOT_LOG, _('View Snapshot Log'))
@@ -135,6 +139,7 @@ class MainWindow(QMainWindow):
         self.mainToolbar.addSeparator()
 
         self.btnSettings = self.mainToolbar.addAction(icon.SETTINGS, _('Settings'))
+        self.btnSettings.setShortcuts(QKeySequence(Qt.CTRL + Qt.SHIFT + Qt.Key_Comma))
         self.btnSettings.triggered.connect(self.btnSettingsClicked)
 
         self.mainToolbar.addSeparator()
@@ -156,6 +161,7 @@ class MainWindow(QMainWindow):
 
         menuHelp = QMenu(self)
         self.btnHelp = menuHelp.addAction(icon.HELP, _('Help'))
+        self.btnHelp.setShortcuts([Qt.Key_F1])
         self.btnHelp.triggered.connect(self.btnHelpClicked)
         self.btnHelpConfig = menuHelp.addAction(icon.HELP, _('Config File Help'))
         self.btnHelpConfig.triggered.connect(self.btnHelpConfigClicked)
@@ -257,7 +263,7 @@ class MainWindow(QMainWindow):
         filesLayout.addWidget(self.filesViewToolbar)
 
         #menubar
-        self.menuSnapshot = self.menuBar().addMenu(_('Snapshot'))
+        self.menuSnapshot = self.menuBar().addMenu(_('&Snapshot'))
         self.menuSnapshot.addAction(self.btnTakeSnapshot)
         self.menuSnapshot.addAction(self.btnUpdateSnapshots)
         self.menuSnapshot.addAction(self.btnNameSnapshot)
@@ -268,7 +274,7 @@ class MainWindow(QMainWindow):
         self.menuSnapshot.addAction(self.btnShutdown)
         self.menuSnapshot.addAction(self.btnQuit)
 
-        self.menuView = self.menuBar().addMenu(_('View'))
+        self.menuView = self.menuBar().addMenu(_('&View'))
         self.menuView.addAction(self.btnFolderUp)
         self.menuView.addAction(self.btnShowHiddenFiles)
         self.menuView.addSeparator()
@@ -277,14 +283,14 @@ class MainWindow(QMainWindow):
         self.menuView.addSeparator()
         self.menuView.addAction(self.btnSnapshots)
 
-        self.menuRestore = self.menuBar().addMenu(_('Restore'))
+        self.menuRestore = self.menuBar().addMenu(_('&Restore'))
         self.menuRestore.addAction(self.btnRestore)
         self.menuRestore.addAction(self.btnRestoreTo)
         self.menuRestore.addSeparator()
         self.menuRestore.addAction(self.btnRestoreParent)
         self.menuRestore.addAction(self.btnRestoreParentTo)
 
-        self.menuHelp = self.menuBar().addMenu(_('Help'))
+        self.menuHelp = self.menuBar().addMenu(_('&Help'))
         self.menuHelp.addAction(self.btnHelp)
         self.menuHelp.addAction(self.btnHelpConfig)
         self.menuHelp.addSeparator()

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -103,7 +103,7 @@ class SettingsDialog(QDialog):
         #TAB: General
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
-        self.tabs.addTab(scrollArea, _('General'))
+        self.tabs.addTab(scrollArea, _('&General'))
 
         layoutWidget = QWidget(self)
         layout = QVBoxLayout(layoutWidget)
@@ -392,7 +392,7 @@ class SettingsDialog(QDialog):
 
         #TAB: Include
         tabWidget = QWidget(self)
-        self.tabs.addTab(tabWidget, _('Include'))
+        self.tabs.addTab(tabWidget, _('&Include'))
         layout = QVBoxLayout(tabWidget)
 
         self.listInclude = QTreeWidget(self)
@@ -428,7 +428,7 @@ class SettingsDialog(QDialog):
 
         #TAB: Exclude
         tabWidget = QWidget(self)
-        self.tabs.addTab(tabWidget, _('Exclude'))
+        self.tabs.addTab(tabWidget, _('&Exclude'))
         layout = QVBoxLayout(tabWidget)
 
         self.lblSshEncfsExcludeWarning = QLabel(_('<b>Warning:</b> Wildcards (\'foo*\', \'[fF]oo\', \'fo?\') will be ignored with mode \'SSH encrypted\'.\nOnly separate asterisk are allowed (\'foo/*\', \'foo/**/bar\')'), self)
@@ -503,7 +503,7 @@ class SettingsDialog(QDialog):
         #TAB: Auto-remove
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
-        self.tabs.addTab(scrollArea, _('Auto-remove'))
+        self.tabs.addTab(scrollArea, _('&Auto-remove'))
 
         layoutWidget = QWidget(self)
         layout = QGridLayout(layoutWidget)
@@ -607,7 +607,7 @@ class SettingsDialog(QDialog):
         #TAB: Options
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
-        self.tabs.addTab(scrollArea, _('Options'))
+        self.tabs.addTab(scrollArea, _('&Options'))
 
         layoutWidget = QWidget(self)
         layout = QVBoxLayout(layoutWidget)
@@ -668,7 +668,7 @@ class SettingsDialog(QDialog):
         #TAB: Expert Options
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
-        self.tabs.addTab(scrollArea, _('Expert Options'))
+        self.tabs.addTab(scrollArea, _('E&xpert Options'))
 
         layoutWidget = QWidget(self)
         layout = QVBoxLayout(layoutWidget)


### PR DESCRIPTION
Adds accelerator keys to the menu bars and tabs in the settings screen. Most of the toolbar buttons now also have shortcut keys for easier keyboard access. This also removes the exit button from the toolbar and changes the shortcut to the more standard CTRL + Q instead of CTRL + W which is often used for closing tabs

Closes #1104, closes #172