### PR TITLE
Use Link Color instead of lightGray as not to break theming

### DIFF
--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1707,7 +1707,7 @@ class SettingsDialog(QDialog):
     def formatExcludeItem(self, item):
         if self.mode == 'ssh_encfs' and tools.patternHasNotEncryptableWildcard(item.text(0)):
             item.setIcon(0, self.icon.INVALID_EXCLUDE)
-            item.setBackground(0, QBrush(Qt.lightGray))
+            item.setBackground(0, QPalette().brush(QPalette.Active, QPalette.Link))
         elif item.text(0) in self.config.DEFAULT_EXCLUDE:
             item.setIcon(0, self.icon.DEFAULT_EXCLUDE)
             item.setBackground(0, QBrush())


### PR DESCRIPTION
This removes the Qt.lightGray Color for the excluded list in the settings, which does not work well with KDE theming, especially dark themes. It uses the link-color instead, which gets themed and looks better (on KDE)

I am not sure if this is a good color choice, but i am not familiar enough with the Qt -framework.