### PR TITLE
fix: Using correct default number as config version.

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -49,7 +49,9 @@ class Config(configfile.ConfigFileWithProfiles):
     APP_NAME = 'Back In Time'
     VERSION = '1.3.2'
     COPYRIGHT = 'Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze'
+
     CONFIG_VERSION = 6
+    """Latest or highest possible version of Backin Time's config file."""
 
     NONE = 0
     AT_EVERY_BOOT = 1
@@ -195,11 +197,16 @@ class Config(configfile.ConfigFileWithProfiles):
             else:
                 os.rename(old_path, self._LOCAL_CONFIG_PATH)
 
+        # Load global config file
         self.load(self._GLOBAL_CONFIG_PATH)
+
+        # Append local config file
         self.append(self._LOCAL_CONFIG_PATH)
 
-        #?Internal version of current config;;self.CONFIG_VERSION
-        currentConfigVersion = self.intValue('config.version', 5)
+        # Get the version of the config file
+        # or assume the highest config version if it isn't set.
+        currentConfigVersion \
+            = self.intValue('config.version', self.CONFIG_VERSION)
 
         if currentConfigVersion < self.CONFIG_VERSION:
             # config.version value wasn't stored since BiT version 0.9.99.22


### PR DESCRIPTION
Because of the value of `config.Config.CONFIG_VERSION` the current version of the config files used by the latest stable BIT release is `6`.

This fix take care that this number is used by default for (empty) config files that don't specify `config.version` by their own.
This problem was introduced by [a commit in the year 2016](https://github.com/bit-team/backintime/commit/72fc4908f083e57cb059cd9cde2175d61bd9274a).

In the wild with normal users this touch only some edge cases. But it is highly relevant for unittesting where some of tests do use empty config files.

This PR also [solves a problem and the need for an associated workaround](https://github.com/bit-team/backintime/blob/be3c256351145b58e11f9363715a3c904aec1f65/common/test/test_backintime.py#L179-L182) encountered by @aryoda. The problem here was that in some cases (e.g. when running TravisCI) a message appeared on `stdout` that informed about the automatic conversion of the config file from version 5 to 6. That pollutes the json output of `--diagnostics`. I will modify that specific unittest later in the context of my "Config-as-singleton" PR I am preparing.

Just another sitenote: This points to another "problem" when using `--diagnostics`. In that case the log level should be set to "warnings" so that "info" messages can not pollute the json output. But the BIT's own `logger` module doesn't provide that. We could only use some "hacks" via the low-level module `syslog`. The whole `logger` module should be replaced in the feature by Pythons own `logging` module. But I won't touch it yet and it seems not to be so urgent. :)