### PR TITLE
Integrate extended diagnostics (#1300 with #1295)

### DIFF
--- a/common/backintime.py
+++ b/common/backintime.py
@@ -34,6 +34,7 @@ import mount
 import password
 import encfstools
 import cli
+from diagnostics import collect_diagnostics
 from exceptions import MountException
 from applicationinstance import ApplicationInstance
 
@@ -737,23 +738,8 @@ class printDiagnostics(argparse.Action):
         super(printDiagnostics, self).__init__(*args, **kwargs)
 
     def __call__(self, *args, **kwargs):
-        cfg = config.Config()
 
-        # TODO Refactor into a separate functions in a new diagnostics.py when more info is added
-        ref, hashid = tools.gitRevisionAndHash()
-        git_branch = "Unknown"
-        git_commit = "Unknown"
-        if ref:
-             git_branch = ref
-             git_commit = hashid
-
-        diagnostics = dict(
-            app_name=config.Config.APP_NAME,
-            app_version=config.Config.VERSION,
-            app_git_branch=git_branch,
-            app_git_commit=git_commit,
-            user_callback=cfg.takeSnapshotUserCallback()
-        )
+        diagnostics = collect_diagnostics()
 
         print(json.dumps(diagnostics, indent=4))
 

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -16,16 +16,18 @@ import config  # config.Config.VERSION  Refactor after src-layout migration
 
 
 def collect_diagnostics():
-    """Collect information's about environment and versions of tools and
+    """Collect information about environment and versions of tools and
     packages used by Back In Time.
 
-    The informatinos can be used e.g. for debugging and but reports.
+    The information can be used e.g. for debugging and bug reports.
 
     Returns:
        dict: A nested dictionary.
     """
     result = {}
 
+    # Replace home folder user names with this dummy name
+    # for privacy reasons
     USER_REPLACED = 'UsernameReplaced'
 
     pwd_struct = pwd.getpwuid(os.getuid())
@@ -33,13 +35,18 @@ def collect_diagnostics():
     # === BACK IN TIME ===
     distro_path = _determine_distro_package_folder()
 
+    # work-around: Instantiate to get the user-callback folder
+    # (should be singleton)
+    cfg = config.Config()
+
     result['backintime'] = {
         'name': config.Config.APP_NAME,
         'version': config.Config.VERSION,
         'config-version': config.Config.CONFIG_VERSION,
         'distribution-package': str(distro_path),
         'started-from': str(pathlib.Path(config.__file__).parent),
-        'running_as_root': pwd_struct.pw_name == 'root',
+        'running-as-root': pwd_struct.pw_name == 'root',
+        'user-callback': cfg.takeSnapshotUserCallback()
     }
 
     # Git repo

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -42,7 +42,11 @@ def collect_diagnostics():
     result['backintime'] = {
         'name': config.Config.APP_NAME,
         'version': config.Config.VERSION,
-        'config-version': config.Config.CONFIG_VERSION,
+        'latest-config-version': config.Config.CONFIG_VERSION,
+        'local-config-file': cfg._LOCAL_CONFIG_PATH,
+        'local-config-file-found': os.path.exists(cfg._LOCAL_CONFIG_PATH),
+        'global-config-file': cfg._GLOBAL_CONFIG_PATH,
+        'global-config-file-found': os.path.exists(cfg._GLOBAL_CONFIG_PATH),
         'distribution-package': str(distro_path),
         'started-from': str(pathlib.Path(config.__file__).parent),
         'running-as-root': pwd_struct.pw_name == 'root',

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -176,11 +176,8 @@ INFO: Restore: /tmp/test/testfile to: /tmp/restored.*''', re.MULTILINE))
 
     def test_diagnostics_arg(self):
 
-        # Workaround: Without this line the next "subprocess.getoutput()" call fails on TravisCI for unknown reasons!
-        subprocess.check_output(["./backintime", "--diagnostics"])
-
         output = subprocess.getoutput("./backintime --diagnostics")
 
         diagnostics = json.loads(output)
-        self.assertEqual(diagnostics["app_name"], config.Config.APP_NAME)
-        self.assertEqual(diagnostics["app_version"], config.Config.VERSION)
+        self.assertEqual(diagnostics["backintime"]["name"],    config.Config.APP_NAME)
+        self.assertEqual(diagnostics["backintime"]["version"], config.Config.VERSION)

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -24,7 +24,7 @@ class Diagnostics(unittest.TestCase):
         )
 
         # 2nd level "backintime"
-        minimal_keys = ['name', 'version', 'config-version',
+        minimal_keys = ['name', 'version', 'latest-config-version',
                         'started-from', 'running-as-root']
         for key in minimal_keys:
             self.assertIn(key, result['backintime'], key)

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -25,7 +25,7 @@ class Diagnostics(unittest.TestCase):
 
         # 2nd level "backintime"
         minimal_keys = ['name', 'version', 'config-version',
-                        'started-from', 'running_as_root']
+                        'started-from', 'running-as-root']
         for key in minimal_keys:
             self.assertIn(key, result['backintime'], key)
 


### PR DESCRIPTION
Integrates:
* #1295
* #1300

Changes:
* Add user-callback path to collect_diagnostics() to avoid regression
* Remove TravisCI test failure workaround (was fixed with #1305)
* Correct some typos in comments.

