### PR TITLE
Removed Not-yet-implemented tests

### DIFF
--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -318,9 +318,6 @@ class TestSnapshots(generic.SnapshotsTestCase):
         self.assertTrue(self.run)
         self.assertTrue(self.sn.restorePermissionFailed)
 
-    @unittest.skip('Not yet implemented')
-    def test_filterRsyncProgress(self):
-        pass
 
     def test_rsyncCallback(self):
         params = [False, False]
@@ -514,9 +511,6 @@ class TestSnapshots(generic.SnapshotsTestCase):
                                              sid15, sid16, sid18, sid19, sid20, sid21,
                                              sid22, sid24, sid27, sid28, sid30])
 
-    @unittest.skip('Not yet implemented')
-    def test_smartRemove(self):
-        pass
 
 class TestSnapshotWithSID(generic.SnapshotsWithSidTestCase):
     def test_backupConfig(self):

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -99,10 +99,6 @@ class TestSSH(generic.SSHTestCase):
         with self.assertRaisesRegex(MountException, r"Cipher .+ failed for.+"):
             ssh.checkCipher()
 
-    @unittest.skip('Not yet implemented')
-    def test_benchmarkCipher(self):
-        pass
-
     def test_checkKnownHosts(self):
         ssh = sshtools.SSH(cfg = self.cfg)
         ssh.checkKnownHosts()

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -384,14 +384,6 @@ class TestTools(generic.TestCase):
                               'symtimes',
                               'prealloc'])
 
-    @unittest.skip('Not yet implemented')
-    def test_rsyncPrefix(self):
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_tempFailureRetry(self):
-        pass
-
     def test_md5sum(self):
         with NamedTemporaryFile() as f:
             f.write(b'foo')
@@ -411,23 +403,7 @@ class TestTools(generic.TestCase):
         self.assertFalse(tools.checkCronPattern('*/6,8'))
         self.assertFalse(tools.checkCronPattern('*/6 a'))
 
-    @unittest.skip('Not yet implemented')
-    def test_checkHomeEncrypt(self):
-        pass
-
     # envLoad and envSave tests are in TestToolsEnviron below
-
-    @unittest.skip('Not yet implemented')
-    def test_keyringSupported(self):
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_password(self):
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_setPassword(self):
-        pass
 
     def test_mountpoint(self):
         self.assertEqual(tools.mountpoint('/nonExistingFolder/foo/bar'), '/')
@@ -488,10 +464,6 @@ class TestTools(generic.TestCase):
         self.assertIn('/', mounts)
         self.assertIn('original_uuid', mounts.get('/'))
 
-    @unittest.skip('Not yet implemented')
-    def test_wrapLine(self):
-        pass
-
     def test_syncfs(self):
         self.assertTrue(tools.syncfs())
 
@@ -545,14 +517,6 @@ class TestTools(generic.TestCase):
             s = f.read().strip('\n')
             self.assertTrue(s.replace(' ', '').isdigit())
             self.assertEqual(len(s), 13)
-
-    @unittest.skip('Not yet implemented')
-    def test_inhibitSuspend(self):
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_unInhibitSuspend(self):
-        pass
 
     @unittest.skipIf(not tools.checkCommand('crontab'),
                      "'crontab' not found.")


### PR DESCRIPTION
This an exotic PR because it doesn't close an Issue but [open it](#1297).

Some unitests where skipped because of constructs like that
```
@unittest.skip('Not yet implemented')
def test_inhibitSuspend(self):
    pass
```

To clean up the test summary I removed them all and collect them in #1297 for further investigation. Only one skipped test is left: #1298 

Everything green except one
![image](https://user-images.githubusercontent.com/11861496/190608123-c3ccb78b-a1bc-499a-a63f-fc1e52ee8c1a.png)
