### PR TITLE
Fix deprecation warnings / Refactoring uuidFromPath incl. unittests improvment

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,7 +12,7 @@ Upcoming Release
 * Translation update: French (#1077)
 * Testing: fix a test fail when dealing with an empty crontab (#1181)
 * Testing: fix a test fail when dealing with an empty config file (#1305)
-* Testing: numerous fixes and extensions to testing (#1115, #1213, #1279, #1280, #1281, #1285, #1288, #1290, #1293)
+* Testing: numerous fixes and extensions to testing (#1115, #1213, #1279, #1280, #1281, #1285, #1288, #1290, #1293, #1309)
 
 Version 1.3.2 (2022-03-12)
 * Fix bug: Tests no longer work with Python 3.10 (https://github.com/bit-team/backintime/issues/1175)

--- a/common/tools.py
+++ b/common/tools.py
@@ -991,7 +991,7 @@ def _uuidFromDev_via_blkid_command(dev):
         # If device does not exist, blkid will exit with a non-zero code
         output = subprocess.check_output(['blkid', dev],
                                         stderr = subprocess.DEVNULL,
-                                        universial_newlines=True)
+                                        universal_newlines=True)
 
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None


### PR DESCRIPTION
I was on the way to investigate and fix our rsync-problem. But on that dirty road I found two tiny warnings about deprecated escape sequences in two regex patterns. Not a big deal. I fixed this. But to write good unittests for that I needed to refactor some code.

The function `tools.uuidFromDev()` was to complex. I split up that code and created three additional and private functions that are used by `uuidFromDev()`. And I add some unittests for it.

Took some time. ;)