### PR TITLE
Add ChainerBackend keyring support to fix password lookup error (#1410) 

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Back In Time
 
 Version 1.3.4-dev (development of upcoming release)
 * Project: Renamed branch "master" to "main" and started "gitflow" branching model.
+* Fix bug: Add support for ChainerBackend class as keyring which iterates over all supported keyring backends (#1410)
 
 Version 1.3.3 (2023-01-04)
 * New feature: Command line argument "--diagnostics" to show helpful info for better issue support (#1100)

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/bit-team/backintime
 
 Package: backintime-common
 Architecture: all
-Depends: rsync, cron-daemon, openssh-client, python3-keyring, python3-dbus, ${python3:Depends}, ${misc:Depends}
+Depends: rsync, cron-daemon, openssh-client, python3-keyring, python3-dbus, python3-packaging, ${python3:Depends}, ${misc:Depends}
 Recommends: sshfs, encfs
 Conflicts: backintime
 Replaces: backintime


### PR DESCRIPTION
Fixes #1410 

Urgently required for the upcoming Debian BiT release.

Successfully ested via my local `openSSH` server and a password on my private key file...

For testing you can change the default keyring backend via a config file
(see instructions: https://github.com/bit-team/backintime#non-working-password-safe-and-bit-forgets-passwords-keyring-backend-issues)

Please review.

Further tests welcome.