### PR TITLE
fix: FAQ Url

### DIFF
--- a/common/man/C/backintime.1
+++ b/common/man/C/backintime.1
@@ -145,7 +145,7 @@ remote host (via interactive ssh session) you are ready to go.
 .PP
 If you have questions on how to install and configure the Optware please refer
 to the community of your device. You can also take a look on Back In Time FAQ on
-GitHub https://github.com/bit-team/backintime/wiki/FAQ
+GitHub https://github.com/bit-team/backintime/blob/-/FAQ.md
 .PP
 If you successfully modified your device to be able to make backups over ssh,
 it would be nice if you write a 'How to' on Launchpad's Answers so we can add

--- a/qt/app.py
+++ b/qt/app.py
@@ -998,7 +998,7 @@ class MainWindow(QMainWindow):
         messagebox.showInfo(self, _('Changelog'), msg)
 
     def btnFaqClicked(self):
-        self.openUrl('https://github.com/bit-team/backintime/wiki/FAQ')
+        self.openUrl('https://github.com/bit-team/backintime/blob/-/FAQ.md')
 
     def btnAskQuestionClicked(self):
         self.openUrl('https://github.com/bit-team/backintime/issues')


### PR DESCRIPTION
The manpage and the Help menu in the GUI where pointing to the old FAQ in the Wiki. Now they point to the latest version of `FAQ.md` in the repo.

Beside this PR I also fixed the Wiki that way that users of older BIT versions are redirected to the correct FAQ file. The FAQ page from Wiki is removed and now the users do see the landing page of the Wiki which points to the FAQ.md file.

@Germar One question to you. Do I see it right that the manpage `backintime.1` is written manually and there is not autogeneration/script involved?