### PR TITLE
Fix #1003: RTE in logFile.flush() during backup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Version 1.3.3-dev (development of upcoming release)
 * GUI change: Define accelerator keys for menu bar and tabs, as well as toolbar shortcuts (#1104)
 * Desktop integration: Update .desktop file to mark Back In Time as a single main window program (#1258)
 * Improvement: Write all log output to stderr; do not pollute stdout with INFO and WARNING messages anymore (#1337)
+* Bugfix: RTE "reentrant call inside io.BufferedWriter" in logFile.flush() during backup (#1003)
 * Bugfix: Incompatibility with rsync 3.2.4 or later because of rsync's "new argument protection" (#1247). Deactivate "--old-args" rsync argument earlier recommaned to users as a workaround.
 * Bugfix: DeprecationWarnings about invalid escape sequences.
 * Bugfix: AttributeError in "Diff Options" dialog (#898)

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -193,11 +193,19 @@ class SnapshotLog(object):
         if not self.logFile:
             self.logFile = open(self.logFileName, 'at')
         self.logFile.write(msg + '\n')
-        self.timer.start(5)
+        self.timer.start(5)  # flush the log output buffer after 5 seconds
 
     def flush(self):
         """
-        Force write log to file.
+        Write the in-memory buffer of the log output into the log file.
         """
         if self.logFile:
-            self.logFile.flush()
+            try:
+                # TODO flush() does not necessarily write the file’s data to disk.
+                #      Use flush() followed by os.fsync() to ensure this behavior.
+                #      https://docs.python.org/2/library/stdtypes.html#file.flush
+                self.logFile.flush()
+            except RuntimeError as e:
+                # Fixes #1003 (RTE reentrant call inside io.BufferedWriter)
+                # This RTE will not be logged since this would be another reentrant call
+                pass


### PR DESCRIPTION
* RuntimeError "reentrant call inside io.BufferedWriter" in logFile.flush()