### PR TITLE
Fix docstring with backslashes (DeprecationWarning: invalid escape sequence)

### DIFF
--- a/common/mount.py
+++ b/common/mount.py
@@ -615,7 +615,7 @@ class MountControl(object):
             return False
 
     def createMountStructure(self):
-        """
+        r"""
         Create folders that are necessary for mounting.
 
         Folder structure in ~/.local/share/backintime/mnt/ (self.mount_root)::


### PR DESCRIPTION
After a `./configure/make/make test` I get this warning:

```
backintime/common/mount.py:618: DeprecationWarning: invalid escape sequence \ 
```

The reason are several single backslashes in the docstring which may be interpreted as invalid escape sequence.

To avoid this follow the PEP instruction:

https://peps.python.org/pep-0257/#what-is-a-docstring

> Use r"""raw triple double quotes""" if you use any backslashes in your docstrings.

PS: The above warning is shown only after the first `make` since later `make`s do not rebuild unchanged artifacts like documentation.