### PR TITLE
Fix DeprecationWarning about StrictVersion

### DIFF
--- a/common/encfstools.py
+++ b/common/encfstools.py
@@ -22,7 +22,7 @@ import re
 import shutil
 import tempfile
 from datetime import datetime
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 import config
 import password
@@ -32,7 +32,8 @@ import sshtools
 import logger
 from mount import MountControl
 from exceptions import MountException, EncodeValueError
-_=gettext.gettext
+
+_ = gettext.gettext
 
 class EncFS_mount(MountControl):
     """
@@ -156,7 +157,7 @@ class EncFS_mount(MountControl):
                                     universal_newlines = True)
             output = proc.communicate()[0]
             m = re.search(r'(\d\.\d\.\d)', output)
-            if m and StrictVersion(m.group(1)) <= StrictVersion('1.7.2'):
+            if m and Version(m.group(1)) <= Version('1.7.2'):
                 logger.debug('Wrong encfs version %s' %m.group(1), self)
                 raise MountException(_('encfs version 1.7.2 and before has a bug with option --reverse. Please update encfs'))
 

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -28,7 +28,7 @@ from PyQt5.QtWidgets import (QFileDialog, QAbstractItemView, QListView,
                              QToolTip, QAction)
 from datetime import (datetime, date, timedelta)
 from calendar import monthrange
-from distutils.version import StrictVersion
+from packaging.version import Version
 
 _ = gettext.gettext
 
@@ -156,7 +156,7 @@ def createQApplication(app_name = 'Back In Time'):
         return qapp
     except NameError:
         pass
-    if StrictVersion(QT_VERSION_STR) >= StrictVersion('5.6') and \
+    if Version(QT_VERSION_STR) >= Version('5.6') and \
         hasattr(Qt, 'AA_EnableHighDpiScaling'):
         QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     qapp = QApplication(sys.argv)


### PR DESCRIPTION
The class `distutils.version.StrictVersion` doing version comparison and its package `distutils` is deprecated. They are replaced by `packaging.Version` (see [PEP440](https://peps.python.org/pep-0440/)).

This is related to #1288 where I did the same but obviously missed some parts of the code. Not sure why I missed them. It seems to me that this DeprecationWarning doesn't occur with Python 3.9 but 3.10. Now I search via `grep` for the use of `distutils` package. I suspect that the deprecated `distutils` package isn't used anymore.