### PR TITLE
show filesizes in log

### DIFF
--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -22,6 +22,7 @@ import gettext
 import logger
 import snapshots
 import tools
+import humanfriendly
 
 _=gettext.gettext
 
@@ -80,7 +81,6 @@ class LogFilter(object):
             str:        decoded ``line`` or ``None`` if the line was filtered
             int:        size of the file in bytes, ``None`` if no size was found.
         """
-
         has_size = False
         original_line = str(line)
         size = 0
@@ -88,7 +88,6 @@ class LogFilter(object):
             has_size = True
             start = line.find("[", 3)+1
             end = line.find(" bytes]")
-            import humanfriendly
             size = int(line[start:end])
             size_hr = " ["+humanfriendly.format_size(size)+"]"
             line = line[0:start-2]
@@ -172,14 +171,22 @@ class SnapshotLog(object):
                         count += 1
                         if count <= skipLines:
                             continue
-                        if line.startswith("====") or line.strip() == "":
+                        if line.startswith("===="):
                             result.append(line)
+                        elif line.strip() == "":
+                            continue
                         else:
                             order.append((size, line))
                 if sort < 0:
                     order = sorted(order)
                 elif sort > 0:
                     order = sorted(order, reverse=True)
+                finalsize = 0
+                for i in order:
+                    finalsize = finalsize + i[0]
+
+                result.append("Snapshotsize: " + humanfriendly.format_size(finalsize))
+                result.append("")
                 for i in order:
                     result.append(i[1])
         except Exception as e:

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -79,15 +79,31 @@ class LogFilter(object):
         Returns:
             str:        decoded ``line`` or ``None`` if the line was filtered
         """
+
+        has_size = False
+        original_line = str(line)
+        if line.startswith("[C]") and line.endswith("bytes]"):
+            has_size = True
+            start = line.find("[", 3)+1
+            end = line.find(" bytes]")
+            import humanfriendly
+            size = " ["+humanfriendly.format_size(int(line[start:end]))+"]"
+            line = line[0:start-2]
+
         if not line:
             #keep empty lines
             return line
         if self.regex and not self.regex.match(line):
             return
         if self.decode:
-            return self.decode.log(line)
+            ret = self.decode.log(line)
+            if has_size:
+                ret = ret + size
+            return ret
         else:
-            return line
+            if has_size:
+                return line + size
+            return original_line
 
 class SnapshotLog(object):
     """

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -172,8 +172,10 @@ class SnapshotLog(object):
                         count += 1
                         if count <= skipLines:
                             continue
-                        order.append((size, line))
-
+                        if line.startswith("====") or line.strip() == "":
+                            result.append(line)
+                        else:
+                            order.append((size, line))
                 if sort < 0:
                     order = sorted(order)
                 elif sort > 0:

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -42,6 +42,7 @@ import bcolors
 import snapshotlog
 from applicationinstance import ApplicationInstance
 from exceptions import MountException, LastSnapshotSymlink
+import humanfriendly
 
 _=gettext.gettext
 
@@ -2353,15 +2354,21 @@ class SID(object):
                     if size is None:
                         size = 0
                     if not line is None:
-                        if line.startswith("====") or line.strip() == "":
+                        if line.startswith("===="):
                             result.append(line)
+                        elif line.strip() == "":
+                            continue
                         else:
                             order.append((size, line))
-
                 if sort < 0:
                     order = sorted(order)
                 elif sort > 0:
                     order = sorted(order, reverse=True)
+                finalsize = 0
+                for i in order:
+                    finalsize = finalsize + i[0]
+                result.append("Snapshotsize: " + humanfriendly.format_size(finalsize))
+                result.append("")
                 for i in order:
                     result.append(i[1])
         except Exception as e:

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1012,7 +1012,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
         # It should delete the excluded folders then
         rsync_prefix.extend(('--delete', '--delete-excluded'))
         rsync_prefix.append('-v')
-        rsync_prefix.extend(('-i', '--out-format=BACKINTIME: %i %n%L'))
+        rsync_prefix.extend(('-i', '--out-format=BACKINTIME: %i %n%L [%b bytes]'))
         if prev_sid:
             link_dest = encode.path(os.path.join(prev_sid.sid, 'backup'))
             link_dest = os.path.join(os.pardir, os.pardir, link_dest)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2353,7 +2353,10 @@ class SID(object):
                     if size is None:
                         size = 0
                     if not line is None:
-                        order.append((size, line))
+                        if line.startswith("====") or line.strip() == "":
+                            result.append(line)
+                        else:
+                            order.append((size, line))
 
                 if sort < 0:
                     order = sorted(order)

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -46,6 +46,7 @@ class LogViewDialog(QDialog):
         self.sid = sid
         self.enableUpdate = False
         self.decode = None
+        self.sort = 0
 
         w = self.config.intValue('qt.logview.width', 800)
         h = self.config.intValue('qt.logview.height', 500)
@@ -113,6 +114,10 @@ class LogViewDialog(QDialog):
         self.cbDecode = QCheckBox(_('decode paths'), self)
         self.cbDecode.stateChanged.connect(self.cbDecodeChanged)
         self.mainLayout.addWidget(self.cbDecode)
+        self.cbSort = QPushButton(_('sort filesize'), self)
+        self.cbSort.setText(_("Sort by Time"))
+        self.cbSort.clicked.connect(self.clickSorting)
+        self.mainLayout.addWidget(self.cbSort)
 
         #buttons
         buttonBox = QDialogButtonBox(QDialogButtonBox.Close)
@@ -240,6 +245,18 @@ class LogViewDialog(QDialog):
             if self.cbDecode.isChecked():
                 self.cbDecode.setChecked(False)
 
+    def clickSorting(self):
+        if self.sort == 0:
+            self.sort = -1
+            self.cbSort.setText(_("Sort by Size, Ascending"))
+        elif self.sort == -1:
+            self.sort = 1
+            self.cbSort.setText(_("Sort by Size, Descending"))
+        else:
+            self.sort = 0
+            self.cbSort.setText(_("Sort by Time"))
+        self.updateLog()
+
     def updateLog(self, watchPath = None):
         if not self.enableUpdate:
             return
@@ -263,9 +280,9 @@ class LogViewDialog(QDialog):
 
         elif self.sid is None:
             log = snapshotlog.SnapshotLog(self.config, self.comboProfiles.currentProfileID())
-            self.txtLogView.setPlainText('\n'.join(log.get(mode = mode, decode = self.decode)))
+            self.txtLogView.setPlainText('\n'.join(log.get(mode = mode, decode = self.decode, sort = self.sort)))
         else:
-            self.txtLogView.setPlainText('\n'.join(self.sid.log(mode, decode = self.decode)))
+            self.txtLogView.setPlainText('\n'.join(self.sid.log(mode, decode = self.decode, sort = self.sort)))
 
     def closeEvent(self, event):
         self.config.setIntValue('qt.logview.width', self.width())


### PR DESCRIPTION
This modifies the logoutput of rsync to include filesizes in byte. This allows to quickly see which files may bloat your backup.

Drawbacks: 
 - sizes are not encrypted and are always readable.

Missing:
 - <del>currently the log cannot be sorted by filesizes</del>
 - <del>calculate and show size of all files in log-viewer</del>
 - <del>The log-header with the snapshotdate should stay on top</del>
 - <del>maybe show full size in log aswell?</del>
 - behaviour of old logs is strange when the sorting is used, since all the items are zero bytes in length
 - behaviour of continued snapshot-log is strange.

this may help with #991, #406
