### PR TITLE
Fix: Invalid escape sequence warnings and some PEP8

### DIFF
--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -765,7 +765,7 @@ class SSH(MountControl):
                 f.write('foo')
 
             # check rsync
-            rsync1 =  tools.rsyncPrefix(
+            rsync1 = tools.rsyncPrefix(
                 self.config, no_perms=False, progress=False)
             rsync1.append(tmp_file)
             rsync1.append('%s@%s:"%s"/' % (
@@ -774,7 +774,7 @@ class SSH(MountControl):
                 remote_tmp_dir_1))
 
             # check remote rsync hard-link support
-            rsync2 =  tools.rsyncPrefix(
+            rsync2 = tools.rsyncPrefix(
                 self.config, no_perms=False, progress=False)
             rsync2.append(
                 '--link-dest=../%s' % os.path.basename(remote_tmp_dir_1))
@@ -785,7 +785,7 @@ class SSH(MountControl):
                 remote_tmp_dir_2))
 
             for cmd in (rsync1, rsync2):
-                logger.debug('Check rsync command: %s' %cmd, self)
+                logger.debug('Check rsync command: %s' % cmd, self)
 
                 proc = subprocess.Popen(cmd,
                                         stdout=subprocess.PIPE,
@@ -794,14 +794,20 @@ class SSH(MountControl):
                 out, err = proc.communicate()
 
                 if err or proc.returncode:
-                    logger.debug('rsync command returned error: %s' %err, self)
+                    logger.debug(
+                        'rsync command returned error: %s' % err, self)
 
-                    raise MountException(_('Remote host %(host)s doesn\'t support \'%(command)s\':\n'
-                                            '%(err)s\nLook at \'man backintime\' for further instructions')
-                                            % {'host' : self.host, 'command' : cmd, 'err' : err})
+                    raise MountException(_(
+                        'Remote host %(host)s doesn\'t support'
+                        ' \'%(command)s\':\n'
+                        '%(err)s\nLook at \'man backintime\' for further '
+                        'instructions') % {
+                            'host': self.host,
+                            'command': cmd,
+                            'err': err})
 
         # check cp chmod find and rm
-        head  = 'tmp1="%s"; tmp2="%s"; ' %(remote_tmp_dir_1, remote_tmp_dir_2)
+        head = 'tmp1="%s"; tmp2="%s"; ' % (remote_tmp_dir_1, remote_tmp_dir_2)
 
         # first define a function to clean up and exit
         head += 'cleanup(){ '
@@ -815,38 +821,38 @@ class SSH(MountControl):
         tail = []
 
         # list inodes
-        cmd  = 'ls -i "$tmp1/a"; ls -i "$tmp2/a"; '
+        cmd = 'ls -i "$tmp1/a"; ls -i "$tmp2/a"; '
         tail.append(cmd)
 
         # try nice -n 19
         if self.nice:
-            cmd  = 'echo \"nice -n 19\"; nice -n 19 true >/dev/null; err_nice=$?; '
+            cmd = 'echo \"nice -n 19\"; nice -n 19 true >/dev/null; err_nice=$?; '
             cmd += 'test $err_nice -ne 0 && cleanup $err_nice; '
             tail.append(cmd)
 
         # try ionice -c2 -n7
         if self.ionice:
-            cmd  = 'echo \"ionice -c2 -n7\"; ionice -c2 -n7 true >/dev/null; err_nice=$?; '
+            cmd = 'echo \"ionice -c2 -n7\"; ionice -c2 -n7 true >/dev/null; err_nice=$?; '
             cmd += 'test $err_nice -ne 0 && cleanup $err_nice; '
             tail.append(cmd)
 
         # try nocache
         if self.nocache:
-            cmd  = 'echo \"nocache\"; nocache true >/dev/null; err_nocache=$?; '
+            cmd = 'echo \"nocache\"; nocache true >/dev/null; err_nocache=$?; '
             cmd += 'test $err_nocache -ne 0 && cleanup $err_nocache; '
             tail.append(cmd)
 
         # try screen, bash and flock used by smart-remove running in background
         if self.config.smartRemoveRunRemoteInBackground(self.profile_id):
-            cmd  = 'echo \"screen -d -m bash -c ...\"; screen -d -m bash -c \"true\" >/dev/null; err_screen=$?; '
+            cmd = 'echo \"screen -d -m bash -c ...\"; screen -d -m bash -c \"true\" >/dev/null; err_screen=$?; '
             cmd += 'test $err_screen -ne 0 && cleanup $err_screen; '
             tail.append(cmd)
 
-            cmd  = 'echo \"(flock -x 9) 9>smr.lock\"; bash -c \"(flock -x 9) 9>smr.lock\" >/dev/null; err_flock=$?; '
+            cmd = 'echo \"(flock -x 9) 9>smr.lock\"; bash -c \"(flock -x 9) 9>smr.lock\" >/dev/null; err_flock=$?; '
             cmd += 'test $err_flock -ne 0 && cleanup $err_flock; '
             tail.append(cmd)
 
-            cmd  = 'echo \"rmdir \\$(mktemp -d)\"; tmp3=$(mktemp -d); test -z "$tmp3" && cleanup 1; rmdir $tmp3 >/dev/null; err_rmdir=$?; '
+            cmd = 'echo \"rmdir \\$(mktemp -d)\"; tmp3=$(mktemp -d); test -z "$tmp3" && cleanup 1; rmdir $tmp3 >/dev/null; err_rmdir=$?; '
             cmd += 'test $err_rmdir -ne 0 && cleanup $err_rmdir; '
             tail.append(cmd)
 
@@ -856,7 +862,7 @@ class SSH(MountControl):
 
         maxLength = self.config.sshMaxArgLength(self.profile_id)
         additionalChars = len('echo ""') \
-            + len(self.config.sshPrefixCmd(self.profile_id, cmd_type = str))
+            + len(self.config.sshPrefixCmd(self.profile_id, cmd_type=str))
 
         output = ''
         err = ''
@@ -878,11 +884,11 @@ class SSH(MountControl):
                 profile_id=self.profile_id)
 
             try:
-                logger.debug('Call command: %s' %' '.join(c), self)
+                logger.debug('Call command: %s' % ' '.join(c), self)
                 proc = subprocess.Popen(c,
                                         stdout=subprocess.PIPE,
                                         stderr=subprocess.PIPE,
-                                        universal_newlines = True)
+                                        universal_newlines=True)
                 ret = proc.communicate()
 
             except OSError as e:
@@ -941,8 +947,7 @@ class SSH(MountControl):
             raise MountException(
                 _('Check commands on host %(host)s returned unknown error:\n'
                   '%(err)s\nLook at \'man backintime\' for further '
-                  'instructions')
-                  % {'host': self.host, 'err': err})
+                  'instructions') % {'host': self.host, 'err': err})
 
         inodes = []
 
@@ -950,7 +955,7 @@ class SSH(MountControl):
 
             for line in output_split:
 
-                m = re.match(r'^(\d+).*?%s' %tmp, line)
+                m = re.match(r'^(\d+).*?%s' % tmp, line)
                 if m:
                     inodes.append(m.group(1))
 
@@ -959,7 +964,6 @@ class SSH(MountControl):
         if len(inodes) == 2 and inodes[0] != inodes[1]:
             raise MountException(
                 _('Remote host %s doesn\'t support hardlinks') % self.host)
-
 
     def randomId(self, size=6, chars=string.ascii_uppercase + string.digits):
         """
@@ -1095,10 +1099,10 @@ def sshKeyFingerprint(path):
         cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
     output = proc.communicate()[0]
 
-    m = re.match(b'\d+\s+(SHA256:\S+|[a-fA-F0-9:]+)\s.*', output)
-
+    m = re.match(r'\d+\s+(SHA256:\S+|[a-fA-F0-9:]+)\s.*',
+                 output.decode())
     if m:
-        return m.group(1).decode('UTF-8')
+        return m.group(1)
 
 
 def sshHostKey(host, port='22'):

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1,5 +1,6 @@
 #    Back In Time
-#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze, Taylor Raack
+#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey,
+#                            Germar Reitze, Taylor Raack
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -23,9 +24,40 @@ import copy
 import grp
 import re
 
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
-from PyQt5.QtCore import *
+from PyQt5.QtGui import QIcon, QFont, QPalette, QBrush, QColor
+from PyQt5.QtWidgets import (QDialog,
+                             QVBoxLayout,
+                             QHBoxLayout,
+                             QGridLayout,
+                             QDialogButtonBox,
+                             QMessageBox,
+                             QInputDialog,
+                             QGroupBox,
+                             QScrollArea,
+                             QFrame,
+                             QWidget,
+                             QTabWidget,
+                             QComboBox,
+                             QLabel,
+                             QPushButton,
+                             QToolButton,
+                             QLineEdit,
+                             QSpinBox,
+                             QTreeWidget,
+                             QTreeWidgetItem,
+                             QAbstractItemView,
+                             QHeaderView,
+                             QCheckBox,
+                             QFileSystemModel,
+                             QMenu,
+                             QProgressBar,
+                             QPlainTextEdit)
+from PyQt5.QtCore import (Qt,
+                          QDir,
+                          QSortFilterProxyModel,
+                          QThread,
+                          pyqtSignal,
+                          pyqtRemoveInputHook)
 
 import config
 import tools
@@ -37,7 +69,7 @@ import sshtools
 import logger
 from exceptions import MountException, NoPubKeyLogin, KnownHost
 
-_=gettext.gettext
+_ = gettext.gettext
 
 
 class SettingsDialog(QDialog):
@@ -60,7 +92,7 @@ class SettingsDialog(QDialog):
 
         self.mainLayout = QVBoxLayout(self)
 
-        #profiles
+        # profiles
         layout = QHBoxLayout()
         self.mainLayout.addLayout(layout)
 
@@ -78,9 +110,12 @@ class SettingsDialog(QDialog):
         layout.addWidget(self.btnEditProfile)
 
         # update to full system backup button
-        self.btnModifyProfileForFullSystemBackup = QPushButton(icon.ADD, _('Modify for Full System Backup'), self)
-        self.btnModifyProfileForFullSystemBackup.clicked.connect(self.modifyProfileForFullSystemBackup)
+        self.btnModifyProfileForFullSystemBackup \
+            = QPushButton(icon.ADD, _('Modify for Full System Backup'), self)
+        self.btnModifyProfileForFullSystemBackup \
+            .clicked.connect(self.modifyProfileForFullSystemBackup)
         layout.addWidget(self.btnModifyProfileForFullSystemBackup)
+
         # hide 'full system backup button' until all dev regarding this is done
         self.btnModifyProfileForFullSystemBackup.hide()
 
@@ -92,15 +127,15 @@ class SettingsDialog(QDialog):
         self.btnRemoveProfile.clicked.connect(self.removeProfile)
         layout.addWidget(self.btnRemoveProfile)
 
-        #TABs
+        # TABs
         self.tabs = QTabWidget(self)
         self.mainLayout.addWidget(self.tabs)
 
-        #occupy whole space for tabs
+        # occupy whole space for tabs
         scrollButtonDefault = self.tabs.usesScrollButtons()
         self.tabs.setUsesScrollButtons(False)
 
-        #TAB: General
+        # TAB: General
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
         self.tabs.addTab(scrollArea, _('&General'))
@@ -108,7 +143,7 @@ class SettingsDialog(QDialog):
         layoutWidget = QWidget(self)
         layout = QVBoxLayout(layoutWidget)
 
-        #select mode
+        # select mode
         self.mode = None
         vlayout = QVBoxLayout()
         layout.addLayout(vlayout)
@@ -125,15 +160,17 @@ class SettingsDialog(QDialog):
             store_modes[key] = self.config.SNAPSHOT_MODES[key][1]
         self.fillCombo(self.comboModes, store_modes)
 
-        #encfs security warning
-        self.encfsWarning = QLabel(_("<b>Warning:</b> %(app)s uses EncFS for encryption. A recent security audit "
-                                     "revealed several possible attack vectors for this. "
-                                     "Please take a look at 'A NOTE ON SECURITY' in 'man backintime'.") \
-                                   % {'app': self.config.APP_NAME})
+        # encfs security warning
+        self.encfsWarning = QLabel(
+            _('<b>Warning:</b> %(app)s uses EncFS for encryption. A recent '
+              'security audit revealed several possible attack vectors for '
+              'this. Please take a look at "A NOTE ON SECURITY" in '
+              '"man backintime".') % {'app': self.config.APP_NAME}
+        )
         self.encfsWarning.setWordWrap(True)
         layout.addWidget(self.encfsWarning)
 
-        #Where to save snapshots
+        # Where to save snapshots
         groupBox = QGroupBox(self)
         self.modeLocal = groupBox
         groupBox.setTitle(_('Where to save snapshots'))
@@ -153,11 +190,11 @@ class SettingsDialog(QDialog):
         self.btnSnapshotsPath.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.btnSnapshotsPath.setIcon(icon.FOLDER)
         self.btnSnapshotsPath.setText(_('Folder'))
-        self.btnSnapshotsPath.setMinimumSize(32,28)
+        self.btnSnapshotsPath.setMinimumSize(32, 28)
         hlayout.addWidget(self.btnSnapshotsPath)
         self.btnSnapshotsPath.clicked.connect(self.btnSnapshotsPathClicked)
 
-        #SSH
+        # SSH
         groupBox = QGroupBox(self)
         self.modeSsh = groupBox
         groupBox.setTitle(_('SSH Settings'))
@@ -209,26 +246,31 @@ class SettingsDialog(QDialog):
         self.btnSshPrivateKeyFile.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.btnSshPrivateKeyFile.setIcon(icon.FOLDER)
         self.btnSshPrivateKeyFile.setToolTip(_('Key File'))
-        self.btnSshPrivateKeyFile.setMinimumSize(32,28)
+        self.btnSshPrivateKeyFile.setMinimumSize(32, 28)
         hlayout3.addWidget(self.btnSshPrivateKeyFile)
-        self.btnSshPrivateKeyFile.clicked.connect(self.btnSshPrivateKeyFileClicked)
+        self.btnSshPrivateKeyFile.clicked \
+            .connect(self.btnSshPrivateKeyFileClicked)
 
         self.btnSshKeyGen = QToolButton(self)
         self.btnSshKeyGen.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.btnSshKeyGen.setIcon(icon.ADD)
-        self.btnSshKeyGen.setToolTip(_('Create a new SSH key without Password.'))
-        self.btnSshKeyGen.setMinimumSize(32,28)
+        self.btnSshKeyGen.setToolTip(
+            _('Create a new SSH key without Password.'))
+        self.btnSshKeyGen.setMinimumSize(32, 28)
         hlayout3.addWidget(self.btnSshKeyGen)
         self.btnSshKeyGen.clicked.connect(self.btnSshKeyGenClicked)
-        self.txtSshPrivateKeyFile.textChanged.connect(lambda x: self.btnSshKeyGen.setEnabled(not x))
+        self.txtSshPrivateKeyFile.textChanged \
+            .connect(lambda x: self.btnSshKeyGen.setEnabled(not x))
 
-        qttools.equalIndent(self.lblSshHost, self.lblSshPath, self.lblSshCipher)
+        qttools.equalIndent(self.lblSshHost,
+                            self.lblSshPath,
+                            self.lblSshCipher)
 
-        #encfs
+        # encfs
         self.modeLocalEncfs = self.modeLocal
         self.modeSshEncfs = self.modeSsh
 
-        #password
+        # password
         groupBox = QGroupBox(self)
         self.groupPassword1 = groupBox
         groupBox.setTitle(_('Password'))
@@ -255,16 +297,20 @@ class SettingsDialog(QDialog):
         self.cbPasswordSave = QCheckBox(_('Save Password to Keyring'), self)
         vlayout.addWidget(self.cbPasswordSave)
 
-        self.cbPasswordUseCache = QCheckBox(_('Cache Password for Cron (Security issue: root can read password)'), self)
+        self.cbPasswordUseCache = QCheckBox(
+            _('Cache Password for Cron (Security '
+              'issue: root can read password)'),
+            self
+        )
         vlayout.addWidget(self.cbPasswordUseCache)
 
         self.keyringSupported = tools.keyringSupported()
         self.cbPasswordSave.setEnabled(self.keyringSupported)
 
-        #mode change
+        # mode change
         self.comboModes.currentIndexChanged.connect(self.comboModesChanged)
 
-        #host, user, profile id
+        # host, user, profile id
         groupBox = QGroupBox(self)
         self.frameAdvanced = groupBox
         groupBox.setTitle(_('Advanced'))
@@ -301,7 +347,7 @@ class SettingsDialog(QDialog):
         self.lblFullPath.setWordWrap(True)
         vlayout2.addWidget(self.lblFullPath)
 
-        #Schedule
+        # Schedule
         groupBox = QGroupBox(self)
         self.globalScheduleGroupBox = groupBox
         groupBox.setTitle(_('Schedule'))
@@ -334,7 +380,11 @@ class SettingsDialog(QDialog):
         glayout.addWidget(self.comboScheduleWeekday, 2, 1)
 
         for d in range(1, 8):
-            self.comboScheduleWeekday.addItem(QIcon(), datetime.date(2011, 11, 6 + d).strftime("%A"), d)
+            self.comboScheduleWeekday.addItem(
+                QIcon(),
+                datetime.date(2011, 11, 6 + d).strftime("%A"),
+                d
+            )
 
         self.lblScheduleTime = QLabel(_('Hour:'), self)
         self.lblScheduleTime.setContentsMargins(5, 0, 0, 0)
@@ -345,25 +395,34 @@ class SettingsDialog(QDialog):
         glayout.addWidget(self.comboScheduleTime, 3, 1)
 
         for t in range(0, 2400, 100):
-            self.comboScheduleTime.addItem(QIcon(), datetime.time(t//100, t%100).strftime("%H:%M"), t)
+            self.comboScheduleTime.addItem(
+                QIcon(),
+                datetime.time(t // 100, t % 100).strftime("%H:%M"),
+                t
+            )
 
         self.lblScheduleCronPatern = QLabel(_('Hours:'), self)
         self.lblScheduleCronPatern.setContentsMargins(5, 0, 0, 0)
-        self.lblScheduleCronPatern.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.lblScheduleCronPatern.setAlignment(
+            Qt.AlignRight | Qt.AlignVCenter)
         glayout.addWidget(self.lblScheduleCronPatern, 4, 0)
 
         self.txtScheduleCronPatern = QLineEdit(self)
         glayout.addWidget(self.txtScheduleCronPatern, 4, 1)
 
-        #anacron
-        self.lblScheduleRepeated = QLabel(_('Run Back In Time repeatedly. This is useful if the computer is not running regularly.'))
+        # anacron
+        self.lblScheduleRepeated = QLabel(
+            _('Run Back In Time repeatedly. This is useful if the '
+              'computer is not running regularly.')
+        )
         self.lblScheduleRepeated.setContentsMargins(5, 0, 0, 0)
         self.lblScheduleRepeated.setWordWrap(True)
         glayout.addWidget(self.lblScheduleRepeated, 5, 0, 1, 2)
 
         self.lblScheduleRepeatedPeriod = QLabel(_('Every:'))
         self.lblScheduleRepeatedPeriod.setContentsMargins(5, 0, 0, 0)
-        self.lblScheduleRepeatedPeriod.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        self.lblScheduleRepeatedPeriod.setAlignment(
+            Qt.AlignRight | Qt.AlignVCenter)
         glayout.addWidget(self.lblScheduleRepeatedPeriod, 7, 0)
 
         hlayout = QHBoxLayout()
@@ -373,13 +432,17 @@ class SettingsDialog(QDialog):
         hlayout.addWidget(self.spbScheduleRepeatedPeriod)
 
         self.comboScheduleRepeatedUnit = QComboBox(self)
-        self.fillCombo(self.comboScheduleRepeatedUnit, self.config.REPEATEDLY_UNITS)
+        self.fillCombo(self.comboScheduleRepeatedUnit,
+                       self.config.REPEATEDLY_UNITS)
         hlayout.addWidget(self.comboScheduleRepeatedUnit)
         hlayout.addStretch()
         glayout.addLayout(hlayout, 7, 1)
 
-        #udev
-        self.lblScheduleUdev = QLabel(_('Run Back In Time as soon as the drive is connected (only once every X days).\nYou will be prompted for your sudo password.'))
+        # udev
+        self.lblScheduleUdev = QLabel(
+            _('Run Back In Time as soon as the drive is connected (only once'
+              ' every X days).\nYou will be prompted for your sudo password.')
+        )
         self.lblScheduleUdev.setWordWrap(True)
         glayout.addWidget(self.lblScheduleUdev, 6, 0, 1, 2)
 
@@ -390,7 +453,7 @@ class SettingsDialog(QDialog):
         scrollArea.setWidget(layoutWidget)
         scrollArea.setWidgetResizable(True)
 
-        #TAB: Include
+        # TAB: Include
         tabWidget = QWidget(self)
         self.tabs.addTab(tabWidget, _('&Include'))
         layout = QVBoxLayout(tabWidget)
@@ -398,15 +461,16 @@ class SettingsDialog(QDialog):
         self.listInclude = QTreeWidget(self)
         self.listInclude.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.listInclude.setRootIsDecorated(False)
-        self.listInclude.setHeaderLabels([ _('Include files and folders'),
-                                            'Count' ])
+        self.listInclude.setHeaderLabels(
+            [_('Include files and folders'), 'Count'])
 
         self.listInclude.header().setSectionResizeMode(0, QHeaderView.Stretch)
         self.listInclude.header().setSectionsClickable(True)
         self.listInclude.header().setSortIndicatorShown(True)
         self.listInclude.header().setSectionHidden(1, True)
         self.listIncludeSortLoop = False
-        self.listInclude.header().sortIndicatorChanged.connect(self.includeCustomSortOrder)
+        self.listInclude.header().sortIndicatorChanged \
+            .connect(self.includeCustomSortOrder)
 
         layout.addWidget(self.listInclude)
         self.listIncludeCount = 0
@@ -426,27 +490,31 @@ class SettingsDialog(QDialog):
         buttonsLayout.addWidget(self.btnIncludeRemove)
         self.btnIncludeRemove.clicked.connect(self.btnIncludeRemoveClicked)
 
-        #TAB: Exclude
+        # TAB: Exclude
         tabWidget = QWidget(self)
         self.tabs.addTab(tabWidget, _('&Exclude'))
         layout = QVBoxLayout(tabWidget)
 
-        self.lblSshEncfsExcludeWarning = QLabel(_('<b>Warning:</b> Wildcards (\'foo*\', \'[fF]oo\', \'fo?\') will be ignored with mode \'SSH encrypted\'.\nOnly separate asterisk are allowed (\'foo/*\', \'foo/**/bar\')'), self)
+        self.lblSshEncfsExcludeWarning = QLabel(
+            _('<b>Warning:</b> Wildcards (\'foo*\', \'[fF]oo\', \'fo?\') '
+              'will be ignored with mode \'SSH encrypted\'.\nOnly separate '
+              'asterisk are allowed (\'foo/*\', \'foo/**/bar\')'), self)
         self.lblSshEncfsExcludeWarning.setWordWrap(True)
         layout.addWidget(self.lblSshEncfsExcludeWarning)
 
         self.listExclude = QTreeWidget(self)
         self.listExclude.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.listExclude.setRootIsDecorated(False)
-        self.listExclude.setHeaderLabels([ _('Exclude patterns, files or folders') ,
-                                            'Count' ])
+        self.listExclude.setHeaderLabels(
+            [_('Exclude patterns, files or folders'), 'Count'])
 
         self.listExclude.header().setSectionResizeMode(0, QHeaderView.Stretch)
         self.listExclude.header().setSectionsClickable(True)
         self.listExclude.header().setSortIndicatorShown(True)
         self.listExclude.header().setSectionHidden(1, True)
         self.listExcludeSortLoop = False
-        self.listExclude.header().sortIndicatorChanged.connect(self.excludeCustomSortOrder)
+        self.listExclude.header().sortIndicatorChanged \
+            .connect(self.excludeCustomSortOrder)
 
         layout.addWidget(self.listExclude)
         self.listExcludeCount = 0
@@ -473,7 +541,9 @@ class SettingsDialog(QDialog):
         buttonsLayout.addWidget(self.btnExcludeFolder)
         self.btnExcludeFolder.clicked.connect(self.btnExcludeFolderClicked)
 
-        self.btnExcludeDefault = QPushButton(icon.DEFAULT_EXCLUDE, _('Add default'), self)
+        self.btnExcludeDefault = QPushButton(icon.DEFAULT_EXCLUDE,
+                                             _('Add default'),
+                                             self)
         buttonsLayout.addWidget(self.btnExcludeDefault)
         self.btnExcludeDefault.clicked.connect(self.btnExcludeDefaultClicked)
 
@@ -481,15 +551,21 @@ class SettingsDialog(QDialog):
         buttonsLayout.addWidget(self.btnExcludeRemove)
         self.btnExcludeRemove.clicked.connect(self.btnExcludeRemoveClicked)
 
-        #exclude files by size
+        # exclude files by size
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
-        self.cbExcludeBySize = QCheckBox(_('Exclude files bigger than: '), self)
-        self.cbExcludeBySize.setToolTip(_('Exclude files bigger than value in %(prefix)s.\n' +\
-        'With \'Full rsync mode\' disabled this will only affect new files\n' +\
-        'because for rsync this is a transfer option, not an exclude option.\n' +\
-        'So big files that has been backed up before will remain in snapshots\n' +\
-        'even if they had changed.' %{'prefix': 'MiB'}))
+        self.cbExcludeBySize = QCheckBox(
+            _('Exclude files bigger than: '), self)
+        self.cbExcludeBySize.setToolTip(
+            _('Exclude files bigger than value in %(prefix)s.\n'
+              'With \'Full rsync mode\' disabled this will only affect '
+              'new files\n'
+              'because for rsync this is a transfer option, not an '
+              'exclude option.\n'
+              'So big files that has been backed up before will remain '
+              'in snapshots\n'
+              'even if they had changed.' % {'prefix': 'MiB'})
+        )
         hlayout.addWidget(self.cbExcludeBySize)
         self.spbExcludeBySize = QSpinBox(self)
         self.spbExcludeBySize.setSuffix(' MiB')
@@ -500,7 +576,7 @@ class SettingsDialog(QDialog):
         enabled(False)
         self.cbExcludeBySize.stateChanged.connect(enabled)
 
-        #TAB: Auto-remove
+        # TAB: Auto-remove
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
         self.tabs.addTab(scrollArea, _('&Auto-remove'))
@@ -508,8 +584,7 @@ class SettingsDialog(QDialog):
         layoutWidget = QWidget(self)
         layout = QGridLayout(layoutWidget)
 
-
-        #remove old snapshots
+        # remove old snapshots
         self.cbRemoveOlder = QCheckBox(_('Older than:'), self)
         layout.addWidget(self.cbRemoveOlder, 0, 0)
         self.cbRemoveOlder.stateChanged.connect(self.updateRemoveOlder)
@@ -520,9 +595,10 @@ class SettingsDialog(QDialog):
 
         self.comboRemoveOlderUnit = QComboBox(self)
         layout.addWidget(self.comboRemoveOlderUnit, 0, 2)
-        self.fillCombo(self.comboRemoveOlderUnit, self.config.REMOVE_OLD_BACKUP_UNITS)
+        self.fillCombo(self.comboRemoveOlderUnit,
+                       self.config.REMOVE_OLD_BACKUP_UNITS)
 
-        #min free space
+        # min free space
         enabled, value, unit = self.config.minFreeSpace()
 
         self.cbFreeSpace = QCheckBox(_('If free space is less than:'), self)
@@ -535,9 +611,10 @@ class SettingsDialog(QDialog):
 
         self.comboFreeSpaceUnit = QComboBox(self)
         layout.addWidget(self.comboFreeSpaceUnit, 1, 2)
-        self.fillCombo(self.comboFreeSpaceUnit, self.config.MIN_FREE_SPACE_UNITS)
+        self.fillCombo(self.comboFreeSpaceUnit,
+                       self.config.MIN_FREE_SPACE_UNITS)
 
-        #min free inodes
+        # min free inodes
         self.cbFreeInodes = QCheckBox(_('If free inodes is less than:'), self)
         layout.addWidget(self.cbFreeInodes, 2, 0)
 
@@ -551,7 +628,7 @@ class SettingsDialog(QDialog):
         enabled(False)
         self.cbFreeInodes.stateChanged.connect(enabled)
 
-        #smart remove
+        # smart remove
         self.cbSmartRemove = QCheckBox(_('Smart remove'), self)
         layout.addWidget(self.cbSmartRemove, 3, 0)
 
@@ -561,41 +638,50 @@ class SettingsDialog(QDialog):
 
         smlayout = QGridLayout(widget)
 
-        self.cbSmartRemoveRunRemoteInBackground = QCheckBox(_('Run in background on remote Host.') + _(' EXPERIMENTAL!'), self)
+        self.cbSmartRemoveRunRemoteInBackground = QCheckBox(
+            _('Run in background on remote Host.') + _(' EXPERIMENTAL!'),
+            self)
         smlayout.addWidget(self.cbSmartRemoveRunRemoteInBackground, 0, 0, 1, 3)
 
-        smlayout.addWidget(QLabel(_('Keep all snapshots for the last'), self), 1, 0)
+        smlayout.addWidget(
+            QLabel(_('Keep all snapshots for the last'), self), 1, 0)
         self.spbKeepAll = QSpinBox(self)
         self.spbKeepAll.setRange(1, 10000)
         smlayout.addWidget(self.spbKeepAll, 1, 1)
         smlayout.addWidget(QLabel(_('day(s)'), self), 1, 2)
 
-        smlayout.addWidget(QLabel(_('Keep one snapshot per day for the last'), self), 2, 0)
+        smlayout.addWidget(
+            QLabel(_('Keep one snapshot per day for the last'), self), 2, 0)
         self.spbKeepOnePerDay = QSpinBox(self)
         self.spbKeepOnePerDay.setRange(1, 10000)
         smlayout.addWidget(self.spbKeepOnePerDay, 2, 1)
         smlayout.addWidget(QLabel(_('day(s)'), self), 2, 2)
 
-        smlayout.addWidget(QLabel(_('Keep one snapshot per week for the last'), self), 3, 0)
+        smlayout.addWidget(
+            QLabel(_('Keep one snapshot per week for the last'), self), 3, 0)
         self.spbKeepOnePerWeek = QSpinBox(self)
         self.spbKeepOnePerWeek.setRange(1, 10000)
         smlayout.addWidget(self.spbKeepOnePerWeek, 3, 1)
         smlayout.addWidget(QLabel(_('weeks(s)'), self), 3, 2)
 
-        smlayout.addWidget(QLabel(_('Keep one snapshot per month for the last'), self), 4, 0)
+        smlayout.addWidget(
+            QLabel(_('Keep one snapshot per month for the last'), self), 4, 0)
         self.spbKeepOnePerMonth = QSpinBox(self)
         self.spbKeepOnePerMonth.setRange(1, 1000)
         smlayout.addWidget(self.spbKeepOnePerMonth, 4, 1)
         smlayout.addWidget(QLabel(_('month(s)'), self), 4, 2)
 
-        smlayout.addWidget(QLabel(_('Keep one snapshot per year for all years'), self), 5, 0, 1, 3)
+        smlayout.addWidget(
+            QLabel(_('Keep one snapshot per year for all years'), self),
+            5, 0, 1, 3)
 
         enabled = lambda state: [smlayout.itemAt(x).widget().setEnabled(state) for x in range(smlayout.count())]
         enabled(False)
         self.cbSmartRemove.stateChanged.connect(enabled)
 
-        #don't remove named snapshots
-        self.cbDontRemoveNamedSnapshots = QCheckBox(_("Don't remove named snapshots"), self)
+        # don't remove named snapshots
+        self.cbDontRemoveNamedSnapshots \
+            = QCheckBox(_("Don't remove named snapshots"), self)
         layout.addWidget(self.cbDontRemoveNamedSnapshots, 5, 0, 1, 3)
 
         #
@@ -604,7 +690,7 @@ class SettingsDialog(QDialog):
         scrollArea.setWidget(layoutWidget)
         scrollArea.setWidgetResizable(True)
 
-        #TAB: Options
+        # TAB: Options
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
         self.tabs.addTab(scrollArea, _('&Options'))
@@ -615,38 +701,50 @@ class SettingsDialog(QDialog):
         self.cbNotify = QCheckBox(_('Enable notifications'), self)
         layout.addWidget(self.cbNotify)
 
-        self.cbNoSnapshotOnBattery = QCheckBox(_('Disable snapshots when on battery'), self)
-        if not tools.powerStatusAvailable ():
-            self.cbNoSnapshotOnBattery.setEnabled (False)
-            self.cbNoSnapshotOnBattery.setToolTip (_('Power status not available from system'))
+        self.cbNoSnapshotOnBattery \
+            = QCheckBox(_('Disable snapshots when on battery'), self)
+        if not tools.powerStatusAvailable():
+            self.cbNoSnapshotOnBattery.setEnabled(False)
+            self.cbNoSnapshotOnBattery.setToolTip(
+                _('Power status not available from system'))
         layout.addWidget(self.cbNoSnapshotOnBattery)
 
         self.cbGlobalFlock = QCheckBox(_('Run only one snapshot at a time'))
-        self.cbGlobalFlock.setToolTip(_('Other snapshots will be blocked until the current snapshot is done.\n'
-                                        'This is a global option. So it will effect all profiles for this user.\n'
-                                        'But you need to activate this for all other users, too.'))
+        self.cbGlobalFlock.setToolTip(
+            _('Other snapshots will be blocked until the current snapshot '
+              'is done.\n'
+              'This is a global option. So it will effect all profiles '
+              'for this user.\n'
+              'But you need to activate this for all other users, too.')
+        )
         layout.addWidget(self.cbGlobalFlock)
 
-        self.cbBackupOnRestore = QCheckBox(_('Backup replaced files on restore'), self)
-        self.cbBackupOnRestore.setToolTip(_("Newer versions of files will be "
-                                            "renamed with trailing '%(suffix)s' "
-                                            "before restoring.\n"
-                                            "If you don't need them anymore "
-                                            "you can remove them with '%(cmd)s'")
-                                             %{'suffix': self.snapshots.backupSuffix(),
-                                               'cmd': 'find ./ -name "*%s" -delete' % self.snapshots.backupSuffix() })
+        self.cbBackupOnRestore = QCheckBox(
+            _('Backup replaced files on restore'), self)
+        self.cbBackupOnRestore.setToolTip(
+            _("Newer versions of files will be renamed with "
+              "trailing '%(suffix)s' before restoring.\n"
+              "If you don't need them anymore you can remove them "
+              "with '%(cmd)s'") % {
+                  'suffix': self.snapshots.backupSuffix(),
+                  'cmd': 'find ./ -name "*%s" -delete' %
+                  self.snapshots.backupSuffix()
+              })
         layout.addWidget(self.cbBackupOnRestore)
 
-        self.cbContinueOnErrors = QCheckBox(_('Continue on errors (keep incomplete snapshots)'), self)
+        self.cbContinueOnErrors = QCheckBox(
+            _('Continue on errors (keep incomplete snapshots)'), self)
         layout.addWidget(self.cbContinueOnErrors)
 
-        self.cbUseChecksum = QCheckBox(_('Use checksum to detect changes'), self)
+        self.cbUseChecksum = QCheckBox(
+            _('Use checksum to detect changes'), self)
         layout.addWidget(self.cbUseChecksum)
 
-        self.cbTakeSnapshotRegardlessOfChanges = QCheckBox(_('Take a new snapshot regardless of there were changes or not.'))
+        self.cbTakeSnapshotRegardlessOfChanges = QCheckBox(
+            _('Take a new snapshot regardless of there were changes or not.'))
         layout.addWidget(self.cbTakeSnapshotRegardlessOfChanges)
 
-        #log level
+        # log level
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
 
@@ -665,7 +763,7 @@ class SettingsDialog(QDialog):
         scrollArea.setWidget(layoutWidget)
         scrollArea.setWidgetResizable(True)
 
-        #TAB: Expert Options
+        # TAB: Expert Options
         scrollArea = QScrollArea(self)
         scrollArea.setFrameStyle(QFrame.NoFrame)
         self.tabs.addTab(scrollArea, _('E&xpert Options'))
@@ -673,7 +771,10 @@ class SettingsDialog(QDialog):
         layoutWidget = QWidget(self)
         layout = QVBoxLayout(layoutWidget)
 
-        label = QLabel(_('Change these options only if you really know what you are doing !'), self)
+        label = QLabel(
+            _('Change these options only if you really know what '
+              'you are doing !'),
+            self)
         qttools.setFontBold(label)
         layout.addWidget(label)
 
@@ -683,10 +784,14 @@ class SettingsDialog(QDialog):
         grid.setColumnMinimumWidth(0, 20)
         layout.addLayout(grid)
 
-        self.cbNiceOnCron = QCheckBox(_('as cron job') + self.printDefault(self.config.DEFAULT_RUN_NICE_FROM_CRON), self)
+        self.cbNiceOnCron = QCheckBox(
+            _('as cron job') + self.printDefault(
+                self.config.DEFAULT_RUN_NICE_FROM_CRON), self)
         grid.addWidget(self.cbNiceOnCron, 0, 1)
 
-        self.cbNiceOnRemote = QCheckBox(_('on remote host') + self.printDefault(self.config.DEFAULT_RUN_NICE_ON_REMOTE), self)
+        self.cbNiceOnRemote = QCheckBox(
+            _('on remote host') + self.printDefault(
+                self.config.DEFAULT_RUN_NICE_ON_REMOTE), self)
         grid.addWidget(self.cbNiceOnRemote, 1, 1)
 
         label = QLabel(_("Run 'rsync' with 'ionice':"))
@@ -695,13 +800,19 @@ class SettingsDialog(QDialog):
         grid.setColumnMinimumWidth(0, 20)
         layout.addLayout(grid)
 
-        self.cbIoniceOnCron = QCheckBox(_('as cron job') + self.printDefault(self.config.DEFAULT_RUN_IONICE_FROM_CRON), self)
+        self.cbIoniceOnCron = QCheckBox(
+            _('as cron job') + self.printDefault(
+                self.config.DEFAULT_RUN_IONICE_FROM_CRON), self)
         grid.addWidget(self.cbIoniceOnCron, 0, 1)
 
-        self.cbIoniceOnUser = QCheckBox(_('when taking a manual snapshot') + self.printDefault(self.config.DEFAULT_RUN_IONICE_FROM_USER), self)
+        self.cbIoniceOnUser = QCheckBox(
+            _('when taking a manual snapshot') + self.printDefault(
+                self.config.DEFAULT_RUN_IONICE_FROM_USER), self)
         grid.addWidget(self.cbIoniceOnUser, 1, 1)
 
-        self.cbIoniceOnRemote = QCheckBox(_('on remote host') + self.printDefault(self.config.DEFAULT_RUN_IONICE_ON_REMOTE), self)
+        self.cbIoniceOnRemote = QCheckBox(
+            _('on remote host') + self.printDefault(
+                self.config.DEFAULT_RUN_IONICE_ON_REMOTE), self)
         grid.addWidget(self.cbIoniceOnRemote, 2, 1)
 
         self.nocacheAvailable = tools.checkCommand('nocache')
@@ -713,26 +824,36 @@ class SettingsDialog(QDialog):
         grid.setColumnMinimumWidth(0, 20)
         layout.addLayout(grid)
 
-        self.cbNocacheOnLocal = QCheckBox(_('on local machine') + self.printDefault(self.config.DEFAULT_RUN_NOCACHE_ON_LOCAL), self)
+        self.cbNocacheOnLocal = QCheckBox(
+            _('on local machine') + self.printDefault(
+                self.config.DEFAULT_RUN_NOCACHE_ON_LOCAL), self)
         self.cbNocacheOnLocal.setEnabled(self.nocacheAvailable)
         grid.addWidget(self.cbNocacheOnLocal, 0, 1)
 
-        self.cbNocacheOnRemote = QCheckBox(_('on remote host') + self.printDefault(self.config.DEFAULT_RUN_NOCACHE_ON_REMOTE), self)
+        self.cbNocacheOnRemote = QCheckBox(
+            _('on remote host') + self.printDefault(
+                self.config.DEFAULT_RUN_NOCACHE_ON_REMOTE), self)
         grid.addWidget(self.cbNocacheOnRemote, 2, 1)
 
-        self.cbRedirectStdoutInCron = QCheckBox(_('Redirect stdout to /dev/null in cronjobs.')
-                                                + self.printDefault(self.config.DEFAULT_REDIRECT_STDOUT_IN_CRON),
-                                                self)
-        self.cbRedirectStdoutInCron.setToolTip('cron will automatically send an email with attached output of cronjobs if a MTA is installed.')
+        self.cbRedirectStdoutInCron = QCheckBox(
+            _('Redirect stdout to /dev/null in cronjobs.')
+            + self.printDefault(self.config.DEFAULT_REDIRECT_STDOUT_IN_CRON),
+            self)
+        self.cbRedirectStdoutInCron.setToolTip(
+            'cron will automatically send an email with attached output '
+            'of cronjobs if a MTA is installed.')
         layout.addWidget(self.cbRedirectStdoutInCron)
 
-        self.cbRedirectStderrInCron = QCheckBox(_('Redirect stderr to /dev/null in cronjobs.')
-                                                + self.printDefault(self.config.DEFAULT_REDIRECT_STDERR_IN_CRON),
-                                                self)
-        self.cbRedirectStderrInCron.setToolTip('cron will automatically send an email with attached errors of cronjobs if a MTA is installed.')
+        self.cbRedirectStderrInCron = QCheckBox(
+            _('Redirect stderr to /dev/null in cronjobs.')
+            + self.printDefault(self.config.DEFAULT_REDIRECT_STDERR_IN_CRON),
+            self)
+        self.cbRedirectStderrInCron.setToolTip(
+            'cron will automatically send an email with attached errors '
+            'of cronjobs if a MTA is installed.')
         layout.addWidget(self.cbRedirectStderrInCron)
 
-        #bwlimit
+        # bwlimit
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
         self.cbBwlimit = QCheckBox(_('Limit rsync bandwidth usage: '), self)
@@ -747,120 +868,134 @@ class SettingsDialog(QDialog):
         enabled(False)
         self.cbBwlimit.stateChanged.connect(enabled)
         self.cbBwlimit.setToolTip(
-                'uses \'rsync --bwlimit=RATE\'\n'
-                'From \'man rsync\':\n'
-                'This option allows you to specify the maximum transfer rate for\n'
-                'the data sent over the socket, specified in units per second.\n'
-                'The RATE value can be suffixed with a string to indicate a size\n'
-                'multiplier, and may be a fractional value (e.g. "--bwlimit=1.5m").\n'
-                'If no suffix is specified, the value will be assumed to be in\n'
-                'units of 1024 bytes (as if "K" or "KiB" had been appended).\n'
-                'See the --max-size option for a description of all the available\n'
-                'suffixes. A value of zero specifies no limit.\n\n'
-                'For backward-compatibility reasons, the rate limit will be\n'
-                'rounded to the nearest KiB unit, so no rate smaller than\n'
-                '1024 bytes per second is possible.\n\n'
-                'Rsync writes data over the socket in blocks, and this option\n'
-                'both limits the size of the blocks that rsync writes, and tries\n'
-                'to keep the average transfer rate at the requested limit.\n'
-                'Some "burstiness" may be seen where rsync writes out a block\n'
-                'of data and then sleeps to bring the average rate into compliance.\n\n'
-                'Due to the internal buffering of data, the --progress option\n'
-                'may not be an accurate reflection on how fast the data is being\n'
-                'sent. This is because some files can show up as being rapidly\n'
-                'sent when the data is quickly buffered, while other can show up\n'
-                'as very slow when the flushing of the output buffer occurs.\n'
-                'This may be fixed in a future version.'
-                )
+            'uses \'rsync --bwlimit=RATE\'\n'
+            'From \'man rsync\':\n'
+            'This option allows you to specify the maximum transfer rate for\n'
+            'the data sent over the socket, specified in units per second.\n'
+            'The RATE value can be suffixed with a string to indicate a size\n'
+            'multiplier, and may be a fractional value '
+            '(e.g. "--bwlimit=1.5m").\n'
+            'If no suffix is specified, the value will be assumed to be in\n'
+            'units of 1024 bytes (as if "K" or "KiB" had been appended).\n'
+            'See the --max-size option for a description of '
+            'all the available\n'
+            'suffixes. A value of zero specifies no limit.\n\n'
+            'For backward-compatibility reasons, the rate limit will be\n'
+            'rounded to the nearest KiB unit, so no rate smaller than\n'
+            '1024 bytes per second is possible.\n\n'
+            'Rsync writes data over the socket in blocks, and this option\n'
+            'both limits the size of the blocks that rsync writes, and tries\n'
+            'to keep the average transfer rate at the requested limit.\n'
+            'Some "burstiness" may be seen where rsync writes out a block\n'
+            'of data and then sleeps to bring the average rate '
+            'into compliance.\n\n'
+            'Due to the internal buffering of data, the --progress option\n'
+            'may not be an accurate reflection on how fast the data is being\n'
+            'sent. This is because some files can show up as being rapidly\n'
+            'sent when the data is quickly buffered, while other can show up\n'
+            'as very slow when the flushing of the output buffer occurs.\n'
+            'This may be fixed in a future version.'
+            )
 
         self.cbPreserveAcl = QCheckBox(_('Preserve ACL'), self)
         self.cbPreserveAcl.setToolTip(
-                'uses \'rsync -A\'\n'
-                'From \'man rsync\':\n'
-                'This option causes rsync to update the destination ACLs to be\n'
-                'the same as the source ACLs. The option also implies --perms.\n\n'
-                'The source and destination systems must have compatible ACL\n'
-                'entries for this option to work properly.\n'
-                'See the --fake-super option for a way to backup  and restore\n'
-                'ACLs that are not compatible.'
-                )
+            'uses \'rsync -A\'\n'
+            'From \'man rsync\':\n'
+            'This option causes rsync to update the destination ACLs to be\n'
+            'the same as the source ACLs. The option also implies '
+            '--perms.\n\n'
+            'The source and destination systems must have compatible ACL\n'
+            'entries for this option to work properly.\n'
+            'See the --fake-super option for a way to backup and restore\n'
+            'ACLs that are not compatible.'
+        )
         layout.addWidget(self.cbPreserveAcl)
 
-        self.cbPreserveXattr = QCheckBox(_('Preserve extended attributes (xattr)'), self)
+        self.cbPreserveXattr = QCheckBox(
+            _('Preserve extended attributes (xattr)'), self)
         self.cbPreserveXattr.setToolTip(
-                'uses \'rsync -X\'\n'
-                'From \'man rsync\':\n'
-                'This option causes rsync to update the destination extended\n'
-                'attributes to be the same as the source ones.\n\n'
-                'For systems that support extended-attribute namespaces, a copy\n'
-                'being done by a super-user copies all namespaces except\n'
-                'system.*. A normal user only copies the user.* namespace.\n'
-                'To be able to backup and restore non-user namespaces as a normal\n'
-                'user, see the --fake-super option.\n\n'
-                'Note that this option does not copy rsyncs special xattr values\n'
-                '(e.g. those used by --fake-super) unless you repeat the option\n'
-                '(e.g. -XX). This "copy all xattrs" mode cannot be used\n'
-                'with --fake-super.'
-                )
+            'uses \'rsync -X\'\n'
+            'From \'man rsync\':\n'
+            'This option causes rsync to update the destination extended\n'
+            'attributes to be the same as the source ones.\n\n'
+            'For systems that support extended-attribute namespaces, a copy\n'
+            'being done by a super-user copies all namespaces except\n'
+            'system.*. A normal user only copies the user.* namespace.\n'
+            'To be able to backup and restore non-user namespaces as '
+            'a normal\n'
+            'user, see the --fake-super option.\n\n'
+            'Note that this option does not copy rsyncs special xattr values\n'
+            '(e.g. those used by --fake-super) unless you repeat the option\n'
+            '(e.g. -XX). This "copy all xattrs" mode cannot be used\n'
+            'with --fake-super.'
+        )
         layout.addWidget(self.cbPreserveXattr)
 
-        self.cbCopyUnsafeLinks = QCheckBox(_('Copy unsafe links (works only with absolute links)'), self)
+        self.cbCopyUnsafeLinks = QCheckBox(
+            _('Copy unsafe links (works only with absolute links)'), self)
         self.cbCopyUnsafeLinks.setToolTip(
-                'uses \'rsync --copy-unsafe-links\'\n'
-                'From \'man rsync\':\n'
-                'This tells rsync to copy the referent of symbolic links that\n'
-                'point outside the copied tree. Absolute symlinks are also\n'
-                'treated like ordinary files, and so are any symlinks in the\n'
-                'source path itself when --relative is used. This option has\n'
-                'no additional effect if --copy-links was also specified.\n'
-                )
+            'uses \'rsync --copy-unsafe-links\'\n'
+            'From \'man rsync\':\n'
+            'This tells rsync to copy the referent of symbolic links that\n'
+            'point outside the copied tree. Absolute symlinks are also\n'
+            'treated like ordinary files, and so are any symlinks in the\n'
+            'source path itself when --relative is used. This option has\n'
+            'no additional effect if --copy-links was also specified.\n'
+        )
         layout.addWidget(self.cbCopyUnsafeLinks)
 
-        self.cbCopyLinks = QCheckBox(_('Copy links (dereference symbolic links)'), self)
+        self.cbCopyLinks = QCheckBox(
+            _('Copy links (dereference symbolic links)'), self)
         self.cbCopyLinks.setToolTip(
-                'uses \'rsync --copy-links\'\n'
-                'From \'man rsync\':\n'
-                'When symlinks are encountered, the item that they point to\n'
-                '(the referent) is copied, rather than the symlink. In older\n'
-                'versions of rsync, this option also had the side-effect of\n'
-                'telling the receiving side to follow symlinks, such as\n'
-                'symlinks to directories. In a modern rsync such as this one,\n'
-                'you\'ll need to specify --keep-dirlinks (-K) to get this extra\n'
-                'behavior. The only exception is when sending files to an rsync\n'
-                'that is too old to understand -K -- in that case, the -L option\n'
-                'will still have the side-effect of -K on that older receiving rsync.'
-                )
+            'uses \'rsync --copy-links\'\n'
+            'From \'man rsync\':\n'
+            'When symlinks are encountered, the item that they point to\n'
+            '(the referent) is copied, rather than the symlink. In older\n'
+            'versions of rsync, this option also had the side-effect of\n'
+            'telling the receiving side to follow symlinks, such as\n'
+            'symlinks to directories. In a modern rsync such as this one,\n'
+            'you\'ll need to specify --keep-dirlinks (-K) to get this extra\n'
+            'behavior. The only exception is when sending files to an rsync\n'
+            'that is too old to understand -K -- in that case, the -L option\n'
+            'will still have the side-effect of -K on that older '
+            'receiving rsync.'
+        )
         layout.addWidget(self.cbCopyLinks)
 
-        #additional rsync options
+        # additional rsync options
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
-        self.cbRsyncOptions = QCheckBox(_('Paste additional options to rsync'), self)
+        self.cbRsyncOptions = QCheckBox(
+            _('Paste additional options to rsync'), self)
         hlayout.addWidget(self.cbRsyncOptions)
         self.txtRsyncOptions = QLineEdit(self)
-        self.txtRsyncOptions.setToolTip(_('Options must be quoted e.g. --exclude-from="/path/to/my exclude file".'))
+        self.txtRsyncOptions.setToolTip(
+            _('Options must be quoted e.g. '
+              '--exclude-from="/path/to/my exclude file".'))
         hlayout.addWidget(self.txtRsyncOptions)
 
         enabled = lambda state: self.txtRsyncOptions.setEnabled(state)
         enabled(False)
         self.cbRsyncOptions.stateChanged.connect(enabled)
 
-        #ssh prefix
+        # ssh prefix
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
         self.cbSshPrefix = QCheckBox(_('Add prefix to SSH commands'), self)
         hlayout.addWidget(self.cbSshPrefix)
         self.txtSshPrefix = QLineEdit(self)
-        self.txtSshPrefix.setToolTip(_('Prefix to run before every command on remote host.\n'
-                                        'Variables need to be escaped with \$FOO.\n'
-                                        'This doesn\'t touch rsync. So to add a prefix\n'
-                                        'for rsync use "%(cbRsyncOptions)s" with\n'
-                                        '%(rsync_options_value)s\n\n'
-                                        '%(default)s: %(def_value)s')
-                                        % {'cbRsyncOptions': self.cbRsyncOptions.text(),
-                                           'rsync_options_value': '--rsync-path="FOO=bar:\$FOO /usr/bin/rsync"',
-                                           'default': _('default'),
-                                           'def_value': self.config.DEFAULT_SSH_PREFIX})
+        self.txtSshPrefix.setToolTip(
+            _('Prefix to run before every command on remote host.\n'
+              'Variables need to be escaped with \\$FOO.\n'
+              'This doesn\'t touch rsync. So to add a prefix\n'
+              'for rsync use "%(cbRsyncOptions)s" with\n'
+              '%(rsync_options_value)s\n\n'
+              '%(default)s: %(def_value)s') % {
+                  'cbRsyncOptions': self.cbRsyncOptions.text(),
+                  'rsync_options_value': '--rsync-path="FOO=bar:\\$FOO /usr/bin/rsync"',
+                  'default': _('default'),
+                  'def_value': self.config.DEFAULT_SSH_PREFIX}
+        )
         hlayout.addWidget(self.txtSshPrefix)
 
         enabled = lambda state: self.txtSshPrefix.setEnabled(state)
@@ -870,13 +1005,16 @@ class SettingsDialog(QDialog):
         qttools.equalIndent(self.cbRsyncOptions, self.cbSshPrefix)
 
         self.cbSshCheckPing = QCheckBox(_('Check if remote host is online'))
-        self.cbSshCheckPing.setToolTip(_('Warning: if disabled and the remote host\n'
-                                         'is not available, this could lead to some\n'
-                                         'weird errors.'))
-        self.cbSshCheckCommands = QCheckBox(_('Check if remote host support all necessary commands'))
-        self.cbSshCheckCommands.setToolTip(_('Warning: if disabled and the remote host\n'
-                                             'does not support all necessary commands,\n'
-                                             'this could lead to some weird errors.'))
+        self.cbSshCheckPing.setToolTip(
+            _('Warning: if disabled and the remote host\n'
+              'is not available, this could lead to some\n'
+              'weird errors.'))
+        self.cbSshCheckCommands = QCheckBox(
+            _('Check if remote host support all necessary commands'))
+        self.cbSshCheckCommands.setToolTip(
+            _('Warning: if disabled and the remote host\n'
+              'does not support all necessary commands,\n'
+              'this could lead to some weird errors.'))
         layout.addWidget(self.cbSshCheckPing)
         layout.addWidget(self.cbSshCheckCommands)
 
@@ -885,10 +1023,14 @@ class SettingsDialog(QDialog):
         scrollArea.setWidget(layoutWidget)
         scrollArea.setWidgetResizable(True)
 
-        #buttons
-        buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent = self)
-        btnRestore = buttonBox.addButton(_('Restore Config'), QDialogButtonBox.ResetRole)
-        btnUserCallback = buttonBox.addButton(_('Edit user-callback'), QDialogButtonBox.ResetRole)
+        # buttons
+        buttonBox = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
+            parent=self)
+        btnRestore = buttonBox.addButton(
+            _('Restore Config'), QDialogButtonBox.ResetRole)
+        btnUserCallback = buttonBox.addButton(
+            _('Edit user-callback'), QDialogButtonBox.ResetRole)
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
         btnRestore.clicked.connect(self.restoreConfig)
@@ -898,7 +1040,7 @@ class SettingsDialog(QDialog):
         self.updateProfiles()
         self.comboModesChanged()
 
-        #enable tabs scroll buttons again but keep dialog size
+        # enable tabs scroll buttons again but keep dialog size
         size = self.sizeHint()
         self.tabs.setUsesScrollButtons(scrollButtonDefault)
         self.resize(size)
@@ -907,19 +1049,26 @@ class SettingsDialog(QDialog):
 
     def modifyProfileForFullSystemBackup(self):
         # verify to user that settings will change
-        message = _("Full system backup can only create a snapshot to be restored to the same physical disk(s) "
-            "with the same disk partitioning as from the source; restoring to new physical disks or the same disks "
-            "with different partitioning will yield a potentially broken and unusable system.\n\n"
-            "Full system backup will override some settings that may have been customized. Continue?")
+        message = _(
+            "Full system backup can only create a snapshot to be restored "
+            "to the same physical disk(s) with the same disk partitioning "
+            "as from the source; restoring to new physical disks or the "
+            "same disks with different partitioning will yield a potentially "
+            "broken and unusable system.\n\n"
+            "Full system backup will override some settings that may have "
+            "been customized. Continue?"
+        )
         if QMessageBox.No == messagebox.warningYesNo(self, message):
             return
 
         # configure for full system backup
-        # don't want to create a backup with any errors and give user false sense that backup was ok
+        # don't want to create a backup with any errors and give user
+        # false sense that backup was ok
         self.config.setContinueOnErrors(False)
         # make sure all files are backed up
         self.config.setExcludeBySize(False, 500)
-        # when we restore the full system, don't want to keep old files (since we back up everything)
+        # when we restore the full system, don't want to keep old
+        # files (since we back up everything)
         self.config.setBackupOnRestore(False)
         # no need for checksum mode
         self.config.setUseChecksum(False)
@@ -936,7 +1085,7 @@ class SettingsDialog(QDialog):
         self.updateProfiles()
 
     def addProfile(self):
-        ret_val =  QInputDialog.getText(self, _('New profile'), str())
+        ret_val = QInputDialog.getText(self, _('New profile'), str())
         if not ret_val[1]:
             return
 
@@ -952,7 +1101,10 @@ class SettingsDialog(QDialog):
         self.updateProfiles()
 
     def editProfile(self):
-        ret_val =  QInputDialog.getText(self, _('Rename profile'), str(), text = self.config.profileName())
+        ret_val = QInputDialog.getText(
+            self, _('Rename profile'), str(),
+            text=self.config.profileName())
+
         if not ret_val[1]:
             return
 
@@ -963,10 +1115,13 @@ class SettingsDialog(QDialog):
         if not self.config.setProfileName(name):
             return
 
-        self.updateProfiles(reloadSettings = False)
+        self.updateProfiles(reloadSettings=False)
 
     def removeProfile(self):
-        if self.questionHandler(_('Are you sure you want to delete the profile "%s" ?') % self.config.profileName()):
+        question = _('Are you sure you want to delete the profile "%s" ?') \
+            % self.config.profileName()
+
+        if self.questionHandler(question):
             self.config.removeProfile()
             self.updateProfiles()
 
@@ -1037,9 +1192,10 @@ class SettingsDialog(QDialog):
             self.config.setCurrentProfile(profile_id)
             self.updateProfile()
 
-    def updateProfiles(self, reloadSettings = True):
+    def updateProfiles(self, reloadSettings=True):
         if reloadSettings:
             self.updateProfile()
+
         current_profile_id = self.config.currentProfile()
 
         self.disableProfileChanged = True
@@ -1063,36 +1219,50 @@ class SettingsDialog(QDialog):
             self.btnRemoveProfile.setEnabled(True)
         self.btnAddProfile.setEnabled(self.config.isConfigured('1'))
 
-        #TAB: General
-        #mode
-        self.setComboValue(self.comboModes, self.config.snapshotsMode(), t = 'str')
+        # TAB: General
+        # mode
+        self.setComboValue(self.comboModes,
+                           self.config.snapshotsMode(),
+                           t='str')
 
-        #local
-        self.editSnapshotsPath.setText(self.config.snapshotsPath(mode = 'local'))
+        # local
+        self.editSnapshotsPath.setText(
+            self.config.snapshotsPath(mode='local'))
 
-        #ssh
+        # ssh
         self.txtSshHost.setText(self.config.sshHost())
         self.txtSshPort.setText(str(self.config.sshPort()))
         self.txtSshUser.setText(self.config.sshUser())
         self.txtSshPath.setText(self.config.sshSnapshotsPath())
-        self.setComboValue(self.comboSshCipher, self.config.sshCipher(), t = 'str')
+        self.setComboValue(self.comboSshCipher,
+                           self.config.sshCipher(),
+                           t='str')
         self.txtSshPrivateKeyFile.setText(self.config.sshPrivateKeyFile())
 
-        #local_encfs
+        # local_encfs
         if self.mode == 'local_encfs':
             self.editSnapshotsPath.setText(self.config.localEncfsPath())
 
-        #password
-        password_1 = self.config.password(mode = self.mode, pw_id = 1, only_from_keyring = True)
-        password_2 = self.config.password(mode = self.mode, pw_id = 2, only_from_keyring = True)
+        # password
+        password_1 = self.config.password(
+            mode=self.mode, pw_id=1, only_from_keyring=True)
+        password_2 = self.config.password(
+            mode=self.mode, pw_id=2, only_from_keyring=True)
+
         if password_1 is None:
             password_1 = ''
+
         if password_2 is None:
             password_2 = ''
+
         self.txtPassword1.setText(password_1)
         self.txtPassword2.setText(password_2)
-        self.cbPasswordSave.setChecked(self.keyringSupported and self.config.passwordSave(mode = self.mode))
-        self.cbPasswordUseCache.setChecked(self.config.passwordUseCache(mode = self.mode))
+
+        self.cbPasswordSave.setChecked(
+            self.keyringSupported and self.config.passwordSave(mode=self.mode))
+
+        self.cbPasswordUseCache.setChecked(
+            self.config.passwordUseCache(mode=self.mode))
 
         host, user, profile = self.config.hostUserProfile()
         self.txtHost.setText(host)
@@ -1102,23 +1272,28 @@ class SettingsDialog(QDialog):
         self.setComboValue(self.comboSchedule, self.config.scheduleMode())
         self.setComboValue(self.comboScheduleTime, self.config.scheduleTime())
         self.setComboValue(self.comboScheduleDay, self.config.scheduleDay())
-        self.setComboValue(self.comboScheduleWeekday, self.config.scheduleWeekday())
+        self.setComboValue(self.comboScheduleWeekday,
+                           self.config.scheduleWeekday())
         self.txtScheduleCronPatern.setText(self.config.customBackupTime())
-        self.spbScheduleRepeatedPeriod.setValue(self.config.scheduleRepeatedPeriod())
-        self.setComboValue(self.comboScheduleRepeatedUnit, self.config.scheduleRepeatedUnit())
+        self.spbScheduleRepeatedPeriod.setValue(
+            self.config.scheduleRepeatedPeriod())
+        self.setComboValue(self.comboScheduleRepeatedUnit,
+                           self.config.scheduleRepeatedUnit())
         self.updateSchedule(self.config.scheduleMode())
 
-        #TAB: Include
+        # TAB: Include
         self.listInclude.clear()
 
         for include in self.config.include():
             self.addInclude(include)
 
-        includeSortColumn = int(self.config.profileIntValue('qt.settingsdialog.include.SortColumn', 1))
-        includeSortOrder  = int(self.config.profileIntValue('qt.settingsdialog.include.SortOrder', Qt.AscendingOrder))
+        includeSortColumn = int(self.config.profileIntValue(
+            'qt.settingsdialog.include.SortColumn', 1))
+        includeSortOrder = int(self.config.profileIntValue(
+            'qt.settingsdialog.include.SortOrder', Qt.AscendingOrder))
         self.listInclude.sortItems(includeSortColumn, includeSortOrder)
 
-        #TAB: Exclude
+        # TAB: Exclude
         self.listExclude.clear()
 
         for exclude in self.config.exclude():
@@ -1126,60 +1301,70 @@ class SettingsDialog(QDialog):
         self.cbExcludeBySize.setChecked(self.config.excludeBySizeEnabled())
         self.spbExcludeBySize.setValue(self.config.excludeBySize())
 
-        excludeSortColumn = int(self.config.profileIntValue('qt.settingsdialog.exclude.SortColumn', 1))
-        excludeSortOrder  = int(self.config.profileIntValue('qt.settingsdialog.exclude.SortOrder', Qt.AscendingOrder))
+        excludeSortColumn = int(self.config.profileIntValue(
+            'qt.settingsdialog.exclude.SortColumn', 1))
+        excludeSortOrder = int(self.config.profileIntValue(
+            'qt.settingsdialog.exclude.SortOrder', Qt.AscendingOrder))
         self.listExclude.sortItems(excludeSortColumn, excludeSortOrder)
 
-        #TAB: Auto-remove
+        # TAB: Auto-remove
 
-        #remove old snapshots
+        # remove old snapshots
         enabled, value, unit = self.config.removeOldSnapshots()
         self.cbRemoveOlder.setChecked(enabled)
         self.spbRemoveOlder.setValue(value)
         self.setComboValue(self.comboRemoveOlderUnit, unit)
 
-        #min free space
+        # min free space
         enabled, value, unit = self.config.minFreeSpace()
         self.cbFreeSpace.setChecked(enabled)
         self.spbFreeSpace.setValue(value)
         self.setComboValue(self.comboFreeSpaceUnit, unit)
 
-        #min free inodes
+        # min free inodes
         self.cbFreeInodes.setChecked(self.config.minFreeInodesEnabled())
         self.spbFreeInodes.setValue(self.config.minFreeInodes())
 
-        #smart remove
-        smart_remove, keep_all, keep_one_per_day, keep_one_per_week, keep_one_per_month = self.config.smartRemove()
+        # smart remove
+        smart_remove, keep_all, keep_one_per_day, keep_one_per_week, \
+            keep_one_per_month = self.config.smartRemove()
         self.cbSmartRemove.setChecked(smart_remove)
         self.spbKeepAll.setValue(keep_all)
         self.spbKeepOnePerDay.setValue(keep_one_per_day)
         self.spbKeepOnePerWeek.setValue(keep_one_per_week)
         self.spbKeepOnePerMonth.setValue(keep_one_per_month)
-        self.cbSmartRemoveRunRemoteInBackground.setChecked(self.config.smartRemoveRunRemoteInBackground())
+        self.cbSmartRemoveRunRemoteInBackground.setChecked(
+            self.config.smartRemoveRunRemoteInBackground())
 
-        #don't remove named snapshots
-        self.cbDontRemoveNamedSnapshots.setChecked(self.config.dontRemoveNamedSnapshots())
+        # don't remove named snapshots
+        self.cbDontRemoveNamedSnapshots.setChecked(
+            self.config.dontRemoveNamedSnapshots())
 
-        #TAB: Options
+        # TAB: Options
         self.cbNotify.setChecked(self.config.notify())
-        self.cbNoSnapshotOnBattery.setChecked(self.config.noSnapshotOnBattery())
+        self.cbNoSnapshotOnBattery.setChecked(
+            self.config.noSnapshotOnBattery())
         self.cbGlobalFlock.setChecked(self.config.globalFlock())
         self.cbBackupOnRestore.setChecked(self.config.backupOnRestore())
         self.cbContinueOnErrors.setChecked(self.config.continueOnErrors())
         self.cbUseChecksum.setChecked(self.config.useChecksum())
-        self.cbTakeSnapshotRegardlessOfChanges.setChecked(self.config.takeSnapshotRegardlessOfChanges())
+        self.cbTakeSnapshotRegardlessOfChanges.setChecked(
+            self.config.takeSnapshotRegardlessOfChanges())
         self.setComboValue(self.comboLogLevel, self.config.logLevel())
 
-        #TAB: Expert Options
+        # TAB: Expert Options
         self.cbNiceOnCron.setChecked(self.config.niceOnCron())
         self.cbIoniceOnCron.setChecked(self.config.ioniceOnCron())
         self.cbIoniceOnUser.setChecked(self.config.ioniceOnUser())
         self.cbNiceOnRemote.setChecked(self.config.niceOnRemote())
         self.cbIoniceOnRemote.setChecked(self.config.ioniceOnRemote())
-        self.cbNocacheOnLocal.setChecked(self.config.nocacheOnLocal() and self.nocacheAvailable)
+        self.cbNocacheOnLocal.setChecked(
+            self.config.nocacheOnLocal() and self.nocacheAvailable)
         self.cbNocacheOnRemote.setChecked(self.config.nocacheOnRemote())
-        self.cbRedirectStdoutInCron.setChecked(self.config.redirectStdoutInCron())
-        self.cbRedirectStderrInCron.setChecked(self.config.redirectStderrInCron())
+        self.cbRedirectStdoutInCron.setChecked(
+            self.config.redirectStdoutInCron())
+        self.cbRedirectStderrInCron.setChecked(
+            self.config.redirectStderrInCron())
         self.cbBwlimit.setChecked(self.config.bwlimitEnabled())
         self.spbBwlimit.setValue(self.config.bwlimit())
         self.cbPreserveAcl.setChecked(self.config.preserveAcl())
@@ -1193,68 +1378,91 @@ class SettingsDialog(QDialog):
         self.cbSshCheckPing.setChecked(self.config.sshCheckPingHost())
         self.cbSshCheckCommands.setChecked(self.config.sshCheckCommands())
 
-        #update
+        # update
         self.updateRemoveOlder()
         self.updateFreeSpace()
 
     def saveProfile(self):
-        if self.comboSchedule.itemData(self.comboSchedule.currentIndex()) == self.config.CUSTOM_HOUR:
+        item_data = self.comboSchedule.itemData(
+            self.comboSchedule.currentIndex())
+
+        if item_data == self.config.CUSTOM_HOUR:
+
             if not tools.checkCronPattern(self.txtScheduleCronPatern.text()):
-                self.errorHandler(_('Custom Hours can only be a comma separated list of hours (e.g. 8,12,18,23) or */3 for periodic backups every 3 hours'))
+
+                self.errorHandler(
+                    _('Custom Hours can only be a comma separated list of '
+                      'hours (e.g. 8,12,18,23) or */3 for periodic '
+                      'backups every 3 hours')
+                )
+
                 return False
 
-        #mode
+        # mode
         mode = str(self.comboModes.itemData(self.comboModes.currentIndex()))
         self.config.setSnapshotsMode(mode)
         mount_kwargs = {}
 
-        #password
+        # password
         password_1 = self.txtPassword1.text()
         password_2 = self.txtPassword2.text()
 
-
         if mode in ('ssh', 'local_encfs'):
-            mount_kwargs = {'password': password_1
-                            }
+            mount_kwargs = {'password': password_1}
 
         if mode == 'ssh_encfs':
             mount_kwargs = {'ssh_password': password_1,
-                            'encfs_password': password_2,
-                            }
+                            'encfs_password': password_2}
 
-        #snapshots path
+        # snapshots path
         self.config.setHostUserProfile(
-                self.txtHost.text(),
-                self.txtUser.text(),
-                self.txt_profile.text())
+            self.txtHost.text(),
+            self.txtUser.text(),
+            self.txt_profile.text()
+        )
 
-        #save ssh
+        # save ssh
         self.config.setSshHost(self.txtSshHost.text())
         self.config.setSshPort(self.txtSshPort.text())
         self.config.setSshUser(self.txtSshUser.text())
         self.config.setSshSnapshotsPath(self.txtSshPath.text())
-        self.config.setSshCipher(self.comboSshCipher.itemData(self.comboSshCipher.currentIndex()))
+        self.config.setSshCipher(
+            self.comboSshCipher.itemData(self.comboSshCipher.currentIndex()))
+
         if mode in ('ssh', 'ssh_encfs'):
+
             if not self.txtSshPrivateKeyFile.text():
-                if self.questionHandler(_('You did not choose a private key file for SSH.\nWould you like to generate a new password-less public/private key pair?')):
+
+                question = _('You did not choose a private key file for '
+                             'SSH.\nWould you like to generate a new '
+                             'password-less public/private key pair?')
+                if self.questionHandler(question):
                     self.btnSshKeyGenClicked()
+
                 if not self.txtSshPrivateKeyFile.text():
                     return False
+
             if not os.path.isfile(self.txtSshPrivateKeyFile.text()):
-                self.errorHandler(_('Private key file "%(file)s" does not exist.')
-                                  %{'file': self.txtSshPrivateKeyFile.text()})
+                self.errorHandler(
+                    _('Private key file "%(file)s" does not exist.')
+                    % {'file': self.txtSshPrivateKeyFile.text()}
+                )
                 self.txtSshPrivateKeyFile.setText('')
+
                 return False
+
         self.config.setSshPrivateKeyFile(self.txtSshPrivateKeyFile.text())
 
-        #save local_encfs
+        # save local_encfs
         self.config.setLocalEncfsPath(self.editSnapshotsPath.text())
 
-        #include list
-        self.config.setProfileIntValue('qt.settingsdialog.include.SortColumn',
-                                          self.listInclude.header().sortIndicatorSection())
-        self.config.setProfileIntValue('qt.settingsdialog.include.SortOrder',
-                                          self.listInclude.header().sortIndicatorOrder())
+        # include list
+        self.config.setProfileIntValue(
+            'qt.settingsdialog.include.SortColumn',
+            self.listInclude.header().sortIndicatorSection())
+        self.config.setProfileIntValue(
+            'qt.settingsdialog.include.SortOrder',
+            self.listInclude.header().sortIndicatorOrder())
         self.listInclude.sortItems(1, Qt.AscendingOrder)
 
         include_list = []
@@ -1264,11 +1472,13 @@ class SettingsDialog(QDialog):
 
         self.config.setInclude(include_list)
 
-        #exclude patterns
-        self.config.setProfileIntValue('qt.settingsdialog.exclude.SortColumn',
-                                          self.listExclude.header().sortIndicatorSection())
-        self.config.setProfileIntValue('qt.settingsdialog.exclude.SortOrder',
-                                          self.listExclude.header().sortIndicatorOrder())
+        # exclude patterns
+        self.config.setProfileIntValue(
+            'qt.settingsdialog.exclude.SortColumn',
+            self.listExclude.header().sortIndicatorSection())
+        self.config.setProfileIntValue(
+            'qt.settingsdialog.exclude.SortOrder',
+            self.listExclude.header().sortIndicatorOrder())
         self.listExclude.sortItems(1, Qt.AscendingOrder)
 
         exclude_list = []
@@ -1278,49 +1488,66 @@ class SettingsDialog(QDialog):
 
         self.config.setExclude(exclude_list)
         self.config.setExcludeBySize(self.cbExcludeBySize.isChecked(),
-                                        self.spbExcludeBySize.value())
+                                     self.spbExcludeBySize.value())
 
-        #schedule
-        self.config.setScheduleMode(self.comboSchedule.itemData(self.comboSchedule.currentIndex()))
-        self.config.setScheduleTime(self.comboScheduleTime.itemData(self.comboScheduleTime.currentIndex()))
-        self.config.setScheduleWeekday(self.comboScheduleWeekday.itemData(self.comboScheduleWeekday.currentIndex()))
-        self.config.setScheduleDay(self.comboScheduleDay.itemData(self.comboScheduleDay.currentIndex()))
+        # schedule
+        self.config.setScheduleMode(
+            self.comboSchedule.itemData(self.comboSchedule.currentIndex()))
+        self.config.setScheduleTime(
+            self.comboScheduleTime.itemData(
+                self.comboScheduleTime.currentIndex()))
+        self.config.setScheduleWeekday(
+            self.comboScheduleWeekday.itemData(
+                self.comboScheduleWeekday.currentIndex()))
+        self.config.setScheduleDay(
+            self.comboScheduleDay.itemData(
+                self.comboScheduleDay.currentIndex()))
         self.config.setCustomBackupTime(self.txtScheduleCronPatern.text())
-        self.config.setScheduleRepeatedPeriod(self.spbScheduleRepeatedPeriod.value())
-        self.config.setScheduleRepeatedUnit(self.comboScheduleRepeatedUnit.itemData(self.comboScheduleRepeatedUnit.currentIndex()))
+        self.config.setScheduleRepeatedPeriod(
+            self.spbScheduleRepeatedPeriod.value())
+        self.config.setScheduleRepeatedUnit(
+            self.comboScheduleRepeatedUnit.itemData(
+                self.comboScheduleRepeatedUnit.currentIndex()))
 
-        #auto-remove
+        # auto-remove
         self.config.setRemoveOldSnapshots(
                         self.cbRemoveOlder.isChecked(),
                         self.spbRemoveOlder.value(),
-                        self.comboRemoveOlderUnit.itemData(self.comboRemoveOlderUnit.currentIndex()))
+                        self.comboRemoveOlderUnit.itemData(
+                            self.comboRemoveOlderUnit.currentIndex()))
         self.config.setMinFreeSpace(
                         self.cbFreeSpace.isChecked(),
                         self.spbFreeSpace.value(),
-                        self.comboFreeSpaceUnit.itemData(self.comboFreeSpaceUnit.currentIndex()))
+                        self.comboFreeSpaceUnit.itemData(
+                            self.comboFreeSpaceUnit.currentIndex()))
         self.config.setMinFreeInodes(
                         self.cbFreeInodes.isChecked(),
                         self.spbFreeInodes.value())
-        self.config.setDontRemoveNamedSnapshots(self.cbDontRemoveNamedSnapshots.isChecked())
+        self.config.setDontRemoveNamedSnapshots(
+            self.cbDontRemoveNamedSnapshots.isChecked())
         self.config.setSmartRemove(
                         self.cbSmartRemove.isChecked(),
                         self.spbKeepAll.value(),
                         self.spbKeepOnePerDay.value(),
                         self.spbKeepOnePerWeek.value(),
                         self.spbKeepOnePerMonth.value())
-        self.config.setSmartRemoveRunRemoteInBackground(self.cbSmartRemoveRunRemoteInBackground.isChecked())
+        self.config.setSmartRemoveRunRemoteInBackground(
+            self.cbSmartRemoveRunRemoteInBackground.isChecked())
 
-        #options
+        # options
         self.config.setNotify(self.cbNotify.isChecked())
-        self.config.setNoSnapshotOnBattery(self.cbNoSnapshotOnBattery.isChecked())
+        self.config.setNoSnapshotOnBattery(
+            self.cbNoSnapshotOnBattery.isChecked())
         self.config.setGlobalFlock(self.cbGlobalFlock.isChecked())
         self.config.setBackupOnRestore(self.cbBackupOnRestore.isChecked())
         self.config.setContinueOnErrors(self.cbContinueOnErrors.isChecked())
         self.config.setUseChecksum(self.cbUseChecksum.isChecked())
-        self.config.setTakeSnapshotRegardlessOfChanges(self.cbTakeSnapshotRegardlessOfChanges.isChecked())
-        self.config.setLogLevel(self.comboLogLevel.itemData(self.comboLogLevel.currentIndex()))
+        self.config.setTakeSnapshotRegardlessOfChanges(
+            self.cbTakeSnapshotRegardlessOfChanges.isChecked())
+        self.config.setLogLevel(
+            self.comboLogLevel.itemData(self.comboLogLevel.currentIndex()))
 
-        #expert options
+        # expert options
         self.config.setNiceOnCron(self.cbNiceOnCron.isChecked())
         self.config.setIoniceOnCron(self.cbIoniceOnCron.isChecked())
         self.config.setIoniceOnUser(self.cbIoniceOnUser.isChecked())
@@ -1328,8 +1555,10 @@ class SettingsDialog(QDialog):
         self.config.setIoniceOnRemote(self.cbIoniceOnRemote.isChecked())
         self.config.setNocacheOnLocal(self.cbNocacheOnLocal.isChecked())
         self.config.setNocacheOnRemote(self.cbNocacheOnRemote.isChecked())
-        self.config.setRedirectStdoutInCron(self.cbRedirectStdoutInCron.isChecked())
-        self.config.setRedirectStderrInCron(self.cbRedirectStderrInCron.isChecked())
+        self.config.setRedirectStdoutInCron(
+            self.cbRedirectStdoutInCron.isChecked())
+        self.config.setRedirectStderrInCron(
+            self.cbRedirectStderrInCron.isChecked())
         self.config.setBwlimit(self.cbBwlimit.isChecked(),
                                self.spbBwlimit.value())
         self.config.setPreserveAcl(self.cbPreserveAcl.isChecked())
@@ -1343,88 +1572,123 @@ class SettingsDialog(QDialog):
         self.config.setSshCheckPingHost(self.cbSshCheckPing.isChecked())
         self.config.setSshCheckCommands(self.cbSshCheckCommands.isChecked())
 
-        # TODO - consider a single API method to bridge the UI layer (settings dialog) and backend layer (config)
-        # when setting snapshots path rather than having to call the mount module from the UI layer
+        # TODO - consider a single API method to bridge the UI layer
+        # (settings dialog) and backend layer (config)
+        # when setting snapshots path rather than having to call the
+        # mount module from the UI layer
         #
-        # currently, setting snapshots path requires the path to be mounted. it seems that it might be nice,
-        # since the config object is more than a data structure, but has side-effect logic as well, to have the
-        # config.setSnapshotsPath() method take care of everything it needs to perform its job
+        # currently, setting snapshots path requires the path to be mounted.
+        # it seems that it might be nice,
+        # since the config object is more than a data structure, but has
+        # side-effect logic as well, to have the
+        # config.setSnapshotsPath() method take care of everything it needs
+        # to perform its job
         # (mounting and unmounting the fuse filesystem if necessary).
         # https://en.wikipedia.org/wiki/Single_responsibility_principle
 
         if not self.config.SNAPSHOT_MODES[mode][0] is None:
-            #preMountCheck
-            mnt = mount.Mount(cfg = self.config, tmp_mount = True, parent = self)
+            # preMountCheck
+            mnt = mount.Mount(cfg=self.config, tmp_mount=True, parent=self)
+
             try:
-                mnt.preMountCheck(mode = mode, first_run = True, **mount_kwargs)
+                mnt.preMountCheck(mode=mode, first_run=True, **mount_kwargs)
             except NoPubKeyLogin as ex:
                 logger.error(str(ex), self)
-                if self.questionHandler(_('Would you like to copy your public SSH key to the\nremote host to enable password-less login?')) \
-                    and sshtools.sshCopyId(self.config.sshPrivateKeyFile() + '.pub',
-                                           self.config.sshUser(),
-                                           self.config.sshHost(),
-                                           port = str(self.config.sshPort()),
-                                           askPass = tools.which('backintime-askpass'),
-                                           cipher = self.config.sshCipher()):
-                        return self.saveProfile()
+
+                question = _(
+                    'Would you like to copy your public SSH key to the\n'
+                    'remote host to enable password-less login?'
+                )
+                rc_copy_id = sshtools.sshCopyId(
+                    self.config.sshPrivateKeyFile() + '.pub',
+                    self.config.sshUser(),
+                    self.config.sshHost(),
+                    port=str(self.config.sshPort()),
+                    askPass=tools.which('backintime-askpass'),
+                    cipher=self.config.sshCipher()
+                )
+
+                if self.questionHandler(question) and rc_copy_id:
+                    return self.saveProfile()
                 else:
                     return False
+
             except KnownHost as ex:
                 logger.error(str(ex), self)
-                fingerprint, hashedKey, keyType = sshtools.sshHostKey(self.config.sshHost(),
-                                                                      str(self.config.sshPort()))
+                fingerprint, hashedKey, keyType = sshtools.sshHostKey(
+                    self.config.sshHost(), str(self.config.sshPort())
+                )
+
                 if not fingerprint:
                     self.errorHandler(str(ex))
+
                     return False
-                msg = _('The authenticity of host "%(host)s" can\'t be established.\n\n%(keytype)s key fingerprint is:')
-                msg = msg %{'host': self.config.sshHost(),
-                            'keytype': keyType}
+
+                msg = _('The authenticity of host "%(host)s" can\'t be '
+                        'established.\n\n%(keytype)s key fingerprint is:')
+                msg = msg % {'host': self.config.sshHost(),
+                             'keytype': keyType}
                 options = []
                 lblFingerprint = QLabel(fingerprint + '\n')
                 lblFingerprint.setWordWrap(False)
                 lblFingerprint.setFont(QFont('Monospace'))
                 options.append({'widget': lblFingerprint, 'retFunc': None})
-                lblQuestion = QLabel(_('Please verify this fingerprint! Would you like to add it to your \'known_hosts\' file?'))
+                lblQuestion = QLabel(
+                    _('Please verify this fingerprint! Would you like to '
+                      'add it to your \'known_hosts\' file?')
+                )
                 options.append({'widget': lblQuestion, 'retFunc': None})
+
                 if messagebox.warningYesNoOptions(self, msg, options)[0]:
                     sshtools.writeKnownHostsFile(hashedKey)
                     return self.saveProfile()
                 else:
                     return False
+
             except MountException as ex:
                 self.errorHandler(str(ex))
+
                 return False
 
-            #okay, lets try to mount
+            # okay, lets try to mount
             try:
-                hash_id = mnt.mount(mode = mode, check = False, **mount_kwargs)
+                hash_id = mnt.mount(mode=mode, check=False, **mount_kwargs)
+
             except MountException as ex:
                 self.errorHandler(str(ex))
+
                 return False
 
-        #save password
-        self.config.setPasswordSave(self.cbPasswordSave.isChecked(), mode = mode)
-        self.config.setPasswordUseCache(self.cbPasswordUseCache.isChecked(), mode = mode)
-        self.config.setPassword(password_1, mode = mode)
-        self.config.setPassword(password_2, mode = mode, pw_id = 2)
+        # save password
+        self.config.setPasswordSave(self.cbPasswordSave.isChecked(),
+                                    mode=mode)
+        self.config.setPasswordUseCache(self.cbPasswordUseCache.isChecked(),
+                                        mode=mode)
+        self.config.setPassword(password_1, mode=mode)
+        self.config.setPassword(password_2, mode=mode, pw_id=2)
 
-        #save snaphots_path
+        # save snaphots_path
         if self.config.SNAPSHOT_MODES[mode][0] is None:
             snapshots_path = self.editSnapshotsPath.text()
         else:
-            snapshots_path = self.config.snapshotsPath(mode = mode, tmp_mount = True)
+            snapshots_path = self.config.snapshotsPath(mode=mode,
+                                                       tmp_mount=True)
 
-        ret = self.config.setSnapshotsPath(snapshots_path, mode = mode)
+        ret = self.config.setSnapshotsPath(snapshots_path, mode=mode)
+
         if not ret:
             return ret
 
-        #umount
+        # umount
         if not self.config.SNAPSHOT_MODES[mode][0] is None:
+
             try:
-                mnt.umount(hash_id = hash_id)
+                mnt.umount(hash_id=hash_id)
             except MountException as ex:
                 self.errorHandler(str(ex))
+
                 return False
+
         return True
 
     def errorHandler(self, message):
@@ -1485,11 +1749,13 @@ class SettingsDialog(QDialog):
         for key in keys:
             combo.addItem(QIcon(), d[key], key)
 
-    def setComboValue(self, combo, value, t = 'int'):
+    def setComboValue(self, combo, value, t='int'):
         for i in range(combo.count()):
+
             if t == 'int' and value == combo.itemData(i):
                 combo.setCurrentIndex(i)
                 break
+
             if t == 'str' and value == combo.itemData(i):
                 combo.setCurrentIndex(i)
                 break
@@ -1548,7 +1814,7 @@ class SettingsDialog(QDialog):
             self.addExclude_(path)
 
     def btnExcludeFolderClicked(self):
-        for path in qttools.getExistingDirectories(self, _('Exclude folder')) :
+        for path in qttools.getExistingDirectories(self, _('Exclude folder')):
             self.addExclude_(path)
 
     def btnExcludeDefaultClicked(self):
@@ -1572,10 +1838,12 @@ class SettingsDialog(QDialog):
                 continue
 
             if os.path.islink(path) \
-              and not (self.cbCopyUnsafeLinks.isChecked() \
-              or self.cbCopyLinks.isChecked()):
-                if self.questionHandler(\
-                  _('"%s" is a symlink. The linked target will not be backed up until you include it, too.\nWould you like to include the symlinks target instead?') % path):
+                and not (self.cbCopyUnsafeLinks.isChecked()
+                         or self.cbCopyLinks.isChecked()):
+                if self.questionHandler(
+                    _('"%s" is a symlink. The linked target will not be '
+                      'backed up until you include it, too.\nWould you like '
+                      'to include the symlinks target instead?') % path):
                     path = os.path.realpath(path)
 
             path = self.config.preparePath(path)
@@ -1592,10 +1860,12 @@ class SettingsDialog(QDialog):
                 continue
 
             if os.path.islink(path) \
-              and not (self.cbCopyUnsafeLinks.isChecked() \
-              or self.cbCopyLinks.isChecked()):
-                if self.questionHandler(\
-                  _('"%s" is a symlink. The linked target will not be backed up until you include it, too.\nWould you like to include the symlinks target instead?') % path):
+                and not (self.cbCopyUnsafeLinks.isChecked()
+                         or self.cbCopyLinks.isChecked()):
+                if self.questionHandler(
+                    _('"%s" is a symlink. The linked target will not be '
+                      'backed up until you include it, too.\nWould you like '
+                      'to include the symlinks target instead?') % path):
                     path = os.path.realpath(path)
 
             path = self.config.preparePath(path)
@@ -1609,14 +1879,23 @@ class SettingsDialog(QDialog):
     def btnSnapshotsPathClicked(self):
         old_path = self.editSnapshotsPath.text()
 
-        path = str(qttools.getExistingDirectory(self,
-                                                 _('Where to save snapshots'),
-                                                 self.editSnapshotsPath.text()))
+        path = str(qttools.getExistingDirectory(
+            self,
+            _('Where to save snapshots'),
+            self.editSnapshotsPath.text()
+        ))
+
         if path:
+
             if old_path and old_path != path:
-                if not self.questionHandler(_('Are you sure you want to change snapshots folder ?')):
+
+                question = _('Are you sure you want to change '
+                             'snapshots folder ?')
+                if not self.questionHandler(question):
                     return
+
                 self.config.removeProfileKey('snapshots.path.uuid')
+
             self.editSnapshotsPath.setText(self.config.preparePath(path))
 
     def btnSshPrivateKeyFileClicked(self):
@@ -1635,7 +1914,9 @@ class SettingsDialog(QDialog):
         if sshtools.sshKeyGen(key):
             self.txtSshPrivateKeyFile.setText(key)
         else:
-            self.errorHandler(_('Failed to create new SSH key in %(path)s') %{'path': key})
+            self.errorHandler(
+                _('Failed to create new SSH key in %(path)s') % {'path': key}
+            )
 
     def comboModesChanged(self, *params):
         if not params:
@@ -1652,10 +1933,12 @@ class SettingsDialog(QDialog):
             self.mode = active_mode
 
         if self.config.modeNeedPassword(active_mode):
-            self.lblPassword1.setText(self.config.SNAPSHOT_MODES[active_mode][2] + ':')
+            self.lblPassword1.setText(
+                self.config.SNAPSHOT_MODES[active_mode][2] + ':')
             self.groupPassword1.show()
             if self.config.modeNeedPassword(active_mode, 2):
-                self.lblPassword2.setText(self.config.SNAPSHOT_MODES[active_mode][3] + ':')
+                self.lblPassword2.setText(
+                    self.config.SNAPSHOT_MODES[active_mode][3] + ':')
                 self.lblPassword2.show()
                 self.txtPassword2.show()
                 qttools.equalIndent(self.lblPassword1, self.lblPassword2)
@@ -1682,7 +1965,8 @@ class SettingsDialog(QDialog):
         self.cbSshCheckPing.setHidden(not enabled)
         self.cbSshCheckCommands.setHidden(not enabled)
 
-        self.encfsWarning.setHidden(active_mode not in ('local_encfs', 'ssh_encfs'))
+        self.encfsWarning.setHidden(
+            active_mode not in ('local_encfs', 'ssh_encfs'))
 
     def fullPathChanged(self, dummy):
         if self.mode in ('ssh', 'ssh_encfs'):
@@ -1705,12 +1989,16 @@ class SettingsDialog(QDialog):
             self.formatExcludeItem(item)
 
     def formatExcludeItem(self, item):
-        if self.mode == 'ssh_encfs' and tools.patternHasNotEncryptableWildcard(item.text(0)):
+        no_encr_wildcard = tools.patternHasNotEncryptableWildcard(item.text(0))
+        if self.mode == 'ssh_encfs' and no_encr_wildcard:
             item.setIcon(0, self.icon.INVALID_EXCLUDE)
-            item.setBackground(0, QPalette().brush(QPalette.Active, QPalette.Link))
+            item.setBackground(0, QPalette().brush(QPalette.Active,
+                                                   QPalette.Link))
+
         elif item.text(0) in self.config.DEFAULT_EXCLUDE:
             item.setIcon(0, self.icon.DEFAULT_EXCLUDE)
             item.setBackground(0, QBrush())
+
         else:
             item.setIcon(0, self.icon.EXCLUDE)
             item.setBackground(0, QBrush())
@@ -1727,21 +2015,21 @@ class SettingsDialog(QDialog):
         return loop
 
     def includeCustomSortOrder(self, *args):
-        self.listIncludeSortLoop = self.customSortOrder(self.listInclude.header(),
-                                                           self.listIncludeSortLoop,
-                                                           *args)
+        self.listIncludeSortLoop = self.customSortOrder(
+            self.listInclude.header(), self.listIncludeSortLoop, *args)
 
     def excludeCustomSortOrder(self, *args):
-        self.listExcludeSortLoop = self.customSortOrder(self.listExclude.header(),
-                                                           self.listExcludeSortLoop,
-                                                           *args)
+        self.listExcludeSortLoop = self.customSortOrder(
+            self.listExclude.header(), self.listExcludeSortLoop, *args)
 
     def printDefault(self, value):
         if value:
             value_ = _('enabled')
+
         else:
             value_ = _('disabled')
-        return ' (%s: %s)' %(_('default'), value_)
+
+        return ' (%s: %s)' % (_('default'), value_)
 
     def restoreConfig(self, *args):
         RestoreConfigDialog(self).exec_()
@@ -1756,18 +2044,24 @@ class SettingsDialog(QDialog):
 
     def cleanup(self, result):
         self.config.clearHandlers()
+
         if not result:
             self.config.dict = self.configDictCopy
+
         self.config.setCurrentProfile(self.originalCurrentProfile)
+
         if result:
-            self.parent.remount(self.originalCurrentProfile, self.originalCurrentProfile)
+            self.parent.remount(self.originalCurrentProfile,
+                                self.originalCurrentProfile)
             self.parent.updateProfiles()
+
 
 class RestoreConfigDialog(QDialog):
     """
     Show a dialog that will help to restore BITs configuration.
     User can select a config from previous snapshots.
     """
+
     def __init__(self, parent):
         super(RestoreConfigDialog, self).__init__(parent)
 
@@ -1781,38 +2075,48 @@ class RestoreConfigDialog(QDialog):
         self.setWindowTitle(_('Restore Settings'))
 
         layout = QVBoxLayout(self)
-        #show a hint on how the snapshot path will look like.
-        samplePath = os.path.join('backintime',
-                                  self.config.host(),
-                                  self.config.user(), '1',
-                                  snapshots.SID(datetime.datetime.now(), self.config).sid
-                                  )
 
-        #inform user to join group fuse if he hasn't already.
-        #If there is no group fuse than it is most likly not nessesary.
+        # show a hint on how the snapshot path will look like.
+        samplePath = os.path.join(
+            'backintime',
+            self.config.host(),
+            self.config.user(), '1',
+            snapshots.SID(datetime.datetime.now(), self.config).sid
+        )
+
+        # inform user to join group fuse if he hasn't already.
+        # If there is no group fuse than it is most likly not nessesary.
         addFuse = ''
+
         try:
             user = self.config.user()
             fuse_grp_members = grp.getgrnam('fuse')[3]
-            if not user in fuse_grp_members:
+
+            if user not in fuse_grp_members:
                 addFuse = _(' and add your user to group \'fuse\'')
+
         except KeyError:
             pass
 
-        label = QLabel(_('Please navigate to the snapshot from which you want '
-                         'to restore %(appName)s\'s configuration. The path '
-                         'may look like: \n%(samplePath)s\n\n'
-                         'If your snapshots are on a remote drive or if they are '
-                         'encrypted you need to manually mount them first. '
-                         'If you use Mode SSH you also may need to set up public key '
-                         'login to the remote host%(addFuse)s.\n'
-                         'Take a look at \'man backintime\'.')
-                         % {'appName': self.config.APP_NAME, 'samplePath': samplePath,
-                         'addFuse': addFuse}, self)
+        label = QLabel(
+            _('Please navigate to the snapshot from which you want '
+              'to restore %(appName)s\'s configuration. The path '
+              'may look like: \n%(samplePath)s\n\n'
+              'If your snapshots are on a remote drive or if they are '
+              'encrypted you need to manually mount them first. '
+              'If you use Mode SSH you also may need to set up public key '
+              'login to the remote host%(addFuse)s.\n'
+              'Take a look at \'man backintime\'.') % {
+                  'appName': self.config.APP_NAME,
+                  'samplePath': samplePath,
+                  'addFuse': addFuse
+              },
+            self
+        )
         label.setWordWrap(True)
         layout.addWidget(label)
 
-        #treeView
+        # treeView
         self.treeView = qttools.MyTreeView(self)
         self.treeViewModel = QFileSystemModel(self)
         self.treeViewModel.setRootPath(QDir().rootPath())
@@ -1831,38 +2135,40 @@ class RestoreConfigDialog(QDialog):
             self.treeView.setColumnHidden(col, col != 0)
         self.treeView.header().hide()
 
-        #expand users home
+        # expand users home
         self.expandAll(os.path.expanduser('~'))
         layout.addWidget(self.treeView)
 
-        #context menu
+        # context menu
         self.treeView.setContextMenuPolicy(Qt.CustomContextMenu)
         self.treeView.customContextMenuRequested.connect(self.onContextMenu)
         self.contextMenu = QMenu(self)
-        self.btnShowHidden = self.contextMenu.addAction(icon.SHOW_HIDDEN, _('Show hidden files'))
+        self.btnShowHidden = self.contextMenu.addAction(
+            icon.SHOW_HIDDEN, _('Show hidden files'))
         self.btnShowHidden.setCheckable(True)
         self.btnShowHidden.toggled.connect(self.onBtnShowHidden)
 
-        #colors
+        # colors
         self.colorRed = QPalette()
         self.colorRed.setColor(QPalette.WindowText, QColor(205, 0, 0))
         self.colorGreen = QPalette()
         self.colorGreen.setColor(QPalette.WindowText, QColor(0, 160, 0))
 
-        #wait indicator which will show that the scan for snapshots is still running
+        # wait indicator which will show that the scan for
+        # snapshots is still running
         self.wait = QProgressBar(self)
         self.wait.setMinimum(0)
         self.wait.setMaximum(0)
         self.wait.setMaximumHeight(7)
         layout.addWidget(self.wait)
 
-        #show where a snapshot with config was found
+        # show where a snapshot with config was found
         self.lblFound = QLabel(_('No config found'), self)
         self.lblFound.setWordWrap(True)
         self.lblFound.setPalette(self.colorRed)
         layout.addWidget(self.lblFound)
 
-        #show profiles inside the config
+        # show profiles inside the config
         self.widgetProfiles = QWidget(self)
         self.widgetProfiles.setContentsMargins(0, 0, 0, 0)
         self.widgetProfiles.hide()
@@ -1881,7 +2187,8 @@ class RestoreConfigDialog(QDialog):
         self.scan.finished.connect(self.scanFinished)
 
         buttonBox = QDialogButtonBox(self)
-        self.restoreButton = buttonBox.addButton(_('Restore'), QDialogButtonBox.AcceptRole)
+        self.restoreButton = buttonBox.addButton(
+            _('Restore'), QDialogButtonBox.AcceptRole)
         self.restoreButton.setEnabled(False)
         buttonBox.addButton(QDialogButtonBox.Cancel)
         buttonBox.accepted.connect(self.accept)
@@ -1914,7 +2221,8 @@ class RestoreConfigDialog(QDialog):
         """
         cfg = self.searchConfig(self.pathFromIndex(current))
         if cfg:
-            self.expandAll(os.path.dirname(os.path.dirname(cfg._LOCAL_CONFIG_PATH)))
+            self.expandAll(
+                os.path.dirname(os.path.dirname(cfg._LOCAL_CONFIG_PATH)))
             self.lblFound.setText(cfg._LOCAL_CONFIG_PATH)
             self.lblFound.setPalette(self.colorGreen)
             self.showProfile(cfg)
@@ -1934,17 +2242,22 @@ class RestoreConfigDialog(QDialog):
                                     self.config.host(),
                                     self.config.user())
         tryPaths = ['', '..', 'last_snapshot']
-        tryPaths.extend([os.path.join(snapshotPath, str(i), 'last_snapshot') for i in range(10)])
+        tryPaths.extend([
+            os.path.join(snapshotPath, str(i), 'last_snapshot')
+            for i in range(10)])
 
         for p in tryPaths:
             cfgPath = os.path.join(path, p, 'config')
+
             if os.path.exists(cfgPath):
+
                 try:
                     cfg = config.Config(cfgPath)
                     if cfg.isConfigured():
                         return cfg
                 except:
                     pass
+
         return
 
     def expandAll(self, path):
@@ -1964,15 +2277,21 @@ class RestoreConfigDialog(QDialog):
         show information about the profiles inside cfg
         """
         child = self.gridProfiles.takeAt(0)
+
         while child:
             child.widget().deleteLater()
             child = self.gridProfiles.takeAt(0)
+
         for row, profileId in enumerate(cfg.profiles()):
-            for col, txt in enumerate((_('Profile:') + ' ' + str(profileId),
-                                        cfg.profileName(profileId),
-                                        _('Mode:') + ' ' + cfg.SNAPSHOT_MODES[cfg.snapshotsMode(profileId)][1]
-                                        )):
+
+            for col, txt in enumerate((
+                    _('Profile:') + ' ' + str(profileId),
+                    cfg.profileName(profileId),
+                    _('Mode:') + ' ' + cfg.SNAPSHOT_MODES[
+                        cfg.snapshotsMode(profileId)][1]
+                    )):
                 self.gridProfiles.addWidget(QLabel(txt, self), row, col)
+
         self.gridProfiles.setColumnStretch(col, 1)
         self.widgetProfiles.show()
 
@@ -2014,6 +2333,7 @@ class RestoreConfigDialog(QDialog):
         self.scan.stop()
         return ret
 
+
 class ScanFileSystem(QThread):
     CONFIG = 'config'
     BACKUP = 'backup'
@@ -2045,27 +2365,37 @@ class ScanFileSystem(QThread):
             for path in self.scanPath(scan, exclude):
                 self.foundConfig.emit(path)
 
-    def scanPath(self, path, excludes = ()):
+    def scanPath(self, path, excludes=()):
         """
         walk through all folders and try to find 'config' file.
         If found make sure it is nested in backintime/FOO/BAR/1/2345/config and
         return its path.
-        Exclude all paths from excludes and also all backintime/FOO/BAR/1/2345/backup
+        Exclude all paths from excludes and also
+        all backintime/FOO/BAR/1/2345/backup
         """
-        for root, dirs, files in os.walk(path, topdown = True):
+        for root, dirs, files in os.walk(path, topdown=True):
+
             if self.stopper:
                 return
+
             for exclude in excludes:
                 exDir, exBase = os.path.split(exclude)
+
                 if root == exDir:
+
                     if exBase in dirs:
                         del dirs[dirs.index(exBase)]
+
             if self.CONFIG in files:
                 rootdirs = root.split(os.sep)
+
                 if len(rootdirs) > 4 and rootdirs[-5].startswith(self.BACKINTIME):
+
                     if self.BACKUP in dirs:
                         del dirs[dirs.index(self.BACKUP)]
+
                     yield root
+
 
 class EditUserCallback(QDialog):
     def __init__(self, parent):
@@ -2080,42 +2410,61 @@ class EditUserCallback(QDialog):
 
         layout = QVBoxLayout(self)
         self.edit = QPlainTextEdit(self)
+
         try:
             with open(self.script, 'rt') as f:
                 self.edit.setPlainText(f.read())
+
         except IOError:
             pass
+
         layout.addWidget(self.edit)
 
-        btnBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, parent = self)
+        btnBox = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel,
+            parent=self)
+
         btnBox.accepted.connect(self.accept)
         btnBox.rejected.connect(self.reject)
         layout.addWidget(btnBox)
 
     def checkScript(self, script):
         m = re.match(r'^#!(/[\w/-]+)\n', script)
+
         if not m:
-            logger.error('user-callback script has no shebang (#!/bin/sh) line.')
-            self.config.errorHandler(_('user-callback script has no shebang (#!/bin/sh) line.'))
+            logger.error(
+                'user-callback script has no shebang (#!/bin/sh) line.')
+            self.config.errorHandler(
+                _('user-callback script has no shebang (#!/bin/sh) line.'))
+
             return False
+
         if not tools.checkCommand(m.group(1)):
             logger.error('Shebang in user-callback script is not executable.')
-            self.config.errorHandler(_('Shebang in user-callback script is not executable.'))
+            self.config.errorHandler(
+                _('Shebang in user-callback script is not executable.'))
+
             return False
+
         return True
 
     def accept(self):
         if not self.checkScript(self.edit.toPlainText()):
             return
+
         with open(self.script, 'wt') as f:
             f.write(self.edit.toPlainText())
+
         os.chmod(self.script, 0o755)
+
         super(EditUserCallback, self).accept()
+
 
 def debugTrace():
     """
     Set a tracepoint in the Python debugger that works with Qt
     """
     from pdb import set_trace
+
     pyqtRemoveInputHook()
     set_trace()


### PR DESCRIPTION
- Eliminated possible deprecation warnings about invalid escape sequences ([W605](https://www.flake8rules.com/rules/W605.html))
- Eliminated round about 800 PEP8 problems in `settingsdialog.py`
- I didn't touched `create-manpage-backintime-config.py` because of #1354 

I was search for invalid escape sequences via `flake8`.