### PR TITLE
Fix: Invalid escape sequences

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Version 1.3.3-dev (development of upcoming release)
 * GUI change: Define accelerator keys for menu bar and tabs, as well as toolbar shortcuts (#1104)
 * Desktop integration: Update .desktop file to mark Back In Time as a single main window program (#1258)
 * Improvement: Write all log output to stderr; do not pollute stdout with INFO and WARNING messages anymore (#1337)
+* Bugfix: DeprecationWarnings about invalid escape sequences.
 * Bugfix: AttributeError in "Diff Options" dialog (#898)
 * Bugfix: Settings GUI: "Save password to Keyring" was disabled due to "no appropriate keyring found" (#1321)
 * Bugfix: Back in Time did not start with D-Bus error

--- a/common/config.py
+++ b/common/config.py
@@ -128,7 +128,7 @@ class Config(configfile.ConfigFileWithProfiles):
     DEFAULT_RUN_IONICE_ON_REMOTE = False
     DEFAULT_RUN_NOCACHE_ON_LOCAL = False
     DEFAULT_RUN_NOCACHE_ON_REMOTE = False
-    DEFAULT_SSH_PREFIX = 'PATH=/opt/bin:/opt/sbin:\$PATH'
+    DEFAULT_SSH_PREFIX = 'PATH=/opt/bin:/opt/sbin:\\$PATH'
     DEFAULT_REDIRECT_STDOUT_IN_CRON = True
     DEFAULT_REDIRECT_STDERR_IN_CRON = False
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -423,7 +423,7 @@ class Snapshots:
                                         restore to original destiantion
             delete (bool):              delete newer files which are not in the
                                         snapshot
-            backup (bool):              create backup files (\*.backup.YYYYMMDD)
+            backup (bool):              create backup files (*.backup.YYYYMMDD)
                                         before changing or deleting local files.
             only_new (bool):            Only restore files which does not exist
                                         or are newer than those in destination.
@@ -1405,22 +1405,25 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             additionalChars = len(self.config.sshPrefixCmd(cmd_type = str))
 
             head = 'screen -d -m bash -c "('
-            head += 'TMP=\$(mktemp -d); '                      #create temp dir used for delete files with rsync
-            head += 'test -z \\\"\$TMP\\\" && exit 1; '        #make sure $TMP dir was created
-            head += 'test -n \\\"\$(ls \$TMP)\\\" && exit 1; ' #make sure $TMP is empty
+            # create temp dir used for delete files with rsync
+            head += 'TMP=\\$(mktemp -d); '
+            # make sure $TMP dir was created
+            head += 'test -z \\\"\\$TMP\\\" && exit 1; '
+            # make sure $TMP is empty
+            head += 'test -n \\\"\\$(ls \\$TMP)\\\" && exit 1; '
             if logger.DEBUG:
                 head += 'logger -t \\\"backintime smart-remove [$BASHPID]\\\" \\\"start\\\"; '
             head += 'flock -x 9; '
             if logger.DEBUG:
                 head += 'logger -t \\\"backintime smart-remove [$BASHPID]\\\" \\\"got exclusive flock\\\"; '
 
-            tail = 'rmdir \$TMP) 9>\\\"%s\\\""' %lckFile
+            tail = 'rmdir \\$TMP) 9>\\\"%s\\\""' %lckFile
 
             cmds = []
             for sid in del_snapshots:
                 remote = self.rsyncRemotePath(sid.path(use_mode = ['ssh', 'ssh_encfs']), use_mode = [], quote = '\\\"')
                 rsync = ' '.join(tools.rsyncRemove(self.config, run_local = False))
-                rsync += ' \\\"\$TMP/\\\" {}; '.format(remote)
+                rsync += ' \\\"\\$TMP/\\\" {}; '.format(remote)
 
                 s = 'test -e \\\"%s\\\" && (' %sid.path(use_mode = ['ssh', 'ssh_encfs'])
                 if logger.DEBUG:
@@ -1634,7 +1637,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
         # /tmp           127266564 115596412   5182296  96% /
         #                                      ^^^^^^^
         for line in output.split(b'\n'):
-            m = re.match(b'^.*?\s+\d+\s+\d+\s+(\d+)\s+\d+%', line, re.M)
+            m = re.match(r'^.*?\s+\d+\s+\d+\s+(\d+)\s+\d+%', line.decode(), re.M)
 
             if m:
                 return int(int(m.group(1)) / 1024)

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -846,7 +846,7 @@ class SSH(MountControl):
             cmd += 'test $err_flock -ne 0 && cleanup $err_flock; '
             tail.append(cmd)
 
-            cmd  = 'echo \"rmdir \$(mktemp -d)\"; tmp3=$(mktemp -d); test -z "$tmp3" && cleanup 1; rmdir $tmp3 >/dev/null; err_rmdir=$?; '
+            cmd  = 'echo \"rmdir \\$(mktemp -d)\"; tmp3=$(mktemp -d); test -z "$tmp3" && cleanup 1; rmdir $tmp3 >/dev/null; err_rmdir=$?; '
             cmd += 'test $err_rmdir -ne 0 && cleanup $err_rmdir; '
             tail.append(cmd)
 


### PR DESCRIPTION
This fix `DeprecationWarnings` about _invalid escape sequences_. Most of that warnings are caught when running `pytest`. That warnings will become serious errors in future Python versions.

This where the warnings. Sorry for providing a screenshot instead of plain text but I still have problems copy & past from a Windows terminal window running ssh client and tmux.
![image](https://user-images.githubusercontent.com/11861496/199974715-74e99261-298a-4271-9f2c-96e99ee7abf1.png)

Of course, I checked all problems and what that strings really need to do.
Most of the warnings are about `\$` which I modified to `\\$`. It is like escaping and escape. Sounds wired but it is intended to be that way. Because that string is handed over (via `subprocess.Popen()`) to a shell command (ssh) which need to receive a string containing an escape.