### PR TITLE
Remove TODO file now present in #1311

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,4 +1,0 @@
-TODO:
-* use rsync return code to check that the snapshot was really taken (no out of space, copy error ...)
-* uid/gid translate table with 'Full rsync mode'
-* grep DBUS_SESSION_BUS_ADDRESS from session-managers environ (https://github.com/bit-team/backintime/issues/723)


### PR DESCRIPTION
Clean up the repo from a 6 years old TODO file.

The content of the file moved into #1311 and need be checked if it is still relevant.