### PR TITLE
Closes #1181: test_readWriteCrontab fails when crontab is empty

### DIFF
--- a/common/tools.py
+++ b/common/tools.py
@@ -1234,6 +1234,8 @@ def readCrontab():
             return []
         else:
             crontab = [x.strip() for x in out.strip('\n').split('\n')]
+            if crontab == ['']:  # Fixes issue #1181 (line count of empty crontab was 1 instead of 0)
+                crontab = []
             logger.debug('Read %s lines from users crontab'
                          %len(crontab))
             return crontab


### PR DESCRIPTION
@emtiu If have fixed this and performed the following manual tests successfully, please merge if OK:

1. Empty crontab file (zero bytes)
2. crontab file with one empty line "\n\n" (no real text contained)
3. crontab file with one text line ("# test")

I have run the unit test for all three scenarios...