### PR TITLE
Add logging for Qt5 platform, style, theme and system tray.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ to support all Ubuntu distros (older and newer ones).
 This issue is tracked in [#1338](https://github.com/bit-team/backintime/issues/1338).
 
 
+
+#### Tray icon or other icons not shown correctly
+
+This effect can be caused by missing installations of Qt5-supported
+themes and icons. Back In Time may activate the wrong theme in this
+case leading to some missing icons. A fix for the next release is in preparation.
+
+As clean solution please check your Linux settings (Appearance, Styles, Icons)
+and install all themes and icons packages for your preferred style via
+your package manager.
+
+See issues [#1306](https://github.com/bit-team/backintime/issues/1306)
+and [#1364](https://github.com/bit-team/backintime/issues/1364).
+
+
+
 ## Download
 
 Please find the latest versions on

--- a/qt/icon.py
+++ b/qt/icon.py
@@ -16,6 +16,10 @@
 
 from PyQt5.QtGui import QIcon
 
+# TODO setThemeName() only for available themes -> QStyleFactory.keys()
+#      since this code may activate a theme that is only partially installed
+#      (or not at all in case of the last theme in the list: oxygen)
+#      See issues #1364 and #1306
 for theme in ('ubuntu-mono-dark', 'gnome', 'oxygen'):
     if not QIcon.fromTheme('document-save').isNull():
         break


### PR DESCRIPTION
* Show QT QPA platform plugin in app window title for "--debug"
* Show "root" in app window title if running as root

This is a partial "fix" for #1364 by adding debug output and documenting icon problems as known issue