### PR TITLE
feat: Extend diagnostic information's

### DIFF
--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -30,8 +30,8 @@ class Diagnostics(unittest.TestCase):
             self.assertIn(key, result['backintime'], key)
 
         # 2nd level "host-setup"
-        minimal_keys = ['platform', 'system', 'display-system',
-                        'locale', 'PATH']
+        minimal_keys = ['platform', 'system', 'display-system', 'locale',
+                        'PATH', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS']
         for key in minimal_keys:
             self.assertIn(key, result['host-setup'], key)
 
@@ -42,7 +42,6 @@ class Diagnostics(unittest.TestCase):
         minimal_keys = ['rsync', 'shell']
         for key in minimal_keys:
             self.assertIn(key, result['external-programs'], key)
-
 
     def test_no_ressource_warning(self):
         """No ResourceWarning's.
@@ -68,6 +67,27 @@ class Diagnostics(unittest.TestCase):
         self.assertEqual(
             diagnostics._get_extern_versions(['fooXbar']),
             '(no fooXbar)'
+        )
+
+    def test_replace_user_path(self):
+        """Replace users path."""
+
+        d = {
+            'foo': '/home/rsync',
+            'bar': '~/rsync'
+        }
+
+        self.assertEqual(
+            diagnostics._replace_username_paths(d, 'rsync'),
+            {
+                'foo': '/home/UsernameReplaced',
+                'bar': '~/UsernameReplaced'
+            }
+        )
+
+        self.assertEqual(
+            diagnostics._replace_username_paths(d, 'user'),
+            d
         )
 
 


### PR DESCRIPTION
Extend diagnostic information's

1. Python executable path.
2. Rsync environment variables.
3. Modified username replacement to replace users homepath and not only its username.
4. PEP8 etc

About 1: Related to #1316 where the path to systems python interpreter was "hacked" via "pyenv". This info will catch situations like that.

About 2: Related to #1247. Rsync 3.2.4 do use a different way of argument protection. The situation is complex and the environment variables RSYNC_OLD_ARGS and RSYNC_PROTECT_ARGS to influence that.

About 3: The replacement is done on the whole JSON-like string and not on specific elements. To prevent replacement of technical informations (e.g. about "rsync") when a user do use a technical login name (e.g. "rsync") now we search for the users homepath and not only is username.

About 4: Replaced use of `os.path` with high-level API `pathlib.Path`. Also reduced "cyclomatic complexity" (was 15) of `get_diagnostics()` with moving one code part into its own private method.

The output no looks like this
```{
    "backintime": {
        "name": "Back In Time",
        "version": "1.3.2",
        "latest-config-version": 6,
        "local-config-file": "/home/UsernameReplaced/.config/backintime/config",
        "local-config-file-found": true,
        "global-config-file": "/etc/backintime/config",
        "global-config-file-found": false,
        "distribution-package": "/home/UsernameReplaced/ownCloud/my.work/bit/backintime",
        "started-from": "/home/UsernameReplaced/ownCloud/my.work/bit/backintime/common",
        "running-as-root": false,
        "user-callback": "/home/UsernameReplaced/.config/backintime/user-callback",
        "git-branch": "improve_diagnostics",
        "git-hash": "eb59d0aedf9b383a0fef646928490701641aeaa8"
    },
    "host-setup": {
        "platform": "Linux-5.10.0-18-amd64-x86_64-with-glibc2.31",
        "system": "Linux #1 SMP Debian 5.10.140-1 (2022-09-02)",
        "os-release": "Debian GNU/Linux 11 (bullseye)",
        "display-system": "tty",
        "locale": "de_DE, UTF-8",
        "PATH": "/home/UsernameReplaced/.local/bin:/home/UsernameReplaced/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games",
        "RSYNC_OLD_ARGS": "(not set)",
        "RSYNC_PROTECT_ARGS": "(not set)"
    },
    "python-setup": {
        "python": "3.9.2 default Feb 28 2021 17:03:44 CPython GCC 10.2.1 20210110",
        "python-executable": "/usr/bin/python3",
        "python-executable-symlink": true,
        "python-executable-resolved": "/usr/bin/python3.9",
        "sys.path": [
            "/home/UsernameReplaced/ownCloud/my.work/bit/backintime/qt/plugins",
            "/home/UsernameReplaced/ownCloud/my.work/bit/backintime/common/plugins",
            "/home/UsernameReplaced/ownCloud/my.work/bit/backintime/plugins",
            "/home/UsernameReplaced/ownCloud/my.work/bit/backintime/common",
            "/usr/lib/python39.zip",
            "/usr/lib/python3.9",
            "/usr/lib/python3.9/lib-dynload",
            "/usr/local/lib/python3.9/dist-packages",
            "/usr/lib/python3/dist-packages",
            "/usr/lib/python3.9/dist-packages"
        ],
        "qt": "PyQt 5.15.2 / Qt 5.15.2"
    },
    "external-programs": {
        "rsync": "3.2.3",
        "ssh": "OpenSSH_8.4p1 Debian-5+deb11u1, OpenSSL 1.1.1n  15 Mar 2022",
        "sshfs": "3.7.1",
        "encfs": "1.9.5",
        "shell": "/bin/bash",
        "shell-version": "GNU bash, Version 5.1.4(1)-release (x86_64-pc-linux-gnu)"
    }
}
```