### PR TITLE
Fix: `str` don't have `toUtf8` method.

### DIFF
--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -73,8 +73,8 @@ class DiffOptionsDialog(QDialog):
         self.mainLayout.addWidget(buttonBox, 3, 0, 3, 2)
 
     def accept(self):
-        diffCmd = str(self.editCmd.text().toUtf8())
-        diffParams = str(self.editParams.text().toUtf8())
+        diffCmd = self.editCmd.text()
+        diffParams = self.editParams.text()
 
         if diffCmd != self.diffCmd or diffParams != self.diffParams:
             self.config.setStrValue('qt.diff.cmd', diffCmd)


### PR DESCRIPTION
`QLineEdit.text()` returns `str` which don't have `toUtf8` method.
Later an command is build up based on this input. I have tested
that it still works with unicode characters.