### PR TITLE
Enh/test remove ssh

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,7 +14,7 @@ Upcoming Release
 * Translation update: French (#1077)
 * Testing: fix a test fail when dealing with an empty crontab (#1181)
 * Testing: fix a test fail when dealing with an empty config file (#1305)
-* Testing: numerous fixes and extensions to testing (#1115, #1213, #1279, #1280, #1281, #1285, #1288, #1290, #1293, #1309)
+* Testing: numerous fixes and extensions to testing (#1115, #1213, #1279, #1280, #1281, #1285, #1288, #1290, #1293, #1309, #1334)
 
 Version 1.3.2 (2022-03-12)
 * Fix bug: Tests no longer work with Python 3.10 (https://github.com/bit-team/backintime/issues/1175)

--- a/common/mount.py
+++ b/common/mount.py
@@ -115,14 +115,18 @@ class Mount(object):
         """
         self.config.PLUGIN_MANAGER.load(cfg = self.config)
         self.config.PLUGIN_MANAGER.mount(self.profile_id)
+
         if mode is None:
             mode = self.config.snapshotsMode(self.profile_id)
 
         if self.config.SNAPSHOT_MODES[mode][0] is None:
-            #mode doesn't need to mount
+            # mode doesn't need to mount
             return 'local'
+
         else:
-            while True:
+
+            while True:  # ???
+
                 try:
                     mounttools = self.config.SNAPSHOT_MODES[mode][0]
                     backend = mounttools(cfg = self.config,
@@ -131,12 +135,16 @@ class Mount(object):
                                          mode = mode,
                                          parent = self.parent,
                                          **kwargs)
+
                     return backend.mount(check = check)
+
                 except HashCollision as ex:
                     logger.warning(str(ex), self)
                     del backend
                     check = False
+
                     continue
+
                 break
 
     def umount(self, hash_id = None):

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -592,6 +592,9 @@ class Snapshots:
 
         Args:
             sid (SID):              snapshot to remove
+
+        Returns:
+            (bool): ``True`` if succedeed otherwise ``False``.
         """
 
         if isinstance(sid, RootSnapshot):
@@ -618,14 +621,18 @@ class Snapshots:
 
             #
             if rc != 0:
-                raise RuntimeError('Last rsync command failed. See previous '
-                                   'WARNING message.')
+                logger.error(
+                    f'Last rsync command failed with return code "{rc}". '
+                    'See previous WARNING message in the logs for details.')
+                return False
 
             # Delete the sid dir. BUT here isn't the remote path used but the
             # temporary mounted variant of it.
             # e.g. /home/user/.local/share/backintime/mnt/4_8030/backintime/ \
             # HOST/user/MyProfile/20221005-000003-880
             shutil.rmtree(sid.path())
+
+            return True
 
     def backup(self, force = False):
         """

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1619,7 +1619,6 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
         # /tmp           127266564 115596412   5182296  96% /
         #                                      ^^^^^^^
         for line in output.split(b'\n'):
-            print(line)
             m = re.match(b'^.*?\s+\d+\s+\d+\s+(\d+)\s+\d+%', line, re.M)
 
             if m:

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -18,6 +18,7 @@
 
 import json
 import os
+import pathlib
 import stat
 import datetime
 import gettext
@@ -38,17 +39,20 @@ import tools
 import encfstools
 import mount
 import progress
-import bcolors
 import snapshotlog
 from applicationinstance import ApplicationInstance
 from exceptions import MountException, LastSnapshotSymlink
 
-_=gettext.gettext
+_ = gettext.gettext
 
 
 class Snapshots:
     """
     Collection of take-snapshot and restore commands.
+
+    BUHTZ 2022-10-09: In my understanding this the representation of a
+    snapshot in the "application layer". This seems to be the difference to
+    the class `SID` which represents a snapshot in the "data layer".
 
     Args:
         cfg (config.Config): current config
@@ -574,16 +578,53 @@ class Snapshots:
         """
         Remove snapshot ``sid``.
 
+        BUHTZ 2022-10-11: From my understanding rsync is used here to sync the
+        directory of a concret snapshot (``sid```) against an empty temporary
+        directory. In the consequence the sid directory is empty but not
+        deleted.
+        To delete that directory simple `rm` call (via `shutil` package) is
+        used to delete the directory. No need to do this via SSH because the
+        directory is temporary mounted.
+
+        It is not clear for me why it is done that way. Why not simply "rm"
+        the directory when it is mounted instead of using rsync in a previous
+        step?! But I won't change it yet.
+
         Args:
             sid (SID):              snapshot to remove
         """
+
         if isinstance(sid, RootSnapshot):
             return
+
+        # build the rsync command and it's arguments
         rsync = tools.rsyncRemove(self.config)
+
+        # an empty temporary directory
+        # e.g. /tmp/tmp8g59onuz
         with TemporaryDirectory() as d:
+            # the temp dir
             rsync.append(d + os.sep)
-            rsync.append(self.rsyncRemotePath(sid.path(use_mode = ['ssh', 'ssh_encfs'])))
-            tools.Execute(rsync).run()
+
+            # the real remote path of a concrete snapshot (a "sid")
+            # e.g. user@myserver:"/MyBackup/.backintime/backintime/HOST/user/ \
+            # MyProfile/20221005-000003-880"
+            rsync.append(
+                self.rsyncRemotePath(sid.path(use_mode=['ssh', 'ssh_encfs'])))
+
+            # Syncing the empty tmp directory against the sid directory
+            # will clear the sid directory.
+            rc = tools.Execute(rsync).run()
+
+            #
+            if rc != 0:
+                raise RuntimeError('Last rsync command failed. See previous '
+                                   'WARNING message.')
+
+            # Delete the sid dir. BUT here isn't the remote path used but the
+            # temporary mounted variant of it.
+            # e.g. /home/user/.local/share/backintime/mnt/4_8030/backintime/ \
+            # HOST/user/MyProfile/20221005-000003-880
             shutil.rmtree(sid.path())
 
     def backup(self, force = False):
@@ -1553,21 +1594,30 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             return None
 
         snapshots_path_ssh = self.config.sshSnapshotsFullPath()
+
         if not len(snapshots_path_ssh):
             snapshots_path_ssh = './'
-        cmd = self.config.sshCommand(['df', snapshots_path_ssh],
-                                     nice = False,
-                                     ionice = False)
 
-        df = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+        cmd = self.config.sshCommand(['df', snapshots_path_ssh],
+                                     nice=False,
+                                     ionice=False)
+
+        df = subprocess.Popen(cmd,
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE)
+
         output = df.communicate()[0]
-        #Filesystem     1K-blocks      Used Available Use% Mounted on
-        #/tmp           127266564 115596412   5182296  96% /
-        #                                     ^^^^^^^
+
+        # Filesystem     1K-blocks      Used Available Use% Mounted on
+        # /tmp           127266564 115596412   5182296  96% /
+        #                                      ^^^^^^^
         for line in output.split(b'\n'):
+            print(line)
             m = re.match(b'^.*?\s+\d+\s+\d+\s+(\d+)\s+\d+%', line, re.M)
+
             if m:
                 return int(int(m.group(1)) / 1024)
+
         logger.warning('Failed to get free space on remote', self)
 
     def filter(self,
@@ -1882,6 +1932,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
 
         return (items1, items2)
 
+
 class FileInfoDict(dict):
     """
     A :py:class:`dict` that maps a path (as :py:class:`bytes`) to a
@@ -1903,9 +1954,12 @@ class FileInfoDict(dict):
         assert isinstance(value[2], bytes), "third value '{}' is not bytes instance".format(value[2])
         super(FileInfoDict, self).__setitem__(key, value)
 
+
 class SID(object):
     """
     Snapshot ID object used to gather all information for a snapshot
+
+    See :py:class:`Snapshots` to understand the difference.
 
     Args:
         date (:py:class:`str`, :py:class:`datetime.date` or :py:class:`datetime.datetime`):
@@ -2393,6 +2447,7 @@ class SID(object):
         rw = os.stat(path).st_mode | stat.S_IWUSR
         return os.chmod(path, rw)
 
+
 class GenericNonSnapshot(SID):
     @property
     def displayID(self):
@@ -2409,6 +2464,7 @@ class GenericNonSnapshot(SID):
     @property
     def withoutTag(self):
         return self.name
+
 
 class NewSnapshot(GenericNonSnapshot):
     """
@@ -2491,6 +2547,7 @@ class NewSnapshot(GenericNonSnapshot):
                 return True
         return False
 
+
 class RootSnapshot(GenericNonSnapshot):
     """
     Snapshot ID for the filesystem root folder ('/')
@@ -2549,6 +2606,7 @@ class RootSnapshot(GenericNonSnapshot):
         else:
             return os.path.join(os.sep, *path)
 
+
 def iterSnapshots(cfg, includeNewSnapshot = False):
     """
     Iterate over snapshots in current snapshot path. Use this in a 'for' loop
@@ -2579,6 +2637,7 @@ def iterSnapshots(cfg, includeNewSnapshot = False):
             if not isinstance(e, LastSnapshotSymlink):
                 logger.debug("'{}' is no snapshot ID: {}".format(item, str(e)))
 
+
 def listSnapshots(cfg, includeNewSnapshot = False, reverse = True):
     """
     List of snapshots in current snapshot path.
@@ -2596,6 +2655,7 @@ def listSnapshots(cfg, includeNewSnapshot = False, reverse = True):
     ret.sort(reverse = reverse)
     return ret
 
+
 def lastSnapshot(cfg):
     """
     Most recent snapshot.
@@ -2609,6 +2669,7 @@ def lastSnapshot(cfg):
     sids = listSnapshots(cfg)
     if sids:
         return sids[0]
+
 
 if __name__ == '__main__':
     config = config.Config()

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -371,7 +371,6 @@ def create_test_files(path):
             └── test
 
     """
-    # DEBUG print(f'create test files: {path}')
     os.makedirs(os.path.join(path, 'foo', 'bar'))
 
     with open(os.path.join(path, 'foo', 'bar', 'baz'), 'wt') as f:

--- a/common/test/test_restore.py
+++ b/common/test/test_restore.py
@@ -178,6 +178,10 @@ class TestRestoreLocal(RestoreTestCase):
 
 @unittest.skipIf(not generic.LOCAL_SSH, 'Skip as this test requires a local ssh server, public and private keys installed')
 class TestRestoreSSH(generic.SSHSnapshotsWithSidTestCase, TestRestoreLocal):
+    """BUHTZ 2022-10-09: Seems to me that testing restore via SSH isn't
+    implemented yet.
+    """
+
     def setUp(self):
         super(TestRestoreSSH, self).setUp()
         self.include = TemporaryDirectory()

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -897,7 +897,7 @@ class TestSshRemoveSnapshots(unittest.TestCase):
         self.assertTrue(self.sid.exists())
 
         # Remove it
-        self.sn.remove(self.sid)
+        self.assertTrue(self.sn.remove(self.sid))
 
         # Shouldn't exist anymore.
         self.assertFalse(self.sid.exists())

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -746,11 +746,6 @@ class TestRemoveSnapshot(generic.SnapshotsWithSidTestCase):
     # TODO: add test with SSH
 
     def test_remove(self):
-
-        print('\n' + 'T'*70)
-        print(self.sid)
-        print(self.__dict__)
-
         self.assertTrue(self.sid.exists())
         self.sn.remove(self.sid)
         self.assertFalse(self.sid.exists())


### PR DESCRIPTION
# Abstract
Introducing a new unit (or better integration) test about removing a snapshot via SSH because there wasn't something like this before. I need this test because of the _rsync incompatibility problem_ (#1247). It is intended to fail with a newer rsync version and to pass with an old one. I checked it with _Debian testing_ (_rsync 3.2.6_) and _Debian 11 stable "bullseye"_ (_rsync 3.2.3_).
# Details
## Target
The target of the test is the method `snapshots.Snapsthots.remove()`. As I explain there in the doc string the removing method seems a bit wired to me. But maybe there are good reasons for this so I didn't modified that behaviour.

But I added a check for the rsync return code. Before my PR it was ignored and had no effect when rsync failed.
## Unittest
My testing class directly derive from `unittest.TestCase` and do not use one of the classes in `generic.py`. The latter isn't an elegant solution but this wasn't the reason why I avoided there use. I needed to introduce blanks in the path names to trigger the "rsync problem I need".

I collected all the code fragments from the `setUp()` etc methods in `generic.py` and build my own _helper_ methods. I copied and refactored that code into private methods of my testing class. I'm sure we can improve that in the future and find a more _generic_ solution to reuse that fragments for other unittests also. But it is IMHO a good start and also helped me to improve my understanding of BIT internals.
## PEP8 and docstrings
Sorry I tried to resist but I did some code formating. I also added some docstrings while trying to understand some details.