### PR TITLE
Exclude vim temporary files via gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # editor backup
 *~
 *.sic
+*.swp
 
 # packaging
 *.deb
@@ -31,10 +32,10 @@ debian/backintime-qt
 common/Makefile
 qt/Makefile
 
-#coveralls.io status
+# coveralls.io status
 .coverage
 
-#sphinx doc build
+# sphinx doc build
 common/doc-dev/_build/doctrees
 common/doc-dev/_build/html
 


### PR DESCRIPTION
Exclude files like that from git

`common/.myrsync.sh.swp`

This is a temporary file created by `vim`.