### PR TITLE
fix: Ease translation strings

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Version 1.3.4-dev (development of upcoming release)
 * Feature: Exclude /swapfile by default (#1053)
 * Documentation: Removed outdated docbook (#1345).
 * Build: Introduced .readthedocs.yaml as asked by ReadTheDocs.org (#1443).
+* Translation: Strings to translate now easier to understand for translators (#1448).
 
 Version 1.3.3 (2023-01-04)
 * New feature: Command line argument "--diagnostics" to show helpful info for better issue support (#1100)

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -101,8 +101,9 @@ class ConfigFile(object):
                 for key in keys:
                     f.write("%s=%s\n" % (key, self.dict[key]))
         except OSError as e:
-            logger.error('Failed to save config: %s' %str(e), self)
-            self.notifyError(_('Failed to save config: %s') %str(e))
+            logger.error('Failed to save config: %s' % str(e), self)
+            self.notifyError(
+                '{}: {}'.format(_('Failed to save config'), str(e)))
             return False
         return True
 
@@ -133,12 +134,13 @@ class ConfigFile(object):
                 lines = f.readlines()
         except OSError as e:
             logger.error('Failed to load config: %s' %str(e), self)
-            self.notifyError(_('Failed to load config: %s') %str(e))
+            self.notifyError(
+                '{}: {}'.format(_('Failed to load config'), str(e)))
 
         for line in lines:
             items = line.strip('\n').split('=', maxsplit)
             if len(items) == 2:
-                self.dict[items[ 0 ] ] = items[ 1]
+                self.dict[items[0]] = items[1]
 
     def remapKey(self, old_key, new_key):
         """
@@ -620,7 +622,8 @@ class ConfigFileWithProfiles(ConfigFile):
 
         for profile_id in profiles:
             if self.profileName(profile_id) == name:
-                self.notifyError(_('Profile "%s" already exists !') % name)
+                self.notifyError(_(
+                    'Profile "{name}" already exists!').format(name=name))
                 return None
 
         new_id = 1
@@ -660,7 +663,7 @@ class ConfigFileWithProfiles(ConfigFile):
 
         profiles = self.profiles()
         if len(profiles) <= 1:
-            self.notifyError(_('You can\'t remove the last profile !'))
+            self.notifyError(_("You can't remove the last profile!"))
             return False
 
         found = False
@@ -703,7 +706,8 @@ class ConfigFileWithProfiles(ConfigFile):
         for profile in profiles:
             if self.profileName(profile) == name:
                 if profile[0] != profile_id:
-                    self.notifyError(_('Profile "%s" already exists !') % name)
+                    self.notifyError(_(
+                        'Profile "{name}" already exists!').format(name=name))
                     return False
 
         self.setProfileStrValue('name', name, profile_id)

--- a/common/dummytools.py
+++ b/common/dummytools.py
@@ -19,7 +19,7 @@ import gettext
 import config
 import mount
 
-_=gettext.gettext
+_ = gettext.gettext
 
 class Dummy(mount.MountControl):
     """
@@ -75,8 +75,8 @@ class Dummy(mount.MountControl):
 
     def preMountCheck(self, first_run = False):
         """
-        check what ever conditions must be given for the mount to be done successful
-        raise MountException(_('Error discription')) if service can not mount
+        check what ever conditions must be given for the mount to be donesuccessful
+        raise MountException(_('Error description')) if service can not mount
         return True if everything is okay
         all pre|post_[u]mount_check can also be used to prepare things or clean up
         """
@@ -85,20 +85,20 @@ class Dummy(mount.MountControl):
     def postMountCheck(self):
         """
         check if mount was successful
-        raise MountException(_('Error discription')) if not
+        raise MountException(_('Error description')) if not
         """
         return True
 
     def preUmountCheck(self):
         """
         check if service is safe to umount
-        raise MountException(_('Error discription')) if not
+        raise MountException(_('Error description')) if not
         """
         return True
 
     def postUmountCheck(self):
         """
         check if umount successful
-        raise MountException(_('Error discription')) if not
+        raise MountException(_('Error description')) if not
         """
         return True

--- a/common/encfstools.py
+++ b/common/encfstools.py
@@ -84,8 +84,11 @@ class EncFS_mount(MountControl):
             output = proc.communicate()[0]
             self.backupConfig()
             if proc.returncode:
-                raise MountException(_('Can\'t mount \'%(command)s\':\n\n%(error)s') \
-                                        % {'command': ' '.join(encfs), 'error': output})
+                raise MountException(
+                    '{}:\n\n{}'.format(
+                        _("Can't mount '{command}'")
+                        .format(command=' '.join(encfs)),
+                        output))
 
     def preMountCheck(self, first_run = False):
         """
@@ -123,26 +126,37 @@ class EncFS_mount(MountControl):
         ask for password confirmation. _mount will then create a new config
         """
         cfg = self.configFile()
+
         if os.path.isfile(cfg):
             logger.debug('Found encfs config in %s'
                          %cfg, self)
             return True
+
         else:
             logger.debug('No encfs config in %s'
                          %cfg, self)
             msg = _('Config for encrypted folder not found.')
+
             if not self.tmp_mount:
                 raise MountException(msg)
+
             else:
-                if not self.config.askQuestion(msg + _('\nCreate a new encrypted folder?')):
+                question = '{}\n{}'.format(
+                    msg,
+                    _('Create a new encrypted folder?')
+                )
+
+                if not self.config.askQuestion(question):
                     raise MountException(_('Cancel'))
+
                 else:
                     pw = password.Password(self.config)
-                    password_confirm = pw.passwordFromUser(self.parent, prompt = _('Please confirm password'))
+                    password_confirm = pw.passwordFromUser(
+                        self.parent, prompt=_('Please confirm password'))
                     if self.password == password_confirm:
                         return False
                     else:
-                        raise MountException(_('Password doesn\'t match'))
+                        raise MountException(_("Password doesn't match"))
 
     def checkVersion(self):
         """
@@ -158,8 +172,10 @@ class EncFS_mount(MountControl):
             output = proc.communicate()[0]
             m = re.search(r'(\d\.\d\.\d)', output)
             if m and Version(m.group(1)) <= Version('1.7.2'):
-                logger.debug('Wrong encfs version %s' %m.group(1), self)
-                raise MountException(_('encfs version 1.7.2 and before has a bug with option --reverse. Please update encfs'))
+                logger.debug('Wrong encfs version %s' % m.group(1), self)
+                raise MountException(
+                    'encfs version 1.7.2 and before has a bug with '
+                    'option --reverse. Please update encfs')
 
     def backupConfig(self):
         """
@@ -476,20 +492,26 @@ class Decode(object):
     def __init__(self, cfg, string = True):
         self.config = cfg
         self.mode = cfg.snapshotsMode()
+
         if self.mode == 'local_encfs':
             self.password = cfg.password(pw_id = 1)
+
         elif self.mode == 'ssh_encfs':
             self.password = cfg.password(pw_id = 2)
+
         self.encfs = cfg.SNAPSHOT_MODES[self.mode][0](cfg)
         self.remote_path = cfg.sshSnapshotsPath()
+
         if not self.remote_path:
             self.remote_path = './'
+
         if not self.remote_path[-1] == os.sep:
             self.remote_path += os.sep
 
-        #german translation changed from Snapshot to Schnappschuss.
-        #catch both variants otherwise old logs wouldn't get decoded.
-        takeSnapshot = _('Take snapshot').replace('Schnappschuss', '(?:Schnappschuss|Snapshot)')
+        # german translation changed from Snapshot to Schnappschuss.
+        # catch both variants otherwise old logs wouldn't get decoded.
+        takeSnapshot = _('Take snapshot') \
+            .replace('Schnappschuss', '(?:Schnappschuss|Snapshot)')
 
         #precompile some regular expressions
         host, port, user, path, cipher = cfg.sshHostUserPortPathCipher()

--- a/common/mount.py
+++ b/common/mount.py
@@ -27,7 +27,7 @@ import tools
 import password
 from exceptions import MountException, HashCollision
 
-_=gettext.gettext
+_ = gettext.gettext
 
 class Mount(object):
     """
@@ -415,22 +415,33 @@ class MountControl(object):
         """
         self.createMountStructure()
         self.mountProcessLockAcquire()
+
         try:
             if self.mounted():
+
                 if not self.compareUmountInfo():
                     #We probably have a hash collision
                     self.config.incrementHashCollision()
-                    raise HashCollision(_('Hash collision occurred in hash_id %s. Incrementing global value hash_collision and try again.') % self.hash_id)
-                logger.info('Mountpoint %s is already mounted' %self.currentMountpoint, self)
+                    raise HashCollision(
+                        f'Hash collision occurred in hash_id {self.hash_id}. '
+                        'Incrementing global value hash_collision and '
+                        'try again.')
+
+                logger.info('Mountpoint {} is already mounted'
+                            .format(self.currentMountpoint),
+                            self)
             else:
                 if check:
                     self.preMountCheck()
+
                 self._mount()
                 self.postMountCheck()
+
                 logger.info('mount %s on %s'
                             %(self.log_command, self.currentMountpoint),
                             self)
                 self.writeUmountInfo()
+
         except Exception:
             raise
         else:
@@ -494,10 +505,11 @@ class MountControl(object):
         """
         try:
             subprocess.check_call(['fusermount', '-u', self.currentMountpoint])
+
         except subprocess.CalledProcessError:
-            raise MountException(_('Can\'t unmount %(proc)s from %(mountpoint)s')
-                                  %{'proc': self.mountproc,
-                                    'mountpoint': self.currentMountpoint})
+            raise MountException(
+                "Can't unmount {} from {}"
+                .format(self.mountproc, self.currentMountpoint))
 
     def preMountCheck(self, first_run = False):
         """
@@ -580,26 +592,33 @@ class MountControl(object):
                                         user is not in group fuse
         """
         logger.debug('Check fuse', self)
+
         if not tools.checkCommand(self.mountproc):
             logger.debug('%s is missing' %self.mountproc, self)
-            raise MountException(_('%(proc)s not found. Please install e.g. %(install_command)s')
-                                  %{'proc': self.mountproc,
-                                    'install_command': "'apt-get install %s'" %self.mountproc})
+            raise MountException(
+                '{] not found. Please install e.g. {}'
+                .format(self.mountproc,
+                        "'apt-get install %s'" % self.mountproc)
+            )
+
         if self.CHECK_FUSE_GROUP:
             user = self.config.user()
+
             try:
                 fuse_grp_members = grp.getgrnam('fuse')[3]
+
             except KeyError:
                 #group fuse doesn't exist. So most likely it isn't used by this distribution
                 logger.debug("Group fuse doesn't exist. Skip test", self)
                 return
+
             if not user in fuse_grp_members:
-                logger.debug('User %s is not in group fuse' %user, self)
-                raise MountException(_('%(user)s is not member of group \'fuse\'.\n '
-                                        'Run \'sudo adduser %(user)s fuse\'. To apply '
-                                        'changes logout and login again.\nLook at '
-                                        '\'man backintime\' for further instructions.')
-                                        % {'user': user})
+                logger.debug('User %s is not in group fuse' % user, self)
+                raise MountException(
+                    "{user} is not member of group 'fuse'. Run 'sudo adduser "
+                    "{user} fuse'. To apply changes logout and login again."
+                    "\nLook at 'man backintime' for further instructions."
+                    .format(user=user))
 
     def mounted(self):
         """
@@ -614,12 +633,16 @@ class MountControl(object):
         """
         if os.path.ismount(self.currentMountpoint):
             return True
+
         else:
             try:
                 if os.listdir(self.currentMountpoint):
-                    raise MountException(_('mountpoint %s not empty.') % self.currentMountpoint)
+                    raise MountException(
+                        'mountpoint %s not empty.' % self.currentMountpoint)
+
             except FileNotFoundError:
                 pass
+
             return False
 
     def createMountStructure(self):

--- a/common/mount.py
+++ b/common/mount.py
@@ -594,9 +594,9 @@ class MountControl(object):
         logger.debug('Check fuse', self)
 
         if not tools.checkCommand(self.mountproc):
-            logger.debug('%s is missing' %self.mountproc, self)
+            logger.debug('%s is missing' % self.mountproc, self)
             raise MountException(
-                '{] not found. Please install e.g. {}'
+                '{}  not found. Please install e.g. {}'
                 .format(self.mountproc,
                         "'apt-get install %s'" % self.mountproc)
             )

--- a/common/password.py
+++ b/common/password.py
@@ -31,7 +31,7 @@ import password_ipc
 import logger
 from exceptions import Timeout
 
-_=gettext.gettext
+_ = gettext.gettext
 
 
 class Password_Cache(tools.Daemon):
@@ -237,7 +237,13 @@ class Password(object):
         and user is logged in.
         """
         if prompt is None:
-            prompt = _('Profile \'%(profile)s\': Enter password for %(mode)s: ') % {'profile': self.config.profileName(profile_id), 'mode': self.config.SNAPSHOT_MODES[mode][pw_id + 1]}
+            """
+            Profile {name}: Enter password for {mode}
+            """
+            prompt = _("Profile '{profile}': Enter password for {mode}: ") \
+                .format(
+                    profile=self.config.profileName(profile_id),
+                    mode=self.config.SNAPSHOT_MODES[mode][pw_id+1])
 
         tools.registerBackintimePath('qt')
 

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -17,13 +17,10 @@
 
 import os
 import re
-import gettext
 
 import logger
 import snapshots
 import tools
-
-_=gettext.gettext
 
 
 class LogFilter(object):
@@ -59,12 +56,17 @@ class LogFilter(object):
         self.decode = decode
 
         if decode:
-            self.header = _('### This log has been decoded with automatic search pattern\n'\
-                            '### If some paths are not decoded you can manually decode them with:\n')
-            self.header +=  '### \'backintime --quiet '
+            self.header = (
+                '### This log has been decoded with automatic search pattern\n'
+                '### If some paths are not decoded you can manually decode '
+                'them with:\n'
+                '### \'backintime --quiet '
+            )
+
             if int(decode.config.currentProfile()) > 1:
-                self.header +=  '--profile "%s" ' %decode.config.profileName()
+                self.header +=  '--profile "%s" ' % decode.config.profileName()
             self.header +=  '--decode <path>\'\n\n'
+
         else:
             self.header = ''
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -322,7 +322,7 @@ class Snapshots:
         """
         if not callback is None:
             if not ok:
-                msg = msg + " : " + _("FAILED")
+                msg = msg + ' : ' + _('FAILED')
                 self.restorePermissionFailed = True
             callback(msg)
 
@@ -518,7 +518,8 @@ class Snapshots:
         #restore permissions
         logger.info('Restore permissions', self)
         self.restoreCallback(callback, True, ' ')
-        self.restoreCallback(callback, True, _("Restore permissions:"))
+        self.restoreCallback(
+            callback, True, '{}:'.format(_('Restore permissions')))
         self.restorePermissionFailed = False
         fileInfoDict = sid.fileInfo
 
@@ -570,11 +571,18 @@ class Snapshots:
                 self.restorePermission(item_path, real_path, fileInfoDict, callback)
 
             self.restoreCallback(callback, True, '')
+
             if self.restorePermissionFailed:
                 status = _('FAILED')
+
             else:
                 status = _('Done')
-            self.restoreCallback(callback, True, _("Restore permissions:") + ' ' + status)
+
+            self.restoreCallback(
+                callback,
+                True,
+                '{}: {}'.format(_('Restore permissions'), status)
+            )
 
         instance.exitApplication()
 
@@ -869,7 +877,8 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
         if not line:
             return
 
-        self.setTakeSnapshotMessage(0, _('Take snapshot') + " (rsync: %s)" % line)
+        self.setTakeSnapshotMessage(
+            0, _('Take snapshot') + " (rsync: %s)" % line)
 
         if line.endswith(')'):
             if line.startswith('rsync:'):
@@ -896,10 +905,16 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             bool:       ``True`` if successful
         """
         if not tools.makeDirs(path):
-            logger.error("Can't create folder: %s" % path, self)
-            self.setTakeSnapshotMessage(1, _('Can\'t create folder: %s') % path)
-            time.sleep(2) #max 1 backup / second
+            logger.error(f"Can't create folder: {path}", self)
+            self.setTakeSnapshotMessage(
+                1,
+                '{}: {}'.format(
+                    _("Can't create folder"),
+                    path)
+            )
+            time.sleep(2)  # max 1 backup / second
             return False
+
         return True
 
     def backupConfig(self, sid):
@@ -1082,15 +1097,19 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                                         ``ret_error`` is ``True`` if there was
                                         an error during taking the snapshot
         """
-        self.setTakeSnapshotMessage(0, _('...'))
+        self.setTakeSnapshotMessage(0, '...')
 
         new_snapshot = NewSnapshot(self.config)
         encode = self.config.ENCODE
-        params = [False, False] # [error, changes]
+        params = [False, False]  # [error, changes]
 
         if new_snapshot.exists() and new_snapshot.saveToContinue:
             logger.info("Found leftover '%s' which can be continued." %new_snapshot.displayID, self)
-            self.setTakeSnapshotMessage(0, _("Found leftover '%s' which can be continued.") %new_snapshot.displayID)
+            self.setTakeSnapshotMessage(
+                0,
+                _('Found leftover {snapshot_id} which can be continued.')
+                .format(snapshot_id=new_snapshot.displayID)
+            )
             # fix permissions
             for file in os.listdir(new_snapshot.path()):
                 file = os.path.join(new_snapshot.path(), file)
@@ -1101,15 +1120,26 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                     pass
             # search previous log for changes and set params
             params[1] = new_snapshot.hasChanges
+
         elif new_snapshot.exists() and not new_snapshot.saveToContinue:
-            logger.info("Remove leftover '%s' folder from last run" %new_snapshot.displayID)
-            self.setTakeSnapshotMessage(0, _("Removing leftover '%s' folder from last run") %new_snapshot.displayID)
+            logger.info('Remove leftover {} folder from last run'
+                        .format(new_snapshot.displayID))
+            self.setTakeSnapshotMessage(
+                0,
+                _('Removing leftover {snapshot_id} folder from last run')
+                .format(snapshot_id=new_snapshot.displayID)
+            )
             self.remove(new_snapshot)
 
             if os.path.exists(new_snapshot.path()):
                 logger.error("Can't remove folder: %s" % new_snapshot.path(), self)
-                self.setTakeSnapshotMessage(1, _('Can\'t remove folder: %s') % new_snapshot.path())
-                time.sleep(2) #max 1 backup / second
+                self.setTakeSnapshotMessage(
+                    1,
+                    '{}: {}'.format(
+                        _("Can't remove folder"),
+                        new_snapshot.path()))
+                time.sleep(2)  # max 1 backup / second
+
                 return [False, True]
 
         if not new_snapshot.saveToContinue and not new_snapshot.makeDirs():
@@ -1200,15 +1230,19 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                          self)
 
         new_snapshot.saveToContinue = False
-        #rename snapshot
+
+        # rename snapshot
         os.rename(new_snapshot.path(), sid.path())
 
         if not sid.exists():
             logger.error("Can't rename %s to %s" % (new_snapshot.path(), sid.path()), self)
-            self.setTakeSnapshotMessage(1, _('Can\'t rename %(new_path)s to %(path)s')
-                                                 %{'new_path': new_snapshot.path(),
-                                                   'path': sid.path()})
-            time.sleep(2) #max 1 backup / second
+            self.setTakeSnapshotMessage(
+                1,
+                _("Can't rename {new_path} to {path}")
+                .format(new_path=new_snapshot.path(), path=sid.path())
+            )
+            time.sleep(2)  # max 1 backup / second
+
             return [False, True]
 
         self.backupInfo(sid)
@@ -1610,8 +1644,13 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
         #try to keep free inodes
         if self.config.minFreeInodesEnabled():
             minFreeInodes = self.config.minFreeInodes()
-            self.setTakeSnapshotMessage(0, _('Trying to keep min %d%% free inodes') % minFreeInodes)
-            logger.debug("Keep min {}%% free inodes".format(minFreeInodes), self)
+            self.setTakeSnapshotMessage(
+                0,
+                _('Trying to keep min {perc}% free inodes').format(perc=minFreeInodes)
+            )
+            logger.debug(
+                "Keep min {perc}% free inodes".format(perc=minFreeInodes),
+                self)
 
             snapshots = listSnapshots(self.config, reverse = False)
 
@@ -1625,7 +1664,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                     max_inodes  = info.f_files
                 except Exception as e:
                     logger.debug('Failed to get free inodes for snapshot path %s: %s'
-                                 %(self.config.snapshotsPath(), str(e)),
+                                 % (self.config.snapshotsPath(), str(e)),
                                  self)
                     break
 
@@ -2216,7 +2255,8 @@ class SID(object):
             ret += ' - {}'.format(name)
 
         if self.failed:
-            ret += ' ({})'.format(_('WITH ERRORS !'))
+            ret += ' ({})'.format('WITH ERRORS !')
+
         return ret
 
     @property

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -202,7 +202,7 @@ class SSH(MountControl):
 
         if proc.returncode:
             raise MountException(
-                _('Can\'t mount %s') % ' '.join(sshfs) + '\n\n' + err)
+                "Can't mount %s" % " ".join(sshfs) + "\n\n" + err)
 
     def preMountCheck(self, first_run=False):
         """
@@ -404,8 +404,8 @@ class SSH(MountControl):
                     'Was not able to unlock private key %s' %
                     self.private_key_file, self)
                 raise MountException(
-                    _('Could not unlock ssh private key. Wrong password '
-                      'or password not available for cron.'))
+                    'Could not unlock ssh private key. Wrong password '
+                    'or password not available for cron.')
 
         else:
             logger.debug('Private key %s is already unlocked in ssh agent'
@@ -444,9 +444,11 @@ class SSH(MountControl):
 
         if proc.returncode:
             raise NoPubKeyLogin(
-                _('Password-less authentication for %(user)s@%(host)s '
-                  'failed. Look at \'man backintime\' for further '
-                  'instructions.') % {'user': self.user, 'host': self.host}
+                'Password-less authentication for %(user)s@%(host)s '
+                'failed. Look at \'man backintime\' for further '
+                'instructions.' % {
+                    'user': self.user,
+                    'host': self.host}
                 + '\n\n' + err)
 
     def checkCipher(self):
@@ -491,7 +493,7 @@ class SSH(MountControl):
                     self.config.SSH_CIPHERS[self.cipher], self)
 
                 raise MountException(
-                    _('Cipher %(cipher)s failed for %(host)s:\n%(err)s')
+                    'Cipher %(cipher)s failed for %(host)s:\n%(err)s'
                     % {
                         'cipher': self.config.SSH_CIPHERS[self.cipher],
                         'host': self.host,
@@ -583,7 +585,7 @@ class SSH(MountControl):
 
         logger.debug('Host %s is not in known hosts file' % self.host, self)
 
-        raise KnownHost(_('%s not found in ssh_known_hosts.') % self.host)
+        raise KnownHost('%s not found in ssh_known_hosts.' % self.host)
 
     def checkRemoteFolder(self):
         """
@@ -641,20 +643,20 @@ class SSH(MountControl):
 
             elif proc.returncode == 11:
                 raise MountException(
-                    _('Remote path exists but is not a directory:\n %s') %
+                    'Remote path exists but is not a directory:\n %s' %
                     self.path)
 
             elif proc.returncode == 12:
                 raise MountException(
-                    _('Remote path is not writable:\n %s') % self.path)
+                    'Remote path is not writable:\n %s' % self.path)
 
             elif proc.returncode == 13:
                 raise MountException(
-                    _('Remote path is not executable:\n %s') % self.path)
+                    'Remote path is not executable:\n %s' % self.path)
 
             else:
                 raise MountException(
-                    _('Couldn\'t create remote path:\n %s') % self.path)
+                    'Couldn\'t create remote path:\n %s' % self.path)
         else:
 
             # returncode is 0
@@ -709,8 +711,7 @@ class SSH(MountControl):
             logger.debug('Failed pinging host %s' % self.host, self)
 
             raise MountException(
-                _('Ping %s failed. Host is down or wrong address.')
-                % self.host)
+                f'Ping {self.host} failed. Host is down or wrong address.')
 
     def checkRemoteCommands(self, retry=False):
         """
@@ -933,9 +934,9 @@ class SSH(MountControl):
 
                 if output_split[-1].startswith(command):
                     raise MountException(
-                        _('Remote host %(host)s doesn\'t support'
+                        'Remote host %(host)s doesn\'t support'
                           ' \'%(command)s\':\n%(err)s\nLook at \'man '
-                          'backintime\' for further instructions')
+                          'backintime\' for further instructions'
                         % {
                             'host': self.host,
                             'command': output_split[-1],
@@ -944,9 +945,9 @@ class SSH(MountControl):
                     )
 
             raise MountException(
-                _('Check commands on host %(host)s returned unknown error:\n'
-                  '%(err)s\nLook at \'man backintime\' for further '
-                  'instructions') % {'host': self.host, 'err': err})
+                'Check commands on host %(host)s returned unknown error:\n'
+                '%(err)s\nLook at \'man backintime\' for further '
+                'instructions' % {'host': self.host, 'err': err})
 
         inodes = []
 
@@ -962,7 +963,7 @@ class SSH(MountControl):
 
         if len(inodes) == 2 and inodes[0] != inodes[1]:
             raise MountException(
-                _('Remote host %s doesn\'t support hardlinks') % self.host)
+                f"Remote host {self.host} doesn't support hardlinks")
 
     def randomId(self, size=6, chars=string.ascii_uppercase + string.digits):
         """
@@ -1043,11 +1044,11 @@ def sshCopyId(pubkey, user, host, port='22',
     env = os.environ.copy()
     env['SSH_ASKPASS'] = askPass
     env['ASKPASS_MODE'] = 'USER'
-    env['ASKPASS_PROMPT'] \
-        = _('Copy public ssh-key "%(pubkey)s" to remote host "%(host)s".\n'
-            'Please enter password for "%(user)s":') % {'pubkey': pubkey,
-                                                        'host': host,
-                                                        'user': user}
+    env['ASKPASS_PROMPT'] = '{}\n{}:'.format(
+        _('Copy public ssh-key "{pubkey}" to remote host "{host}"').format(
+            pubkey=pubkey, host=host),
+        _('Please enter password for "{user}"').format(user=user)
+    )
 
     cmd = ['ssh-copy-id', '-i', pubkey, '-p', port]
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -228,13 +228,16 @@ class MainWindow(QMainWindow):
 
         #restore menu
         self.menuRestore = qttools.Menu(self)
-        self.btnRestore = self.menuRestore.addAction(icon.RESTORE, _('Restore'))
-        self.btnRestore.setToolTip(_('Restore the selected files or folders '
-                                     'to the original destination.'))
+        self.btnRestore = self.menuRestore.addAction(
+            icon.RESTORE, _('Restore'))
+        self.btnRestore.setToolTip(_(
+            'Restore the selected files or folders to the '
+            'original destination.'))
         self.btnRestore.triggered.connect(self.restoreThis)
-        self.btnRestoreTo = self.menuRestore.addAction(icon.RESTORE_TO, _('Restore to ...'))
-        self.btnRestoreTo.setToolTip(_('Restore the selected files or '
-                                       'folders to a new destination.'))
+        self.btnRestoreTo = self.menuRestore.addAction(
+            icon.RESTORE_TO, _('Restore to ...'))
+        self.btnRestoreTo.setToolTip(_(
+            'Restore the selected files or folders to a new destination.'))
         self.btnRestoreTo.triggered.connect(self.restoreThisTo)
         self.menuRestore.addSeparator()
         self.btnRestoreParent = self.menuRestore.addAction(icon.RESTORE, '')
@@ -242,7 +245,8 @@ class MainWindow(QMainWindow):
                                            'folder and all its content to '
                                            'the original destination.'))
         self.btnRestoreParent.triggered.connect(self.restoreParent)
-        self.btnRestoreParentTo = self.menuRestore.addAction(icon.RESTORE_TO, '')
+        self.btnRestoreParentTo = self.menuRestore.addAction(
+            icon.RESTORE_TO, '')
         self.btnRestoreParentTo.setToolTip(_('Restore the currently shown '
                                              'folder and all its content '
                                              'to a new destination.'))
@@ -251,14 +255,17 @@ class MainWindow(QMainWindow):
 
         for action in self.menuRestore.actions():
             action.setIconVisibleInMenu(True)
-        self.btnRestoreMenu = self.filesViewToolbar.addAction(icon.RESTORE, _('Restore'))
+        self.btnRestoreMenu = self.filesViewToolbar.addAction(
+            icon.RESTORE, _('Restore'))
         self.btnRestoreMenu.setMenu(self.menuRestore)
-        self.btnRestoreMenu.setToolTip(_('Restore selected file or folder.\n'
-                                          'If this button is grayed out this is most likely '
-                                          'because "%(now)s" is selected in left hand snapshots list.') % {'now': _('Now')})
+        self.btnRestoreMenu.setToolTip(_(
+            'Restore selected file or folder.\n'
+            'If this button is grayed out this is most likely because "{now}"'
+            ' is selected in left hand snapshots list.').format(now=_('Now')))
         self.btnRestoreMenu.triggered.connect(self.restoreThis)
 
-        self.btnSnapshots = self.filesViewToolbar.addAction(icon.SNAPSHOTS, _('Snapshots'))
+        self.btnSnapshots = self.filesViewToolbar.addAction(
+            icon.SNAPSHOTS, _('Snapshots'))
         self.btnSnapshots.triggered.connect(self.btnSnapshotsClicked)
 
         filesLayout.addWidget(self.filesViewToolbar)
@@ -327,8 +334,11 @@ class MainWindow(QMainWindow):
         self.places.header().setSectionsClickable(True)
         self.places.header().setSortIndicatorShown(True)
         self.places.header().setSectionHidden(1, True)
-        self.places.header().setSortIndicator(int(self.config.profileIntValue('qt.places.SortColumn', 1)),
-                                                   int(self.config.profileIntValue('qt.places.SortOrder', Qt.AscendingOrder)))
+        self.places.header().setSortIndicator(
+            int(self.config.profileIntValue('qt.places.SortColumn', 1)),
+            int(self.config.profileIntValue(
+                'qt.places.SortOrder', Qt.AscendingOrder))
+        )
         self.placesSortLoop = {self.config.currentProfile(): False}
         self.secondSplitter.addWidget(self.places)
         self.places.header().sortIndicatorChanged.connect(self.sortPlaces)
@@ -339,7 +349,9 @@ class MainWindow(QMainWindow):
         self.secondSplitter.addWidget(widget)
 
         #folder don't exist label
-        self.lblFolderDontExists = QLabel(_('This folder doesn\'t exist\nin the current selected snapshot!'), self)
+        self.lblFolderDontExists = QLabel(_("This folder doesn't exist\nin "
+                                            "the current selected snapshot!"),
+                                          self)
         qttools.setFontBold(self.lblFolderDontExists)
         self.lblFolderDontExists.setFrameShadow(QFrame.Sunken)
         self.lblFolderDontExists.setFrameShape(QFrame.Panel)
@@ -453,19 +465,26 @@ class MainWindow(QMainWindow):
         h = self.config.intValue('qt.main_window.height', 500)
         self.resize(w, h)
 
-        mainSplitterLeftWidth = self.config.intValue('qt.main_window.main_splitter_left_w', 150)
-        mainSplitterRightWidth = self.config.intValue('qt.main_window.main_splitter_right_w', 450)
+        mainSplitterLeftWidth = self.config.intValue(
+            'qt.main_window.main_splitter_left_w', 150)
+        mainSplitterRightWidth = self.config.intValue(
+            'qt.main_window.main_splitter_right_w', 450)
         sizes = [mainSplitterLeftWidth, mainSplitterRightWidth]
         self.mainSplitter.setSizes(sizes)
 
-        secondSplitterLeftWidth = self.config.intValue('qt.main_window.second_splitter_left_w', 150)
-        secondSplitterRightWidth = self.config.intValue('qt.main_window.second_splitter_right_w', 300)
+        secondSplitterLeftWidth = self.config.intValue(
+            'qt.main_window.second_splitter_left_w', 150)
+        secondSplitterRightWidth = self.config.intValue(
+            'qt.main_window.second_splitter_right_w', 300)
         sizes = [secondSplitterLeftWidth, secondSplitterRightWidth]
         self.secondSplitter.setSizes(sizes)
 
-        filesViewColumnNameWidth = self.config.intValue('qt.main_window.files_view.name_width', -1)
-        filesViewColumnSizeWidth = self.config.intValue('qt.main_window.files_view.size_width', -1)
-        filesViewColumnDateWidth = self.config.intValue('qt.main_window.files_view.date_width', -1)
+        filesViewColumnNameWidth = self.config.intValue(
+            'qt.main_window.files_view.name_width', -1)
+        filesViewColumnSizeWidth = self.config.intValue(
+            'qt.main_window.files_view.size_width', -1)
+        filesViewColumnDateWidth = self.config.intValue(
+            'qt.main_window.files_view.date_width', -1)
         if filesViewColumnNameWidth > 0 and filesViewColumnSizeWidth > 0 and filesViewColumnDateWidth > 0:
             self.filesView.header().resizeSection(0, filesViewColumnNameWidth)
             self.filesView.header().resizeSection(1, filesViewColumnSizeWidth)
@@ -473,10 +492,14 @@ class MainWindow(QMainWindow):
 
         #force settingdialog if it is not configured
         if not config.isConfigured():
-            message = _('%(appName)s is not configured. Would you like '
-                        'to restore a previous configuration?' % {'appName': self.config.APP_NAME})
+            message = _(
+                '{appName} is not configured. Would you like '
+                'to restore a previous configuration?') \
+                .format(appName=self.config.APP_NAME)
+
             if QMessageBox.Yes == messagebox.warningYesNo(self, message):
                 settingsdialog.RestoreConfigDialog(self).exec_()
+
             settingsdialog.SettingsDialog(self).exec_()
 
         if not config.isConfigured():
@@ -484,7 +507,7 @@ class MainWindow(QMainWindow):
 
         profile_id = config.currentProfile()
 
-        #mount
+        # mount
         try:
             mnt = mount.Mount(cfg = self.config, profile_id = profile_id, parent = self)
             hash_id = mnt.mount()
@@ -494,7 +517,9 @@ class MainWindow(QMainWindow):
             self.config.setCurrentHashId(hash_id)
 
         if not config.canBackup(profile_id):
-            messagebox.critical(self, _('Can\'t find snapshots folder.\nIf it is on a removable drive please plug it and then press OK'))
+            messagebox.critical(self, _(
+                "Can't find snapshots folder.\nIf it is on a removable "
+                "drive please plug it and then press OK."))
 
         self.filesViewProxyModel.layoutChanged.connect(self.dirListerCompleted)
 
@@ -529,16 +554,21 @@ class MainWindow(QMainWindow):
 
     def closeEvent(self, event):
         if self.shutdown.askBeforeQuit():
-            if QMessageBox.Yes != messagebox.warningYesNo(self, _('If you close this window Back In Time will not be able to shutdown your system when the snapshot has finished.\nDo you really want to close?')):
+            msg = _('If you close this window Back In Time will not be able '
+                    'to shutdown your system when the snapshot has finished.'
+                    '\nDo you really want to close?')
+            if QMessageBox.Yes != messagebox.warningYesNo(self, msg):
                 return event.ignore()
 
         self.config.setStrValue('qt.last_path', self.path)
         self.config.setProfileStrValue('qt.last_path', self.path)
 
-        self.config.setProfileIntValue('qt.places.SortColumn',
-                                          self.places.header().sortIndicatorSection())
-        self.config.setProfileIntValue('qt.places.SortOrder',
-                                          self.places.header().sortIndicatorOrder())
+        self.config.setProfileIntValue(
+            'qt.places.SortColumn',
+            self.places.header().sortIndicatorSection())
+        self.config.setProfileIntValue(
+            'qt.places.SortOrder',
+            self.places.header().sortIndicatorOrder())
 
         self.config.setIntValue('qt.main_window.x', self.x())
         self.config.setIntValue('qt.main_window.y', self.y())
@@ -721,11 +751,13 @@ class MainWindow(QMainWindow):
             self.lastTakeSnapshotMessage = takeSnapshotMessage
 
             if fake_busy:
-                message = _('Working:') + ' ' + self.lastTakeSnapshotMessage[1].replace('\n', ' ')
+                message = _('Working') + ': ' + self.lastTakeSnapshotMessage[1].replace('\n', ' ')
+
             elif takeSnapshotMessage[0] == 0:
                 message = self.lastTakeSnapshotMessage[1].replace('\n', ' ')
+
             else:
-                message = _('Error:') + ' ' + self.lastTakeSnapshotMessage[1].replace('\n', ' ')
+                message = _('Error') + ': ' + self.lastTakeSnapshotMessage[1].replace('\n', ' ')
 
             self.status.setText(message)
 
@@ -745,15 +777,21 @@ class MainWindow(QMainWindow):
         #	self.lastTakeSnapshotMessage = None
 
     def getProgressBarFormat(self, pg, message):
-        d = (('sent',   _('Sent:')), \
-             ('speed',  _('Speed:')),\
-             ('eta',    _('ETA:')))
+        d = (
+            ('sent', '{}:'.format(_('Sent'))),
+            ('speed', '{}:'.format(_('Speed'))),
+            ('eta', '{}:'.format(_('ETA')))
+        )
         yield '{}%'.format(pg.intValue('percent'))
+
         for key, txt in d:
             value = pg.strValue(key, '')
+
             if not value:
                 continue
+
             yield txt + ' ' + value
+
         yield message
 
     def placesChanged(self, item, previous):
@@ -939,19 +977,26 @@ class MainWindow(QMainWindow):
                 #probably because user pressed refresh
                 pass
 
+        # try to use filter(..)
         items = [item for item in self.timeLine.selectedItems() if not isinstance(item, snapshots.RootSnapshot)]
+
         if not items:
             return
 
-        if QMessageBox.Yes != messagebox.warningYesNo(self, \
-                              _('Are you sure you want to remove the snapshot:\n%s') \
-                                %'\n'.join([item.snapshotID().displayName for item in items])):
+        question_msg = '{}:{}'.format(
+            _('Are you sure you want to remove the snapshot'),
+            '\n'.join([item.snapshotID().displayName for item in items]))
+
+        if QMessageBox.Yes != messagebox.warningYesNo(self, question_msg):
             return
 
         for item in items:
+
             item.setDisabled(True)
+
             if item is self.timeLine.currentItem():
                 self.timeLine.selectRootItem()
+
         thread = RemoveSnapshotThread(self, items)
         thread.refreshSnapshotList.connect(self.updateTimeLine)
         thread.hideTimelineItem.connect(hideItem)
@@ -1027,21 +1072,29 @@ class MainWindow(QMainWindow):
         self.updateFilesView(1)
 
     def backupOnRestore(self):
-        cb = QCheckBox(_("Backup local files before overwriting or\nremoving with trailing '%(suffix)s'.")
-                       % {'suffix': self.snapshots.backupSuffix()})
+        cb = QCheckBox(_(
+            'Backup local files before overwriting or\nremoving with '
+            'trailing {suffix}.').format(
+                suffx=self.snapshots.backupSuffix()))
+
         cb.setChecked(self.config.backupOnRestore())
-        cb.setToolTip(_("Newer versions of files will be "
-                        "renamed with trailing '%(suffix)s' "
-                        "before restoring.\n"
-                        "If you don't need them anymore "
-                        "you can remove them with '%(cmd)s'")
-                         %{'suffix': self.snapshots.backupSuffix(),
-                           'cmd': 'find ./ -name "*%s" -delete' % self.snapshots.backupSuffix() })
-        return {'widget': cb, 'retFunc': cb.isChecked, 'id': 'backup'}
+        cb.setToolTip(_(
+            "Newer versions of files will be renamed with trailing "
+            "{suffix} before restoring.\n"
+            "If you don't need them anymore you can remove them with {cmd}")
+            .format(suffix=self.snapshots.backupSuffix(),
+                    cmd='find ./ -name "*{suffix}" -delete'
+                        .format(suffx=self.snapshots.backupSuffix()))
+        )
+        return {
+            'widget': cb,
+            'retFunc': cb.isChecked,
+            'id': 'backup'
+        }
 
     def restoreOnlyNew(self):
-        cb = QCheckBox(_('Only restore files which do not exist or\n'    +\
-                         'are newer than those in destination.\n' +\
+        cb = QCheckBox(_('Only restore files which do not exist or\n'
+                         'are newer than those in destination.\n'
                          'Using "rsync --update" option.'))
         cb.setToolTip("""From 'man rsync':
 
@@ -1085,10 +1138,12 @@ files that the receiver requests to be transferred.""")
 
     def confirmRestore(self, paths, restoreTo = None):
         if restoreTo:
-            msg = _("Do you really want to restore this files(s)\ninto new folder '%(path)s':") \
-                    %{'path': restoreTo}
+            msg = '{}:'.format(
+                _('Do you really want to restore this files(s)\ninto '
+                  'new folder {path}').format(path=restoreTo))
         else:
-            msg = _('Do you really want to restore this files(s):')
+            msg = '{}:'.format(
+                _('Do you really want to restore this files(s)'))
 
         confirm, opt = messagebox.warningYesNoOptions(self,
                                                       msg,
@@ -1100,14 +1155,17 @@ files that the receiver requests to be transferred.""")
 
     def confirmDelete(self, warnRoot = False, restoreTo = None):
         if restoreTo:
-            msg = _("Are you sure you want to remove all newer files "
-                    "in '%(path)s'?") %{'path': restoreTo}
+            msg = _('Are you sure you want to remove all newer files '
+                    'in {path}?').format(path=restoreTo)
         else:
             msg = _('Are you sure you want to remove all newer files in your '
                     'original folder?')
         if warnRoot:
-            msg += '\n\n'
-            msg += _('WARNING: deleting files in filesystem root could break your whole system!!!')
+            msg = '{}\n\n{}'.format(
+                msg,
+                _('WARNING: deleting files in filesystem root could break '
+                  'your whole system!!!'))
+
         return QMessageBox.Yes == messagebox.warningYesNo(self, msg)
 
     def restoreThis(self):
@@ -1312,8 +1370,8 @@ files that the receiver requests to be transferred.""")
             tooltip = _('View the current disk content')
         else:
             name = self.sid.displayName
-            text = _('Snapshot: %s') % name
-            tooltip = _('View the snapshot made at %s') % name
+            text = '{}: {}'.format(_('Snapshot'), name)
+            tooltip = _('View the snapshot made at {name}').format(name=name)
 
         self.filesWidget.setTitle(text)
         self.filesWidget.setToolTip(tooltip)
@@ -1351,8 +1409,10 @@ files that the receiver requests to be transferred.""")
 
         #show current path
         self.editCurrentPath.setText(self.path)
-        self.btnRestoreParent.setText(_("Restore '%s'") % self.path)
-        self.btnRestoreParentTo.setText(_("Restore '%s' to ...") % self.path)
+        self.btnRestoreParent.setText(
+            _('Restore {path}').format(path=self.path))
+        self.btnRestoreParentTo.setText(
+            _('Restore {path} to ...').format(path=self.path))
 
         #update folder_up button state
         self.btnFolderUp.setEnabled(len(self.path) > 1)

--- a/qt/app.py
+++ b/qt/app.py
@@ -1084,7 +1084,7 @@ class MainWindow(QMainWindow):
             "If you don't need them anymore you can remove them with {cmd}")
             .format(suffix=self.snapshots.backupSuffix(),
                     cmd='find ./ -name "*{suffix}" -delete'
-                        .format(suffx=self.snapshots.backupSuffix()))
+                        .format(suffix=self.snapshots.backupSuffix()))
         )
         return {
             'widget': cb,

--- a/qt/app.py
+++ b/qt/app.py
@@ -983,7 +983,7 @@ class MainWindow(QMainWindow):
         if not items:
             return
 
-        question_msg = '{}:{}'.format(
+        question_msg = '{}:\n{}'.format(
             _('Are you sure you want to remove the snapshot'),
             '\n'.join([item.snapshotID().displayName for item in items]))
 

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -63,15 +63,15 @@ class LogViewDialog(QDialog):
         layout = QHBoxLayout()
         self.mainLayout.addLayout(layout)
 
-        #profiles
-        self.lblProfile = QLabel(_('Profile:'), self)
+        # profiles
+        self.lblProfile = QLabel(_('Profile') + ':', self)
         layout.addWidget(self.lblProfile)
 
         self.comboProfiles = qttools.ProfileCombo(self)
         layout.addWidget(self.comboProfiles, 1)
         self.comboProfiles.currentIndexChanged.connect(self.profileChanged)
 
-        #snapshots
+        # snapshots
         self.lblSnapshots = QLabel(_('Snapshots') + ':', self)
         layout.addWidget(self.lblSnapshots)
         self.comboSnapshots = qttools.SnapshotCombo(self)
@@ -85,8 +85,8 @@ class LogViewDialog(QDialog):
             self.lblProfile.hide()
             self.comboProfiles.hide()
 
-        #filter
-        layout.addWidget(QLabel(_('Filter:')))
+        # filter
+        layout.addWidget(QLabel(_('Filter') + ':'))
 
         self.comboFilter = QComboBox(self)
         layout.addWidget(self.comboFilter, 1)
@@ -191,10 +191,20 @@ class LogViewDialog(QDialog):
         edit = QLineEdit(self)
         edit.setText(path)
         edit.setMinimumWidth(600)
-        options = {'widget': edit, 'retFunc': edit.text, 'id': 'path'}
-        confirm, opt = messagebox.warningYesNoOptions(self, _("Do you want to exclude this?"), (options, ))
+        options = {
+            'widget': edit,
+            'retFunc': edit.text,
+            'id': 'path'
+        }
+        confirm, opt = messagebox.warningYesNoOptions(
+            self,
+            _('Do you want to exclude this?'),
+            (options, )
+        )
+
         if not confirm:
             return
+
         exclude.append(opt['path'])
         self.config.setExclude(exclude)
 

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -66,7 +66,8 @@ class QtSysTrayIcon:
         #self.status_icon.actionCollection().clear()
         self.contextMenu = QMenu()
 
-        self.menuProfileName = self.contextMenu.addAction(_('Profile: "%s"') % self.config.profileName())
+        self.menuProfileName = self.contextMenu.addAction(
+            '{}: {}'.format(_('Profile'), self.config.profileName())
         qttools.setFontBold(self.menuProfileName)
         self.contextMenu.addSeparator()
 
@@ -186,13 +187,18 @@ class QtSysTrayIcon:
             self.menuProgress.setVisible(False)
 
     def getMenuProgress(self, pg):
-        d = (('sent',   _('Sent:')), \
-             ('speed',  _('Speed:')),\
-             ('eta',    _('ETA:')))
+        d = (
+            ('sent', _('Sent') + ':'),
+            ('speed', _('Speed') + ':'),
+            ('eta',    _('ETA') + ':')
+        )
+
         for key, txt in d:
             value = pg.strValue(key, '')
+
             if not value:
                 continue
+
             yield txt + ' ' + value
 
     def onStartBIT(self):

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -67,7 +67,7 @@ class QtSysTrayIcon:
         self.contextMenu = QMenu()
 
         self.menuProfileName = self.contextMenu.addAction(
-            '{}: {}'.format(_('Profile'), self.config.profileName())
+            '{}: {}'.format(_('Profile'), self.config.profileName()))
         qttools.setFontBold(self.menuProfileName)
         self.contextMenu.addSeparator()
 

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -109,6 +109,7 @@ def getExistingDirectories(parent, *args, **kwargs):
 
     if dlg.exec_() == QDialog.Accepted:
         return dlg.selectedFiles()
+
     return [str(), ]
 
 def getExistingDirectory(parent, *args, **kwargs):
@@ -393,9 +394,12 @@ class SnapshotItem(TimeLineItem):
         self.setData(0, Qt.UserRole, sid)
 
         if sid.isRoot:
-            self.setToolTip(0, _('This is NOT a snapshot but a live view of your local files'))
+            self.setToolTip(0, _('This is NOT a snapshot but a live '
+                                 'view of your local files'))
         else:
-            self.setToolTip(0, _('Last check %s') %sid.lastChecked)
+            self.setToolTip(
+                0,
+                _('Last check {time}').format(time=id.lastChecked))
 
     def updateText(self):
         sid = self.snapshotID()

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -399,7 +399,7 @@ class SnapshotItem(TimeLineItem):
         else:
             self.setToolTip(
                 0,
-                _('Last check {time}').format(time=id.lastChecked))
+                _('Last check {time}').format(time=sid.lastChecked))
 
     def updateText(self):
         sid = self.snapshotID()

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -96,7 +96,7 @@ class SettingsDialog(QDialog):
         layout = QHBoxLayout()
         self.mainLayout.addLayout(layout)
 
-        layout.addWidget(QLabel(_('Profile:'), self))
+        layout.addWidget(QLabel(_('Profile') + ':', self))
 
         self.firstUpdateAll = True
         self.disableProfileChanged = True
@@ -148,7 +148,7 @@ class SettingsDialog(QDialog):
         vlayout = QVBoxLayout()
         layout.addLayout(vlayout)
 
-        self.lblModes = QLabel(_('Mode:'), self)
+        self.lblModes = QLabel(_('Mode') + ':', self)
 
         self.comboModes = QComboBox(self)
         hlayout = QHBoxLayout()
@@ -161,12 +161,13 @@ class SettingsDialog(QDialog):
         self.fillCombo(self.comboModes, store_modes)
 
         # encfs security warning
-        self.encfsWarning = QLabel(
-            _('<b>Warning:</b> %(app)s uses EncFS for encryption. A recent '
-              'security audit revealed several possible attack vectors for '
-              'this. Please take a look at "A NOTE ON SECURITY" in '
-              '"man backintime".') % {'app': self.config.APP_NAME}
-        )
+        self.encfsWarning = QLabel('<b>{}:</b>{}'.format(
+            _('Warning'),
+            _('{app} uses EncFS for encryption. A recent security audit '
+              'revealed several possible attack vectors for this. Please '
+              'take a look at "A NOTE ON SECURITY" in "man backintime".')
+            .format(app=self.config.APP_NAME)
+        ))
         self.encfsWarning.setWordWrap(True)
         layout.addWidget(self.encfsWarning)
 
@@ -209,34 +210,34 @@ class SettingsDialog(QDialog):
         hlayout3 = QHBoxLayout()
         vlayout.addLayout(hlayout3)
 
-        self.lblSshHost = QLabel(_('Host:'), self)
+        self.lblSshHost = QLabel(_('Host') + ':', self)
         hlayout1.addWidget(self.lblSshHost)
         self.txtSshHost = QLineEdit(self)
         hlayout1.addWidget(self.txtSshHost)
 
-        self.lblSshPort = QLabel(_('Port:'), self)
+        self.lblSshPort = QLabel(_('Port') + ':', self)
         hlayout1.addWidget(self.lblSshPort)
         self.txtSshPort = QLineEdit(self)
         hlayout1.addWidget(self.txtSshPort)
 
-        self.lblSshUser = QLabel(_('User:'), self)
+        self.lblSshUser = QLabel(_('User') + ':', self)
         hlayout1.addWidget(self.lblSshUser)
         self.txtSshUser = QLineEdit(self)
         hlayout1.addWidget(self.txtSshUser)
 
-        self.lblSshPath = QLabel(_('Path:'), self)
+        self.lblSshPath = QLabel(_('Path') + ':', self)
         hlayout2.addWidget(self.lblSshPath)
         self.txtSshPath = QLineEdit(self)
         self.txtSshPath.textChanged.connect(self.fullPathChanged)
         hlayout2.addWidget(self.txtSshPath)
 
-        self.lblSshCipher = QLabel(_('Cipher:'), self)
+        self.lblSshCipher = QLabel(_('Cipher') + ':', self)
         hlayout3.addWidget(self.lblSshCipher)
         self.comboSshCipher = QComboBox(self)
         hlayout3.addWidget(self.comboSshCipher)
         self.fillCombo(self.comboSshCipher, self.config.SSH_CIPHERS)
 
-        self.lblSshPrivateKeyFile = QLabel(_('Private Key:'), self)
+        self.lblSshPrivateKeyFile = QLabel(_('Private Key') + ':', self)
         hlayout3.addWidget(self.lblSshPrivateKeyFile)
         self.txtSshPrivateKeyFile = QLineEdit(self)
         self.txtSshPrivateKeyFile.setReadOnly(True)
@@ -245,7 +246,8 @@ class SettingsDialog(QDialog):
         self.btnSshPrivateKeyFile = QToolButton(self)
         self.btnSshPrivateKeyFile.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.btnSshPrivateKeyFile.setIcon(icon.FOLDER)
-        self.btnSshPrivateKeyFile.setToolTip(_('Choose an existing private key file (normally named "id_rsa")'))
+        self.btnSshPrivateKeyFile.setToolTip(
+            _('Choose an existing private key file (normally named "id_rsa")'))
         self.btnSshPrivateKeyFile.setMinimumSize(32, 28)
         hlayout3.addWidget(self.btnSshPrivateKeyFile)
         self.btnSshPrivateKeyFile.clicked \
@@ -255,7 +257,8 @@ class SettingsDialog(QDialog):
         self.btnSshKeyGen.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.btnSshKeyGen.setIcon(icon.ADD)
         self.btnSshKeyGen.setToolTip(
-            _('Create a new SSH key without password (not allowed if a private key file is already selected)'))
+            _('Create a new SSH key without password (not allowed if a '
+              'private key file is already selected)'))
         self.btnSshKeyGen.setMinimumSize(32, 28)
         hlayout3.addWidget(self.btnSshKeyGen)
         self.btnSshKeyGen.clicked.connect(self.btnSshKeyGenClicked)
@@ -326,25 +329,25 @@ class SettingsDialog(QDialog):
         hlayout2 = QHBoxLayout()
         vlayout2.addLayout(hlayout2)
 
-        self.lblHost = QLabel(_('Host:'), self)
+        self.lblHost = QLabel(_('Host') + ':', self)
         hlayout2.addWidget(self.lblHost)
         self.txtHost = QLineEdit(self)
         self.txtHost.textChanged.connect(self.fullPathChanged)
         hlayout2.addWidget(self.txtHost)
 
-        self.lblUser = QLabel(_('User:'), self)
+        self.lblUser = QLabel(_('User') ':', self)
         hlayout2.addWidget(self.lblUser)
         self.txtUser = QLineEdit(self)
         self.txtUser.textChanged.connect(self.fullPathChanged)
         hlayout2.addWidget(self.txtUser)
 
-        self.lblProfile = QLabel(_('Profile:'), self)
+        self.lblProfile = QLabel(_('Profile') + ':', self)
         hlayout2.addWidget(self.lblProfile)
         self.txt_profile = QLineEdit(self)
         self.txt_profile.textChanged.connect(self.fullPathChanged)
         hlayout2.addWidget(self.txt_profile)
 
-        self.lblFullPath = QLabel(_('Full snapshot path: '), self)
+        self.lblFullPath = QLabel(_('Full snapshot path') + ': ', self)
         self.lblFullPath.setWordWrap(True)
         vlayout2.addWidget(self.lblFullPath)
 
@@ -361,7 +364,7 @@ class SettingsDialog(QDialog):
         glayout.addWidget(self.comboSchedule, 0, 0, 1, 2)
         self.fillCombo(self.comboSchedule, self.config.SCHEDULE_MODES)
 
-        self.lblScheduleDay = QLabel(_('Day:'), self)
+        self.lblScheduleDay = QLabel(_('Day') + ':', self)
         self.lblScheduleDay.setContentsMargins(5, 0, 0, 0)
         self.lblScheduleDay.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         glayout.addWidget(self.lblScheduleDay, 1, 0)
@@ -372,7 +375,7 @@ class SettingsDialog(QDialog):
         for d in range(1, 29):
             self.comboScheduleDay.addItem(QIcon(), str(d), d)
 
-        self.lblScheduleWeekday = QLabel(_('Weekday:'), self)
+        self.lblScheduleWeekday = QLabel(_('Weekday') + ':', self)
         self.lblScheduleWeekday.setContentsMargins(5, 0, 0, 0)
         self.lblScheduleWeekday.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         glayout.addWidget(self.lblScheduleWeekday, 2, 0)
@@ -387,7 +390,7 @@ class SettingsDialog(QDialog):
                 d
             )
 
-        self.lblScheduleTime = QLabel(_('Hour:'), self)
+        self.lblScheduleTime = QLabel(_('Hour') + ':', self)
         self.lblScheduleTime.setContentsMargins(5, 0, 0, 0)
         self.lblScheduleTime.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
         glayout.addWidget(self.lblScheduleTime, 3, 0)
@@ -402,7 +405,7 @@ class SettingsDialog(QDialog):
                 t
             )
 
-        self.lblScheduleCronPatern = QLabel(_('Hours:'), self)
+        self.lblScheduleCronPatern = QLabel(_('Hours') + ':', self)
         self.lblScheduleCronPatern.setContentsMargins(5, 0, 0, 0)
         self.lblScheduleCronPatern.setAlignment(
             Qt.AlignRight | Qt.AlignVCenter)
@@ -420,7 +423,7 @@ class SettingsDialog(QDialog):
         self.lblScheduleRepeated.setWordWrap(True)
         glayout.addWidget(self.lblScheduleRepeated, 5, 0, 1, 2)
 
-        self.lblScheduleRepeatedPeriod = QLabel(_('Every:'))
+        self.lblScheduleRepeatedPeriod = QLabel(_('Every') + ':')
         self.lblScheduleRepeatedPeriod.setContentsMargins(5, 0, 0, 0)
         self.lblScheduleRepeatedPeriod.setAlignment(
             Qt.AlignRight | Qt.AlignVCenter)
@@ -586,7 +589,7 @@ class SettingsDialog(QDialog):
         layout = QGridLayout(layoutWidget)
 
         # remove old snapshots
-        self.cbRemoveOlder = QCheckBox(_('Older than:'), self)
+        self.cbRemoveOlder = QCheckBox(_('Older than') + ':', self)
         layout.addWidget(self.cbRemoveOlder, 0, 0)
         self.cbRemoveOlder.stateChanged.connect(self.updateRemoveOlder)
 
@@ -602,7 +605,8 @@ class SettingsDialog(QDialog):
         # min free space
         enabled, value, unit = self.config.minFreeSpace()
 
-        self.cbFreeSpace = QCheckBox(_('If free space is less than:'), self)
+        self.cbFreeSpace = QCheckBox(
+            _('If free space is less than') + ':', self)
         layout.addWidget(self.cbFreeSpace, 1, 0)
         self.cbFreeSpace.stateChanged.connect(self.updateFreeSpace)
 
@@ -616,7 +620,8 @@ class SettingsDialog(QDialog):
                        self.config.MIN_FREE_SPACE_UNITS)
 
         # min free inodes
-        self.cbFreeInodes = QCheckBox(_('If free inodes is less than:'), self)
+        self.cbFreeInodes = QCheckBox(
+            _('If free inodes is less than') + ':', self)
         layout.addWidget(self.cbFreeInodes, 2, 0)
 
         self.spbFreeInodes = QSpinBox(self)
@@ -723,14 +728,14 @@ class SettingsDialog(QDialog):
         self.cbBackupOnRestore = QCheckBox(
             _('Backup replaced files on restore'), self)
         self.cbBackupOnRestore.setToolTip(
-            _("Newer versions of files will be renamed with "
-              "trailing '%(suffix)s' before restoring.\n"
-              "If you don't need them anymore you can remove them "
-              "with '%(cmd)s'") % {
-                  'suffix': self.snapshots.backupSuffix(),
-                  'cmd': 'find ./ -name "*%s" -delete' %
-                  self.snapshots.backupSuffix()
-              })
+            _("Newer versions of files will be renamed with trailing "
+              "{suffix} before restoring.\n"
+              "If you don't need them anymore you can remove them with {cmd}")
+            .format(suffix=self.snapshots.backupSuffix(),
+                    cmd='find ./ -name "*{suffix}" -delete'
+                        .format(suffix=self.snapshots.backupSuffix())
+                    )
+        )
         layout.addWidget(self.cbBackupOnRestore)
 
         self.cbContinueOnErrors = QCheckBox(
@@ -749,14 +754,15 @@ class SettingsDialog(QDialog):
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
 
-        hlayout.addWidget(QLabel(_('Log Level:'), self))
+        hlayout.addWidget(QLabel(_('Log Level') + ':', self))
 
         self.comboLogLevel = QComboBox(self)
         hlayout.addWidget(self.comboLogLevel, 1)
 
         self.comboLogLevel.addItem(QIcon(), _('None'), 0)
         self.comboLogLevel.addItem(QIcon(), _('Errors'), 1)
-        self.comboLogLevel.addItem(QIcon(), _('Changes & Errors'), 2)
+        self.comboLogLevel.addItem(QIcon(),
+                                   _('Changes') + ' & ' + _('Errors'), 2)
         self.comboLogLevel.addItem(QIcon(), _('All'), 3)
 
         #
@@ -779,7 +785,7 @@ class SettingsDialog(QDialog):
         qttools.setFontBold(label)
         layout.addWidget(label)
 
-        label = QLabel(_("Run 'rsync' with 'nice':"))
+        label = QLabel(_("Run 'rsync' with '{cmd}':").format(cmd='nice'))
         layout.addWidget(label)
         grid = QGridLayout()
         grid.setColumnMinimumWidth(0, 20)
@@ -795,7 +801,7 @@ class SettingsDialog(QDialog):
                 self.config.DEFAULT_RUN_NICE_ON_REMOTE), self)
         grid.addWidget(self.cbNiceOnRemote, 1, 1)
 
-        label = QLabel(_("Run 'rsync' with 'ionice':"))
+        label = QLabel(_("Run 'rsync' with '{cmd}':").format(cmd='ionice'))
         layout.addWidget(label)
         grid = QGridLayout()
         grid.setColumnMinimumWidth(0, 20)
@@ -817,7 +823,8 @@ class SettingsDialog(QDialog):
         grid.addWidget(self.cbIoniceOnRemote, 2, 1)
 
         self.nocacheAvailable = tools.checkCommand('nocache')
-        txt = _("Run 'rsync' with 'nocache':")
+        txt = _("Run 'rsync' with '{cmd}':").format(cmd='nocache')
+
         if not self.nocacheAvailable:
             txt += ' ' + _("(Please install 'nocache' to enable this option)")
         layout.addWidget(QLabel(txt))
@@ -857,7 +864,8 @@ class SettingsDialog(QDialog):
         # bwlimit
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
-        self.cbBwlimit = QCheckBox(_('Limit rsync bandwidth usage: '), self)
+        self.cbBwlimit = QCheckBox(
+            _('Limit rsync bandwidth usage') + ': ', self)
         hlayout.addWidget(self.cbBwlimit)
         self.spbBwlimit = QSpinBox(self)
         self.spbBwlimit.setSuffix(_(' KB/sec'))
@@ -1841,10 +1849,14 @@ class SettingsDialog(QDialog):
             if os.path.islink(path) \
                 and not (self.cbCopyUnsafeLinks.isChecked()
                          or self.cbCopyLinks.isChecked()):
-                if self.questionHandler(
-                    _('"%s" is a symlink. The linked target will not be '
+
+                question_msg = _(
+                    '"{path}" is a symlink. The linked target will not be '
                       'backed up until you include it, too.\nWould you like '
-                      'to include the symlinks target instead?') % path):
+                      'to include the symlinks target instead?'
+                ).format(path=path)
+
+                if self.questionHandler(question_msg):
                     path = os.path.realpath(path)
 
             path = self.config.preparePath(path)
@@ -1915,9 +1927,8 @@ class SettingsDialog(QDialog):
         if sshtools.sshKeyGen(key):
             self.txtSshPrivateKeyFile.setText(key)
         else:
-            self.errorHandler(
-                _('Failed to create new SSH key in %(path)s') % {'path': key}
-            )
+            self.errorHandler(_('Failed to create new SSH key in {path}')
+                              .format(path=key))
 
     def comboModesChanged(self, *params):
         if not params:
@@ -2286,9 +2297,9 @@ class RestoreConfigDialog(QDialog):
         for row, profileId in enumerate(cfg.profiles()):
 
             for col, txt in enumerate((
-                    _('Profile:') + ' ' + str(profileId),
+                    _('Profile') + ': ' + str(profileId),
                     cfg.profileName(profileId),
-                    _('Mode:') + ' ' + cfg.SNAPSHOT_MODES[
+                    _('Mode') + ': ' + cfg.SNAPSHOT_MODES[
                         cfg.snapshotsMode(profileId)][1]
                     )):
                 self.gridProfiles.addWidget(QLabel(txt, self), row, col)

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -335,7 +335,7 @@ class SettingsDialog(QDialog):
         self.txtHost.textChanged.connect(self.fullPathChanged)
         hlayout2.addWidget(self.txtHost)
 
-        self.lblUser = QLabel(_('User') ':', self)
+        self.lblUser = QLabel(_('User') + ':', self)
         hlayout2.addWidget(self.lblUser)
         self.txtUser = QLineEdit(self)
         self.txtUser.textChanged.connect(self.fullPathChanged)

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -57,11 +57,11 @@ class DiffOptionsDialog(QDialog):
         self.diffCmd = self.config.strValue('qt.diff.cmd', DIFF_CMD)
         self.diffParams = self.config.strValue('qt.diff.params', DIFF_PARAMS)
 
-        self.mainLayout.addWidget(QLabel(_('Command:')), 0, 0)
+        self.mainLayout.addWidget(QLabel(_('Command') + ':'), 0, 0)
         self.editCmd = QLineEdit(self.diffCmd, self)
         self.mainLayout.addWidget(self.editCmd, 0, 1)
 
-        self.mainLayout.addWidget(QLabel(_('Parameters:')), 1, 0)
+        self.mainLayout.addWidget(QLabel(_('Parameters') + ':'), 1, 0)
         self.editParams = QLineEdit(self.diffParams, self)
         self.mainLayout.addWidget(self.editParams, 1, 1)
 
@@ -108,15 +108,18 @@ class SnapshotsDialog(QDialog):
         self.mainLayout.addWidget(self.editPath)
 
         #list different snapshots only
-        self.cbOnlyDifferentSnapshots = QCheckBox(_('List only different snapshots'), self)
+        self.cbOnlyDifferentSnapshots = QCheckBox(
+            _('List only different snapshots'), self)
         self.mainLayout.addWidget(self.cbOnlyDifferentSnapshots)
         self.cbOnlyDifferentSnapshots.stateChanged.connect(self.cbOnlyDifferentSnapshotsChanged)
 
         #list equal snapshots only
         layout = QHBoxLayout()
         self.mainLayout.addLayout(layout)
-        self.cbOnlyEqualSnapshots = QCheckBox(_('List only equal snapshots to: '), self)
-        self.cbOnlyEqualSnapshots.stateChanged.connect(self.cbOnlyEqualSnapshotsChanged)
+        self.cbOnlyEqualSnapshots = QCheckBox(
+            _('List only equal snapshots to: '), self)
+        self.cbOnlyEqualSnapshots.stateChanged.connect(
+            self.cbOnlyEqualSnapshotsChanged)
         layout.addWidget(self.cbOnlyEqualSnapshots)
 
         self.comboEqualTo = qttools.SnapshotCombo(self)
@@ -124,7 +127,7 @@ class SnapshotsDialog(QDialog):
         self.comboEqualTo.setEnabled(False)
         layout.addWidget(self.comboEqualTo)
 
-        #deep check
+        # deep check
         self.cbDeepCheck = QCheckBox(_('Deep check (more accurate, but slow)'), self)
         self.mainLayout.addWidget(self.cbDeepCheck)
         self.cbDeepCheck.stateChanged.connect(self.cbDeepCheckChanged)
@@ -321,16 +324,18 @@ class SnapshotsDialog(QDialog):
         path1 = sid1.pathBackup(self.path)
         path2 = sid2.pathBackup(self.path)
 
-        #check if the 2 paths are different
+        # check if the 2 paths are different
         if path1 == path2:
-            messagebox.critical(self, _('You can\'t compare a snapshot to itself'))
+            messagebox.critical(
+                self, _("You can't compare a snapshot to itself"))
             return
 
         diffCmd = self.config.strValue('qt.diff.cmd', DIFF_CMD)
         diffParams = self.config.strValue('qt.diff.params', DIFF_PARAMS)
 
         if not tools.checkCommand(diffCmd):
-            messagebox.critical(self, _('Command not found: %s') % diffCmd)
+            messagebox.critical(
+                self, '{}: {}'.format(_('Command not found'), diffCmd)
             return
 
         # prevent backup data from being accidentally overwritten
@@ -355,15 +360,23 @@ class SnapshotsDialog(QDialog):
 
     def btnDeleteClicked(self):
         items = self.timeLine.selectedItems()
+
         if not items:
             return
+
         elif len(items) == 1:
-            msg = _('Do you really want to delete "%(file)s" in snapshot "%(snapshot_id)s?\n') \
-                    % {'file' : self.path, 'snapshot_id' : items[0].snapshotID()}
+            msg = _('Do you really want to delete "{file}" in snapshot '
+                    '"{snapshot_id}"?').format(
+                        file=self.path, snapshot_id=items[0].snapshotID())
+
         else:
-            msg = _('Do you really want to delete "%(file)s" in %(count)d snapshots?\n') \
-                    % {'file' : self.path, 'count' : len(items)}
-        msg += _('WARNING: This can not be revoked!')
+            msg = _('Do you really want to delete "{file}" in {count} '
+                    'snapshots?').format(
+                        file=self.path, count=len(items))
+
+        msg = '{}\n{}: {}'.format(
+            msg, _('WARNING'), _('This can not be revoked!'))
+
         if QMessageBox.Yes == messagebox.warningYesNo(self, msg):
             for item in items:
                 item.setFlags(Qt.NoItemFlags)
@@ -378,7 +391,9 @@ class SnapshotsDialog(QDialog):
             thread.start()
 
             exclude = self.config.exclude()
-            msg = _('Exclude "%s" from future snapshots?' % self.path)
+            msg = _('Exclude "{path}" from future snapshots?').format(
+                path=self.path)
+
             if self.path not in exclude and QMessageBox.Yes == messagebox.warningYesNo(self, msg):
                 exclude.append(self.path)
                 self.config.setExclude(exclude)

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -336,6 +336,7 @@ class SnapshotsDialog(QDialog):
         if not tools.checkCommand(diffCmd):
             messagebox.critical(
                 self, '{}: {}'.format(_('Command not found'), diffCmd)
+            )
             return
 
         # prevent backup data from being accidentally overwritten


### PR DESCRIPTION
Now translatable strings are simplified and easier to understand for non-technical translators using our platform.
On the other side all translations now need a rework. But IMHO this is OK because there is no near release planned.

- "Cryptic" (format) characters and escape sequences are removed from the strings where ever possible. E.g. `'You don\'t can'` is now `"You don't can"`
- Strings are generalized where every possible to reduce the amount of translatable strings. E.g. `_("Profile:")` now is `_("Profile") + ":"`
- The context of a strings is now IMHO easier to understand. E.g. `_("Can not load %s")` now is `_("Can not load {path}").format(path=self.fancyvar)`
- Some translations are totally removed; e.g. Exceptions don't need to be translated because they are not intended to be read by users (if we do a good job), and crypto-alogrithm-names like SSH256 don't need a translation.

After this PR I can do a fresh transfer between the repo and weblate to see how many strings are left. Before this PR we do have 354 translatable strings.

I will do some more live tests on a virtual machine because this type of modification is not covered by unittests.

There is a high risk of bugs introduced. But they should be of minor type; e.g. typos or problems with parenthesis.