### PR TITLE
Fix rsync issues with quotes in remote path

### DIFF
--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1647,7 +1647,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
         return snapshotsFiltered
 
     #TODO: move this to config.Config
-    def rsyncRemotePath(self, path, use_mode = ['ssh', 'ssh_encfs'], quote = '"'):
+    def rsyncRemotePath(self, path, use_mode = ['ssh', 'ssh_encfs'], quote = ''):
         """
         Format the destination string for rsync depending on which profile is
         used.

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -554,17 +554,17 @@ class SSH(MountControl):
             #check rsync
             rsync1 =  tools.rsyncPrefix(self.config, no_perms = False, progress = False)
             rsync1.append(tmp_file)
-            rsync1.append('%s@%s:"%s"/' %(self.user,
-                                        tools.escapeIPv6Address(self.host),
-                                        remote_tmp_dir_1))
+            rsync1.append('%s@%s:%s/' %(self.user,
+                                      tools.escapeIPv6Address(self.host),
+                                      remote_tmp_dir_1))
 
             #check remote rsync hard-link support
             rsync2 =  tools.rsyncPrefix(self.config, no_perms = False, progress = False)
             rsync2.append('--link-dest=../%s' %os.path.basename(remote_tmp_dir_1))
             rsync2.append(tmp_file)
-            rsync2.append('%s@%s:"%s"/' %(self.user,
-                                        tools.escapeIPv6Address(self.host),
-                                        remote_tmp_dir_2))
+            rsync2.append('%s@%s:%s/' %(self.user,
+                                      tools.escapeIPv6Address(self.host),
+                                      remote_tmp_dir_2))
 
             for cmd in (rsync1, rsync2):
                 logger.debug('Check rsync command: %s' %cmd, self)

--- a/common/tools.py
+++ b/common/tools.py
@@ -577,12 +577,13 @@ def rsyncPrefix(config,
     if config.nocacheOnLocal():
         cmd.append('nocache')
     cmd.append('rsync')
-    cmd.extend(('--recursive',     # recurse into directories
+    cmd.extend(('--recursive',      # recurse into directories
                 '--times',          # preserve modification times
                 '--devices',        # preserve device files (super-user only)
                 '--specials',       # preserve special files
                 '--hard-links',     # preserve hard links
-                '--human-readable'))# numbers in a human-readable format
+                '--human-readable', # numbers in a human-readable format
+                '--protect-args'))  # no space splitting, wildcard chars only
 
     if config.useChecksum() or config.forceUseChecksum:
         cmd.append('--checksum')


### PR DESCRIPTION
I recently noticed that my scheduled backups were failing because of a rsync error. Here's the log output: 
```log
[I] ...
[I] Take snapshot
[I] rsync --recursive --times --devices --specials --hard-links --human-readable --links --perms --executability --group --owner --rsh=ssh -o ServerAliveInterval=240 -o LogLevel=Error -o IdentityFile=/home/florian/.ssh/id_rsa -p 22 --delete --delete-excluded -v -i --out-format=BACKINTIME: %i %n%L --link-dest=../../20220516-210001-824/backup --chmod=Du+wx --exclude=... --include=... / Florian@my_server:"backups/backintime/manjaro/florian/1/new_snapshot/backup"
[I] Take snapshot (rsync: sending incremental file list)
[I] Take snapshot (rsync: rsync: mkdir "/volume1/homes/Florian/"backups/backintime/manjaro/florian/1/new_snapshot/backup"" failed: No such file or directory (2))
[E] Error: rsync: mkdir "/volume1/homes/Florian/"backups/backintime/manjaro/florian/1/new_snapshot/backup"" failed: No such file or directory (2)
[I] Take snapshot (rsync: rsync error: error in file IO (code 11) at main.c(615) [Receiver=3.0.9])
[I] Take snapshot (rsync: rsync: connection unexpectedly closed (215 bytes received so far) [sender])
[I] Take snapshot (rsync: rsync error: error in rsync protocol data stream (code 12) at io.c(228) [sender=v3.2.4])
```

Just for reference: The SSH server I'm backing up to is a Synology NAS.

The problem is that rsync seems unable to handle the quotes in `Florian@my_server:"backups/backintime/manjaro/florian/1/new_snapshot/backup"`. Removing the quotes resulted in a successful backup again.

I don't know whether my local rsync or the remote rsync changed behavior in a newer version. For reference here are the rsync versions I'm using:  
local  
```console
$ rsync --version
rsync  version v3.2.4  protocol version 31
Copyright (C) 1996-2022 by Andrew Tridgell, Wayne Davison, and others.
Web site: https://rsync.samba.org/
Capabilities:
    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
    xattrs, optional protect-args, iconv, prealloc, stop-at, no crtimes
Optimizations:
    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
Checksum list:
    xxh128 xxh3 xxh64 (xxhash) md5 md4 none
Compress list:
    zstd lz4 zlibx zlib none
```
remote  
```console
$ rsync --version
rsync  version 3.0.9  protocol version 30
Copyright (C) 1996-2011 by Andrew Tridgell, Wayne Davison, and others.
Web site: http://rsync.samba.org/
Capabilities:
    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
    no socketpairs, hardlinks, symlinks, IPv6, batchfiles, inplace,
    append, no ACLs, xattrs, iconv, no symtimes
```

I assume the purpose of the quotes is to support paths with spaces. So, to achieve the same behavior as before there is the `--protect-args` option in rsync which allows using paths with spaces without having to surround them with additional quotes.

This PR adds the `--protect-args` flag to the rsync command and removes all explicit quotes around remote paths.  
I don't know if changing the default value of the `quote` parameter in `rsyncRemotePath` is the preferred solution but it was the easiest for me to do. :D

I tested this with my setup using a remote backup path with and without spaces and it worked just as before.

Just FYI: I also found the suggestion that quoting the whole `user@host:path` (i.e. `"Florian@my_server:backups/backintime/manjaro/florian/1/new_snapshot/backup"` in my case) should work but this didn't seem to be the case here.