### PR TITLE
Fix FileNotFoundError exception in mount.mounted

### DIFF
--- a/common/mount.py
+++ b/common/mount.py
@@ -607,8 +607,11 @@ class MountControl(object):
         if os.path.ismount(self.currentMountpoint):
             return True
         else:
-            if os.listdir(self.currentMountpoint):
-                raise MountException(_('mountpoint %s not empty.') % self.currentMountpoint)
+            try:
+                if os.listdir(self.currentMountpoint):
+                    raise MountException(_('mountpoint %s not empty.') % self.currentMountpoint)
+            except FileNotFoundError:
+                pass
             return False
 
     def createMountStructure(self):


### PR DESCRIPTION
If the user manually unmounts the drive containing the mount dir in the user-callback script, then os.listdir(self.currentMountpoint) will throw an exception, as the directory won't exist.

This PR avoids the following exception
```
INFO: mount ssh: backups@domain:/media/user/drive/path on /home/user/.local/share/backintime/mnt/ID/mountpoint
[...]
INFO: Create info file
Traceback (most recent call last):
  File "/usr/share/backintime/common/backintime.py", line 1165, in <module>
    startApp()
  File "/usr/share/backintime/common/backintime.py", line 517, in startApp
    args.func(args)
  File "/usr/share/backintime/common/backintime.py", line 739, in backup
    ret = takeSnapshot(cfg, force)
  File "/usr/share/backintime/common/backintime.py", line 94, in takeSnapshot
    ret = snapshots.Snapshots(cfg).backup(force)
  File "/usr/share/backintime/common/snapshots.py", line 733, in backup
    mount.Mount(cfg = self.config).umount(self.config.current_hash_id)
  File "/usr/share/backintime/common/mount.py", line 178, in umount
    backend.umount()
  File "/usr/share/backintime/common/mount.py", line 449, in umount
    if not self.mounted():
  File "/usr/share/backintime/common/mount.py", line 610, in mounted
    if os.listdir(self.currentMountpoint):
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.local/share/backintime/mnt/ID/mountpoint'
```

This occurs because the user script in my case remotely does the following
```bash
ssh domain -p 25 -l backups sudo umount /media/user/drive
```