### PR TITLE
Test backing up permissions in a "SSH local" profile.

### DIFF
--- a/common/mount.py
+++ b/common/mount.py
@@ -883,22 +883,29 @@ class MountControl(object):
         """
         if not self.symlink:
             return
+
         if profile_id is None:
             profile_id = self.profile_id
+
         if hash_id is None:
             hash_id = self.hash_id
+
         if tmp_mount is None:
             tmp_mount = self.tmp_mount
-        dst = self.config.snapshotsPath(profile_id = profile_id,
-                                             mode = self.mode,
-                                             tmp_mount = tmp_mount)
+
+        dst = self.config.snapshotsPath(profile_id=profile_id,
+                                        mode=self.mode,
+                                        tmp_mount=tmp_mount)
         mountpoint = self.mountpoint(hash_id)
+
         if self.symlink_subfolder is None:
             src = mountpoint
         else:
             src = os.path.join(mountpoint, self.symlink_subfolder)
+
         if os.path.exists(dst):
             os.remove(dst)
+
         os.symlink(src, dst)
 
     def removeSymlink(self, profile_id = None, tmp_mount = None):

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -64,6 +64,8 @@ try:
 except ConnectionRefusedError:
     sshdPortAvailable = False
 
+SKIP_SSH_TEST_MESSAGE = 'Skip as this test requires a local ssh server, ' \
+                        'public and private keys installed'
 LOCAL_SSH = all((tools.processExists('sshd'),
                  os.path.isfile(PRIV_KEY_FILE),
                  KEY_IN_AUTH,
@@ -71,6 +73,7 @@ LOCAL_SSH = all((tools.processExists('sshd'),
 
 ON_TRAVIS = os.environ.get('TRAVIS', 'None').lower() == 'true'
 ON_RTD = os.environ.get('READTHEDOCS', 'None').lower() == 'true'
+
 
 
 class TestCase(unittest.TestCase):


### PR DESCRIPTION
Introducing class `test_snapshots.py::TestSshPermissions` testing `snapshots.py::Snapshot.backupPermissions()` in a "SSH local" environment.

The case was untested before. Especially it is needed to support the fix of #1247 (rsync incompatibility).

I slightly improved the method `Snapshots.backupPermissions()` because before it was silent and didn't care about if the used `rsync` call succeeded or not. No the return code of `rsync` is returned and can be used in a unittest.

The "helper" functions in `test_snapshots.py` are refactored and improved a bit. Now they are used by this new `TestSshPermissions` and the before introduced `TestSshRemoveSnapshot` tests.