### PR TITLE
Fix root launcher

### DIFF
--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -1,9 +1,30 @@
-#!/bin/sh
+#!/bin/bash
 
-if [ "x$XDG_SESSION_TYPE" = "xwayland" ]; then
-    PREFIX="env QT_QPA_PLATFORM=wayland-egl XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+app_command="backintime-qt"
+
+if [ "$(id -u)" -eq 0 ]; then
+	# user is admin
+	${app_command}
 else
-    PREFIX=""
+	# user is not admin
+	if echo $- | grep "i" >/dev/null 2>&1; then
+		# script is running in interactive mode
+		su - -c "${app_command}"
+	else
+		# script is running in non-interactive mode
+		if [ "$XDG_SESSION_TYPE" = "wayland" ] ; then
+			xhost +SI:localuser:root
+			pkexec ${app_command}
+			xhost -SI:localuser:root
+			xhost
+		elif command -v pkexec >/dev/null 2>&1; then
+			pkexec ${app_command}
+		elif command -v sudo >/dev/null 2>&1; then
+			x-terminal-emulator -e "sudo ${app_command}"
+		elif command -v su >/dev/null 2>&1; then
+			x-terminal-emulator -e "su - -c '${app_command}'"
+		else
+			x-terminal-emulator -e "echo 'Command must be run as root user: ${app_command}'"
+		fi
+	fi
 fi
-
-pkexec --disable-internal-agent $PREFIX "/usr/bin/backintime-qt" "$@"


### PR DESCRIPTION
Back In Time (root) fails to launch on Ubuntu Desktop 22.04.

Fix is borrowed from https://github.com/linuxmint/timeshift/blob/master/src/timeshift-launcher