### PR TITLE
Release candidate for FR #1100 (unclear user-callback location)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Upcoming Release
 * Translation update: French (#1077)
 * Testing: fix a test fail when dealing with an empty crontab (#1181)
 * Testing: numerous fixes and extensions to testing (#1115, #1213, #1279, #1280, #1281, #1285, #1288, #1290, #1293)
+* Add feature: New argument "--diagnostics" to show helpful info for better issue support (#1100)
 
 Version 1.3.2 (2022-03-12)
 * Fix bug: Tests no longer work with Python 3.10 (https://github.com/bit-team/backintime/issues/1175)

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -20,6 +20,11 @@ import re
 import subprocess
 import sys
 from test import generic
+import json
+
+import config
+
+
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -168,3 +173,14 @@ INFO: Restore: /tmp/test/testfile to: /tmp/restored.*''', re.MULTILINE))
                                  "-r",
                                  "/tmp/test",
                                  "/tmp/restored"])
+
+    def test_diagnostics_arg(self):
+
+        # Workaround: Without this line the next "subprocess.getoutput()" call fails on TravisCI for unknown reasons!
+        subprocess.check_output(["./backintime", "--diagnostics"])
+
+        output = subprocess.getoutput("./backintime --diagnostics")
+
+        diagnostics = json.loads(output)
+        self.assertEqual(diagnostics["app_name"], config.Config.APP_NAME)
+        self.assertEqual(diagnostics["app_version"], config.Config.VERSION)


### PR DESCRIPTION
**THIS IS A PREVIEW FOR DISCUSSIONS - PLEASE DO NOT YET MERGE INTO MASTER**

I have created a first PR to make the location and file name of the user-callback script visible.

Applied changes:

1. `backintime` now shows the same content as before + (new!) the user callback location (I call this: "about" `backintime`)
2. `backintime -v` did show only the version number. It now shows the same "about" output as above

The main reason for 2. was that 1. is not obvious to call and 2. does not hurt (having a longer output now).
The version number can still be easily parsed via a regexp (if someone really needs to do so).

**Open:**
- I did not (yet) implement the syslog output whenever the user-callback is called (could also be a second PR)

**Out of scope:**

- #827 (together with #1292): I would work an that in a separate PR (to provide an _agile_ "minimal viable product" here)

**New output:**

```
> backintime      # now same as:  backintime -v

Back In Time
Version: 1.3.2
User callback script file: /home/xxx/.config/backintime/user-callback

Back In Time comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it
under certain conditions; type `backintime --license' for details.
```

**Old output:**

```
> backintime -v
backintime 1.2.1
```

```
> backintime

Back In Time
Version: 1.2.1

Back In Time comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it
under certain conditions; type `backintime --license' for details.
```

**Possible future extensions (out of scope for this PR/issue):**

I think of extending the output later with another PR to show more "diagnostics" that could be copied&pasted
into a new issue, eg. also:

```
> backintime      # now same as:  backintime -v

Back In Time
Version: 1.3.2
User callback script file: /home/xxx/.config/backintime/user-callback
Distro: Ubuntu 20.04.5 LTS
Desktop Environment: KDE
Display Server protocol: wayland

Back In Time comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it
under certain conditions; type `backintime --license' for details.
```
