### PR TITLE
Mark BackInTime as a single main window program

### DIFF
--- a/common/backintime.desktop
+++ b/common/backintime.desktop
@@ -4,6 +4,6 @@ Name=Backintime Password Cache
 Exec=/bin/sh -c "backintime pw-cache start 2>&1 >/dev/null"
 Comment=Cache passwords for non-interactive Backintime cronjobs
 Icon=gtk-save
-SingleMainWindow=True
+SingleMainWindow=true
 Terminal=false
 Type=Application

--- a/common/backintime.desktop
+++ b/common/backintime.desktop
@@ -4,5 +4,6 @@ Name=Backintime Password Cache
 Exec=/bin/sh -c "backintime pw-cache start 2>&1 >/dev/null"
 Comment=Cache passwords for non-interactive Backintime cronjobs
 Icon=gtk-save
+SingleMainWindow=True
 Terminal=false
 Type=Application


### PR DESCRIPTION
As it happens with other programs (https://github.com/nextcloud/desktop/pull/4194 , 
https://invent.kde.org/pim/knotes/-/commit/70e81d7286c83ff28deadb2f2b80e67b463d1db7 ,
https://github.com/qbittorrent/qBittorrent/pull/15996 ,
https://nicolasfella.de/posts/taskbar-single-app ,
https://gitlab.freedesktop.org/xdg/xdg-specs/-/merge_requests/53):

There can only be one instance of the program running. Mark it as such in 
the .desktop file. This allows desktop environments to adjust their UI 
accordingly.