### PR TITLE
Write all log output to stderr (do not pollute stdout)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Upcoming Release
 * GUI change: remove Exit button from the toolbar (#172)
 * GUI change: define accelerator keys for menu bar and tabs, as well as toolbar shortcuts (#1104)
 * Desktop integration: update .desktop file to mark Back In Time as a single main window program (#1258)
+* Improvement: Write all log output to stderr; do not pollute stdout with INFO and WARNING messages anymore (#1337)
 * Bugfix: AttributeError in "Diff Options" dialog (#898)
 * Bugfix: Settings GUI: "Save password to Keyring" was disabled due to "no appropriate keyring found" (#1321)
 * Bugfix: Avoid logging errors while waiting for a target drive to be mounted (#1142, #1143, #1328)

--- a/common/logger.py
+++ b/common/logger.py
@@ -23,8 +23,8 @@ import atexit
 import tools
 import bcolors
 
-DEBUG = False
-APP_NAME = 'backintime'
+DEBUG = False            # Set to "True" when passing "--debug" as cmd arg
+APP_NAME = 'backintime'  # TODO Duplicated code (see Config.APP_NAME)
 
 def openlog():
     name = os.getenv('LOGNAME', 'unknown')
@@ -55,14 +55,16 @@ def warning(msg , parent = None, traceDepth = 0):
 def info(msg , parent = None, traceDepth = 0):
     if DEBUG:
         msg = '%s %s' %(_debugHeader(parent, traceDepth), msg)
-    print('%sINFO%s: %s' %(bcolors.OKGREEN, bcolors.ENDC, msg), file=sys.stdout)
+    print('%sINFO%s: %s' %(bcolors.OKGREEN, bcolors.ENDC, msg), file=sys.stderr)
     for line in tools.wrapLine(msg):
         syslog.syslog(syslog.LOG_INFO, 'INFO: ' + line)
 
 def debug(msg, parent = None, traceDepth = 0):
     if DEBUG:
         msg = '%s %s' %(_debugHeader(parent, traceDepth), msg)
-        print('%sDEBUG%s: %s' %(bcolors.OKBLUE, bcolors.ENDC, msg), file = sys.stdout)
+        # Why does this code differ from eg. "error()"
+        # (where the following lines are NOT part of the "if")?
+        print('%sDEBUG%s: %s' %(bcolors.OKBLUE, bcolors.ENDC, msg), file=sys.stderr)
         for line in tools.wrapLine(msg):
             syslog.syslog(syslog.LOG_DEBUG, 'DEBUG: %s' %line)
 

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -125,14 +125,17 @@ Version: \d+.\d+.\d+.*
 Back In Time comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions; type `backintime --license' for details.
+''', re.MULTILINE))
 
-INFO: Lock
+        # The log output completely goes to stderr
+        self.assertRegex(error.decode(), re.compile(r'''INFO: Lock
 INFO: Take a new snapshot. Profile: 1 Main profile
 INFO: Call rsync to take the snapshot
 INFO: Save config file
 INFO: Save permissions
 INFO: Create info file
-INFO: Unlock''', re.MULTILINE))
+INFO: Unlock
+''', re.MULTILINE))
 
         # get snapshot id
         subprocess.check_output(["./backintime",
@@ -165,8 +168,11 @@ Back In Time comes with ABSOLUTELY NO WARRANTY.
 This is free software, and you are welcome to redistribute it
 under certain conditions; type `backintime --license' for details.
 
+''', re.MULTILINE))
 
-INFO: Restore: /tmp/test/testfile to: /tmp/restored.*''', re.MULTILINE))
+        # The log output completely goes to stderr
+        self.assertRegex(error.decode(), re.compile(r'''INFO: Restore: /tmp/test/testfile to: /tmp/restored.*''',
+                                                     re.MULTILINE))
 
         # verify that files restored are the same as those backed up
         subprocess.check_output(["diff",


### PR DESCRIPTION
* Affects logger.info and logger.debug
* complies now to the behavior of pythons's standard logging package

### Background

Our logging system pollutes the normal (non-logging) stdout output with logging output, we need a clear separation here
(eg. logging to stderr instead of stdout) otherwise we can never separate normal from (partially random) logging output in unit tests.

Standard python's logger package says:

> If you call the functions [debug()](https://docs.python.org/3/library/logging.html#logging.debug), [info()](https://docs.python.org/3/library/logging.html#logging.info), [warning()](https://docs.python.org/3/library/logging.html#logging.warning), [error()](https://docs.python.org/3/library/logging.html#logging.error) and [critical()](https://docs.python.org/3/library/logging.html#logging.critical), they will check to see if no destination is set; and if one is not set, they will set a destination of the console (sys.stderr)

https://docs.python.org/3/howto/logging.html
