### PR TITLE
test: Update Travis CI file for better testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,11 @@ jobs:
       python: "3.9-dev"
     - arch: ppc64le
       python: "nightly"
+    # Disable Python "3.9-dev" and "nightly" testing for AMD64, too.
+    - arch: amd64
+      python: "3.9-dev"
+    - arch: amd64
+      python: "nightly"
 
 install:
   - pip install coveralls


### PR DESCRIPTION
This PR disables Python testing for versions `3.9-dev` and `nightly` on AMD64 architecture, to keep the testing to a necessary minimum.