### PR TITLE
Fix bug: sshMaxArg main function was using only the first profile

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -569,8 +569,9 @@ class Config(configfile.ConfigFileWithProfiles):
         self.setProfileStrValue('snapshots.ssh.private_key_file', value, profile_id)
 
     def sshMaxArgLength(self, profile_id = None):
-        #?Maximum argument length of commands run on remote host. This can be tested
-        #?with 'python3 /usr/share/backintime/common/sshMaxArg.py USER@HOST'.\n
+        #?Maximum command length of commands run on remote host. This can be tested
+        #?for all ssh profiles in the configuration
+        #?with 'python3 /usr/share/backintime/common/sshMaxArg.py [initial_ssh_cmd_length]'.\n
         #?0 = unlimited;0, >700
         value = self.profileIntValue('snapshots.ssh.max_arg_length', 0, profile_id)
         if value and value < 700:

--- a/common/sshMaxArg.py
+++ b/common/sshMaxArg.py
@@ -38,7 +38,7 @@ def probe_max_ssh_command_size(config,
 
     Try a SSH command with length ``ssh_command_size``. The command is
     decreased by ``size_offset`` if it was too long or increased if it worked.
-    The function calls itself in recursively until it finds the maximum
+    The function calls itself recursively until it finds the maximum
     possible length. The offset ``size_offset`` is bisect in each try.
 
     Args:


### PR DESCRIPTION
* Now all profiles with ssh mode are probed for the max ssh cmd length
* Code doc for config property "sshMaxArgLength" updated (used to generate man pages)
* Fix some minor documentation issues

+ Unit tests did work

Output is now:

```
> python3 sshMaxArg.py
Profile 1 - Main profile: Mode = local
Profile 2 - profile 2: Mode = local
Profile 3 - test2config: Mode = local
Profile 4 - ext dev test: Mode = local
Profile 5 - ssh-hello-world: Mode = ssh
Tried length 1,048,320... Python exception: "Argument list too long". Decrease by 524,160 and try again.
Tried length 524,160... Python exception: "Argument list too long". Decrease by 262,080 and try again.
Tried length 262,080... Python exception: "Argument list too long". Decrease by 131,040 and try again.
Tried length 131,040... Can be longer. Increase by 65,520 and try again.
Tried length 196,560... Python exception: "Argument list too long". Decrease by 32,760 and try again.
Tried length 163,800... Python exception: "Argument list too long". Decrease by 16,380 and try again.
Tried length 147,420... Python exception: "Argument list too long". Decrease by 8,190 and try again.
Tried length 139,230... Python exception: "Argument list too long". Decrease by 4,095 and try again.
Tried length 135,135... Python exception: "Argument list too long". Decrease by 2,048 and try again.
Tried length 133,087... Python exception: "Argument list too long". Decrease by 1,024 and try again.
Tried length 132,063... Python exception: "Argument list too long". Decrease by 512 and try again.
Tried length 131,551... Python exception: "Argument list too long". Decrease by 256 and try again.
Tried length 131,295... Python exception: "Argument list too long". Decrease by 128 and try again.
Tried length 131,167... Python exception: "Argument list too long". Decrease by 64 and try again.
Tried length 131,103... Python exception: "Argument list too long". Decrease by 32 and try again.
Tried length 131,071... stderr: "/bin/bash: Argument list too long". Decrease by 16 and try again.
Tried length 131,055... Can be longer. Increase by 8 and try again.
Tried length 131,063... Can be longer. Increase by 4 and try again.
Tried length 131,067... stderr: "/bin/bash: Argument list too long". Decrease by 2 and try again.
Tried length 131,065... stderr: "/bin/bash: Argument list too long". Decrease by 1 and try again.
Tried length 131,064... Found correct length. Adding length of "printf" to it.
Maximum SSH command length between "mycomputer" and "localhost" is 131,070.
```