### PR TITLE
Unittest: Workaround fix parsing output

### DIFF
--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -138,10 +138,8 @@ under certain conditions; type `backintime --license' for details.
         #       regex but if the BiT serviceHelper.py DBus daemon is not
         #       installed at all the warnings also occur in the middle of below
         #       expected INFO log lines so they are removed by filtering here.
-        # TODO If filtering output rows should become a common testing pattern
-        #      this code should be refactored into a function for re-usability.
+        #       The same goes with Gtk warnings.
 
-        # checked via str.startswith()
         line_beginnings_to_exclude = [
             "WARNING: Failed to connect to Udev serviceHelper",
             "WARNING: D-Bus message:",
@@ -149,11 +147,24 @@ under certain conditions; type `backintime --license' for details.
             "WARNING: Inhibit Suspend failed",
         ]
 
+        line_contains_to_exclude = [
+            "Gtk-WARNING"
+        ]
+
+        # remove lines via startswith()
         filtered_log_output = filter(
             lambda line: not any([
                 line.startswith(ex) for ex in line_beginnings_to_exclude]),
             error.decode().split('\n')
         )
+
+        # remove lines via __contains__()
+        filtered_log_output = filter(
+            lambda line: not any([
+                ex in line for ex in line_contains_to_exclude]),
+            filtered_log_output
+        )
+
         filtered_log_output = '\n'.join(filtered_log_output)
 
         self.assertRegex(filtered_log_output, re.compile(r'''INFO: Lock

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -165,6 +165,12 @@ under certain conditions; type `backintime --license' for details.
             filtered_log_output
         )
 
+        # remove empty lines
+        filtered_log_output = filter(
+            lambda line: line != '\n',
+            filtered_log_output
+        )
+
         filtered_log_output = '\n'.join(filtered_log_output)
 
         self.assertRegex(filtered_log_output, re.compile(r'''INFO: Lock

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -167,7 +167,7 @@ under certain conditions; type `backintime --license' for details.
 
         # remove empty lines
         filtered_log_output = filter(
-            lambda line: line != '\n',
+            lambda line: line,
             filtered_log_output
         )
 
@@ -179,8 +179,7 @@ INFO: Call rsync to take the snapshot
 INFO: Save config file
 INFO: Save permissions
 INFO: Create info file
-INFO: Unlock
-''', re.MULTILINE))
+INFO: Unlock''', re.MULTILINE))
 
         # get snapshot id
         subprocess.check_output(["./backintime",


### PR DESCRIPTION
This should fix the problem with polluted output with Gtk-Warnings while testing (see #1409).

It is still a workaround. The whole test should be refactored. But it is an *integration test* or somewhere higher in the *test pyramid*. It means before refactoring this test a lot of other *unit test* lower in the test pyramid and there affected units need to refactored.

The current workaround is to exclude lines from the catched output before testing that output via `assertRegex`. Some lines removed because they do begin with a string (DBus stuff). Others excluded because they contain a string (Gtk-Warnings).

The filter and exclude mechanic now is more efficient using `filter()` and list comprehension instead of explicit `for` loops.

Because #1409 is not reproducible currently I'm not able to test that.