### PR TITLE
Fix #1429 (Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Back In Time
 Version 1.3.4-dev (development of upcoming release)
 * Project: Renamed branch "master" to "main" and started "gitflow" branching model.
 * Fix bug: Add support for ChainerBackend class as keyring which iterates over all supported keyring backends (#1410)
+# Fix bug: Unit test fails on some machines due to warning "Ignoring XDG_SESSION_TYPE=wayland on Gnome..." (#1429)
 
 Version 1.3.3 (2023-01-04)
 * New feature: Command line argument "--diagnostics" to show helpful info for better issue support (#1100)

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -145,10 +145,12 @@ under certain conditions; type `backintime --license' for details.
             "WARNING: D-Bus message:",
             "WARNING: Udev-based profiles cannot be changed or checked",
             "WARNING: Inhibit Suspend failed",
+            "Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway"
         ]
 
         line_contains_to_exclude = [
-            "Gtk-WARNING"
+            "Gtk-WARNING",
+            "qt.qpa.plugin: Could not find the Qt platform plugin"
         ]
 
         # remove lines via startswith()


### PR DESCRIPTION
Also ignores the qt.qpa.plugin warning:

`qt.qpa.plugin: Could not find the Qt platform plugin "wayland" in ""`
