### PR TITLE
fix: Warnings by Sphinx

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -20,7 +20,7 @@
 
 This module and its `Config` class contain the application logic handling the
 configuration of Back In Time. The handling of the configuration file itself
-is separated in the module :py:module:`configfile`.
+is separated in the module :py:mod:`configfile`.
 
 Development notes:
     Some of the methods have code comments starting with `#? ` instead of

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -423,11 +423,11 @@ class Snapshots:
                                         restore to original destination
             delete (bool):              delete newer files which are not in the
                                         snapshot
-            backup (bool):              create backup files (*.backup.YYYYMMDD)
+            backup (bool):              create backup files (``*.backup.YYYYMMDD``)
                                         before changing or deleting local files.
             only_new (bool):            Only restore files which does not exist
                                         or are newer than those in destination.
-                                        Using "rsync --update" option.
+                                        Using ``rsync --update`` option.
         """
         instance = ApplicationInstance(
             pidFile=self.config.restoreInstanceFile(),


### PR DESCRIPTION
Fixed two simple warnings in Sphinx's doc build. I encountered them while using `-W` (warnings to errors) flag in the build process.