### PR TITLE
fix: "5 minutes" translation and fine tuning strings

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -163,14 +163,30 @@ class Config(configfile.ConfigFileWithProfiles):
     DEFAULT_REDIRECT_STDOUT_IN_CRON = True
     DEFAULT_REDIRECT_STDERR_IN_CRON = False
 
-    exp = _(' EXPERIMENTAL!')
     SNAPSHOT_MODES = {
-                #mode           : (<mounttools>,            'ComboBox Text',        need_pw|lbl_pw_1,       need_2_pw|lbl_pw_2),
-                'local'         : (None,                    _('Local'),             False,                  False),
-                'ssh'           : (sshtools.SSH,            _('SSH'),               _('SSH private key'),   False),
-                'local_encfs'   : (encfstools.EncFS_mount,  _('Local encrypted'),   _('Encryption'),        False),
-                'ssh_encfs'     : (encfstools.EncFS_SSH,    _('SSH encrypted'),     _('SSH private key'),   _('Encryption'))
-                }
+                # mode: (
+                #     <mounttools>,
+                #     'ComboBox Text',
+                #     need_pw|lbl_pw_1,
+                #     need_2_pw|lbl_pw_2
+                # ),
+                'local': (
+                    None, _('Local'), False, False),
+                'ssh': (
+                    sshtools.SSH, 'SSH', _('SSH private key'), False),
+                'local_encfs': (
+                    encfstools.EncFS_mount,
+                    '{} {}'.format(_('Local'), _('encrypted')),
+                    _('Encryption'),
+                    False
+                ),
+                'ssh_encfs': (
+                    encfstools.EncFS_SSH,
+                    _('SSH encrypted'),
+                    _('SSH private key'),
+                    _('Encryption')
+                )
+    }
 
     SSH_CIPHERS = {
         'default': _('Default'),

--- a/common/config.py
+++ b/common/config.py
@@ -94,7 +94,7 @@ class Config(configfile.ConfigFileWithProfiles):
     SCHEDULE_MODES = {
                 NONE: _('Disabled'),
                 AT_EVERY_BOOT: _('At every boot/reboot'),
-                _5_MIN: _('Every {n} minutes'),
+                _5_MIN: _('Every {n} minutes').format(n=5),
                 _10_MIN: _('Every {n} minutes').format(n=10),
                 _30_MIN: _('Every {n} minutes').format(n=30),
                 _1_HOUR: _('Every hour'),

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -926,7 +926,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             sid (SID):  snapshot in which the config should be stored
         """
         logger.info('Save config file', self)
-        self.setTakeSnapshotMessage(0, _('Saving config file...'))
+        self.setTakeSnapshotMessage(0, _('Saving config file…'))
 
         with open(self.config._LOCAL_CONFIG_PATH, 'rb') as src:
 
@@ -1002,7 +1002,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             int: Return code of rsync.
         """
         logger.info('Save permissions', self)
-        self.setTakeSnapshotMessage(0, _('Saving permissions...'))
+        self.setTakeSnapshotMessage(0, _('Saving permissions…'))
 
         fileInfoDict = FileInfoDict()
 
@@ -1097,7 +1097,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                                         ``ret_error`` is ``True`` if there was
                                         an error during taking the snapshot
         """
-        self.setTakeSnapshotMessage(0, '...')
+        self.setTakeSnapshotMessage(0, '…')
 
         new_snapshot = NewSnapshot(self.config)
         encode = self.config.ENCODE

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1646,8 +1646,8 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             minFreeInodes = self.config.minFreeInodes()
             self.setTakeSnapshotMessage(
                 0,
-                _('Trying to keep min {perc}% free inodes')
-                .format(perc=minFreeInodes)
+                _('Trying to keep min {perc} free inodes')
+                .format(perc=f'{minFreeInodes}%')
             )
             logger.debug(
                 "Keep min {perc}% free inodes".format(perc=minFreeInodes),

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -785,7 +785,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
 
                             if ret_error:
                                 logger.error('Failed to take snapshot !!!', self)
-                                self.setTakeSnapshotMessage(1, _('Failed to take snapshot %s !!!') % sid.displayID)
+                                self.setTakeSnapshotMessage(1, _('Failed to take snapshot {snapshot_id} !!!').format(snapshot_id=sid.displayID))
                                 time.sleep(2)
                             else:
                                 logger.warning("No new snapshot", self)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -926,7 +926,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             sid (SID):  snapshot in which the config should be stored
         """
         logger.info('Save config file', self)
-        self.setTakeSnapshotMessage(0, _('Saving config file…'))
+        self.setTakeSnapshotMessage(0, _('Saving config file...'))
 
         with open(self.config._LOCAL_CONFIG_PATH, 'rb') as src:
 
@@ -1002,7 +1002,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             int: Return code of rsync.
         """
         logger.info('Save permissions', self)
-        self.setTakeSnapshotMessage(0, _('Saving permissions…'))
+        self.setTakeSnapshotMessage(0, _('Saving permissions...'))
 
         fileInfoDict = FileInfoDict()
 
@@ -1097,7 +1097,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                                         ``ret_error`` is ``True`` if there was
                                         an error during taking the snapshot
         """
-        self.setTakeSnapshotMessage(0, '…')
+        self.setTakeSnapshotMessage(0, '...')
 
         new_snapshot = NewSnapshot(self.config)
         encode = self.config.ENCODE

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -96,7 +96,10 @@ class QtSysTrayIcon:
 
         self.openLog = self.contextMenu.addAction(icon.VIEW_LAST_LOG, _('View Last Log'))
         self.openLog.triggered.connect(self.onOpenLog)
-        self.startBIT = self.contextMenu.addAction(icon.BIT_LOGO, _('Start BackInTime'))
+        self.startBIT = self.contextMenu.addAction(
+            icon.BIT_LOGO,
+            _('Start {appname}').format(appname=self.config.APP_NAME)
+        )
         self.startBIT.triggered.connect(self.onStartBIT)
         self.status_icon.setContextMenu(self.contextMenu)
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -500,9 +500,16 @@ class SettingsDialog(QDialog):
         layout = QVBoxLayout(tabWidget)
 
         self.lblSshEncfsExcludeWarning = QLabel(
-            _('<b>Warning:</b> Wildcards (\'foo*\', \'[fF]oo\', \'fo?\') '
-              'will be ignored with mode \'SSH encrypted\'.\nOnly separate '
-              'asterisk are allowed (\'foo/*\', \'foo/**/bar\')'), self)
+            "<b>{}:</b> {}".format(
+                _("Warning"),
+                _(
+                    "Wildcards ('foo*', '[fF]oo', 'fo?') will be ignored "
+                    "with mode 'SSH encrypted'.\nOnly separate asterisk "
+                    "are allowed ('foo/*', 'foo/**/bar')"
+                )
+            ),
+            self
+        )
         self.lblSshEncfsExcludeWarning.setWordWrap(True)
         layout.addWidget(self.lblSshEncfsExcludeWarning)
 
@@ -523,7 +530,7 @@ class SettingsDialog(QDialog):
         layout.addWidget(self.listExclude)
         self.listExcludeCount = 0
 
-        label = QLabel(_('Highly recommended:'), self)
+        label = QLabel(_('Highly recommended') + ':', self)
         qttools.setFontBold(label)
         layout.addWidget(label)
         label = QLabel(', '.join(sorted(self.config.DEFAULT_EXCLUDE)), self)

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -878,7 +878,7 @@ class SettingsDialog(QDialog):
             _('Limit rsync bandwidth usage') + ': ', self)
         hlayout.addWidget(self.cbBwlimit)
         self.spbBwlimit = QSpinBox(self)
-        self.spbBwlimit.setSuffix(_(' KB/sec'))
+        self.spbBwlimit.setSuffix(' ' + _('KB/sec'))
         self.spbBwlimit.setSingleStep(100)
         self.spbBwlimit.setRange(0, 1000000)
         hlayout.addWidget(self.spbBwlimit)
@@ -1463,8 +1463,8 @@ class SettingsDialog(QDialog):
 
             if not os.path.isfile(self.txtSshPrivateKeyFile.text()):
                 self.errorHandler(
-                    _('Private key file "%(file)s" does not exist.')
-                    % {'file': self.txtSshPrivateKeyFile.text()}
+                    _('Private key file "{file}" does not exist.')
+                    .format(file=self.txtSshPrivateKeyFile.text())
                 )
                 self.txtSshPrivateKeyFile.setText('')
 
@@ -1643,18 +1643,18 @@ class SettingsDialog(QDialog):
 
                     return False
 
-                msg = _('The authenticity of host "%(host)s" can\'t be '
-                        'established.\n\n%(keytype)s key fingerprint is:')
-                msg = msg % {'host': self.config.sshHost(),
-                             'keytype': keyType}
+                msg = _("The authenticity of host {host} can't be "
+                        "established.\n\n{keytype} key fingerprint is:") \
+                        .format(host='"{}"'.format(self.config.sshHost()),
+                                keytype=keyType)
                 options = []
                 lblFingerprint = QLabel(fingerprint + '\n')
                 lblFingerprint.setWordWrap(False)
                 lblFingerprint.setFont(QFont('Monospace'))
                 options.append({'widget': lblFingerprint, 'retFunc': None})
                 lblQuestion = QLabel(
-                    _('Please verify this fingerprint! Would you like to '
-                      'add it to your \'known_hosts\' file?')
+                    _("Please verify this fingerprint! Would you like to "
+                      "add it to your 'known_hosts' file?")
                 )
                 options.append({'widget': lblQuestion, 'retFunc': None})
 
@@ -1885,10 +1885,13 @@ class SettingsDialog(QDialog):
             if os.path.islink(path) \
                 and not (self.cbCopyUnsafeLinks.isChecked()
                          or self.cbCopyLinks.isChecked()):
-                if self.questionHandler(
-                    _('"%s" is a symlink. The linked target will not be '
-                      'backed up until you include it, too.\nWould you like '
-                      'to include the symlinks target instead?') % path):
+
+                question_msg = _(
+                    '"{path}" is a symlink. The linked target will not be '
+                    'backed up until you include it, too.\nWould you like '
+                    'to include the symlinks target instead?') \
+                    .format(path=path)
+                if self.questionHandler(question_msg):
                     path = os.path.realpath(path)
 
             path = self.config.preparePath(path)

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -645,7 +645,10 @@ class SettingsDialog(QDialog):
         smlayout = QGridLayout(widget)
 
         self.cbSmartRemoveRunRemoteInBackground = QCheckBox(
-            _('Run in background on remote Host.') + _(' EXPERIMENTAL!'),
+            '{} {}!'.format(
+                _('Run in background on remote Host.'),
+                _('EXPERIMENTAL')
+            ),
             self)
         smlayout.addWidget(self.cbSmartRemoveRunRemoteInBackground, 0, 0, 1, 3)
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -161,7 +161,7 @@ class SettingsDialog(QDialog):
         self.fillCombo(self.comboModes, store_modes)
 
         # encfs security warning
-        self.encfsWarning = QLabel('<b>{}:</b>{}'.format(
+        self.encfsWarning = QLabel('<b>{}:</b> {}'.format(
             _('Warning'),
             _('{app} uses EncFS for encryption. A recent security audit '
               'revealed several possible attack vectors for this. Please '


### PR DESCRIPTION
- Improved some translatable strings and fixed problems encountered while watching the ongoing [translation process of our translation team](http://translate.codeberg.org/engage/backintime). The intention about moving from [printf()-style string formatting](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting) to [Advanced String Formatting (PEP 3101)](https://peps.python.org/pep-3101/) or [f-string formatting (PEP 498)](https://peps.python.org/pep-0498/) is to make our strings easier to understand by translators who are not (Python)-Developers. It also reduce the amount of string-format-errors introduced by translators.
- Fix a translation related minor bug ([reported via comment on commit by @Fantu](https://github.com/bit-team/backintime/commit/8daa19ab57826ab16147f102e6ae5b88b02fc1d7#r119246500))
- Workaround [Weblate Issue #9449](https://github.com/WeblateOrg/weblate/issues/9449) misinterpreting not escaped `%`. The `%` don't need to be escaped when using Advanced String Formatting but [Weblate isn't able](https://github.com/WeblateOrg/weblate/issues/9449) yet to differentiate the multiple string-formatting styles in its check routines.