### PR TITLE
Make tools.py work on python 3.10

### DIFF
--- a/common/tools.py
+++ b/common/tools.py
@@ -1802,7 +1802,7 @@ class PathHistory(object):
         self.history = [path,]
         self.index = 0
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
     """
     OrderedSet from Python recipe
     http://code.activestate.com/recipes/576694/


### PR DESCRIPTION
collections.MutableSet is deprecated since Python 3.3, and display this warning:
```
<stdin>:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```

Now 3.10 is out, the code is breaking when running test on Fedora Rawhide.