### PR TITLE
qt/plugins/notifyplugin: Fix setting self.user, not local variable

### DIFF
--- a/qt/plugins/notifyplugin.py
+++ b/qt/plugins/notifyplugin.py
@@ -32,13 +32,13 @@ class NotifyPlugin(pluginmanager.Plugin):
 
         if not self.user:
             try:
-                user = os.environ['USER']
+                self.user = os.environ['USER']
             except:
                 pass
 
         if not self.user:
             try:
-                user = os.environ['LOGNAME']
+                self.user = os.environ['LOGNAME']
             except:
                 pass
 


### PR DESCRIPTION
This fallback code I found while developing something else does not really set `self.user` but creates and sets a new local variable called `user`, which is and can never used afterwards.