### PR TITLE
refactor: Introduce GNU gettext class-based API

### DIFF
--- a/common/backintime.py
+++ b/common/backintime.py
@@ -17,7 +17,6 @@
 
 import os
 import sys
-import gettext
 import argparse
 import atexit
 import subprocess
@@ -25,10 +24,14 @@ from datetime import datetime
 from time import sleep
 import json
 
+import tools
+# Workaround for situations where startApp() is not invoked.
+# E.g. when using --diagnostics and other argparse.Action
+tools.initiate_translation()
+
 import config
 import logger
 import snapshots
-import tools
 import sshtools
 import mount
 import password
@@ -37,8 +40,6 @@ import cli
 from diagnostics import collect_diagnostics
 from exceptions import MountException
 from applicationinstance import ApplicationInstance
-
-_=gettext.gettext
 
 RETURN_OK = 0
 RETURN_ERR = 1

--- a/common/config.py
+++ b/common/config.py
@@ -41,6 +41,14 @@ except ImportError:
     import getpass
     pwd = None
 
+# Workaround: Mostly relevant on TravisCI but not exclusivley.
+# While unittesting and without regular invocation of BIT the GNU gettext
+# class-based API isn't setup yet.
+try:
+    _('Foo')
+except NameError:
+    _ = lambda val: val
+
 import tools
 import configfile
 import logger

--- a/common/config.py
+++ b/common/config.py
@@ -32,7 +32,6 @@ Development notes:
 import os
 import sys
 import datetime
-import gettext
 import socket
 import random
 import shlex
@@ -53,11 +52,6 @@ from exceptions import PermissionDeniedByPolicy, \
                        InvalidChar, \
                        InvalidCmd, \
                        LimitExceeded
-
-_ = gettext.gettext
-
-gettext.bindtextdomain('backintime', os.path.join(tools.sharePath(), 'locale'))
-gettext.textdomain('backintime')
 
 
 class Config(configfile.ConfigFileWithProfiles):
@@ -341,6 +335,8 @@ class Config(configfile.ConfigFileWithProfiles):
         self.xWindowId = None
         self.inhibitCookie = None
         self.setupUdev = tools.SetupUdev()
+
+        tools.initiate_translation()
 
     def save(self):
         self.setIntValue('config.version', self.CONFIG_VERSION)

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -19,11 +19,7 @@
 import os
 import collections
 import re
-
-import gettext
 import logger
-
-_ = gettext.gettext
 
 
 class ConfigFile(object):

--- a/common/dummytools.py
+++ b/common/dummytools.py
@@ -14,12 +14,9 @@
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import gettext
-
 import config
 import mount
 
-_ = gettext.gettext
 
 class Dummy(mount.MountControl):
     """

--- a/common/encfstools.py
+++ b/common/encfstools.py
@@ -16,7 +16,6 @@
 
 import os
 import grp
-import gettext
 import subprocess
 import re
 import shutil
@@ -33,7 +32,6 @@ import logger
 from mount import MountControl
 from exceptions import MountException, EncodeValueError
 
-_ = gettext.gettext
 
 class EncFS_mount(MountControl):
     """

--- a/common/mount.py
+++ b/common/mount.py
@@ -17,7 +17,6 @@
 import os
 import subprocess
 import json
-import gettext
 from zlib import crc32
 from time import sleep
 
@@ -27,7 +26,6 @@ import tools
 import password
 from exceptions import MountException, HashCollision
 
-_ = gettext.gettext
 
 class Mount(object):
     """

--- a/common/password.py
+++ b/common/password.py
@@ -20,7 +20,6 @@ import time
 import atexit
 import signal
 import subprocess
-import gettext
 import re
 import errno
 
@@ -30,8 +29,6 @@ import tools
 import password_ipc
 import logger
 from exceptions import Timeout
-
-_ = gettext.gettext
 
 
 class Password_Cache(tools.Daemon):

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -43,8 +43,6 @@ import snapshotlog
 from applicationinstance import ApplicationInstance
 from exceptions import MountException, LastSnapshotSymlink
 
-_ = gettext.gettext
-
 
 class Snapshots:
     """

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -16,7 +16,6 @@
 
 import os
 import subprocess
-import gettext
 import string
 import random
 import tempfile
@@ -31,8 +30,6 @@ import password_ipc
 from mount import MountControl
 from exceptions import MountException, NoPubKeyLogin, KnownHost
 import bcolors
-
-_ = gettext.gettext
 
 
 class SSH(MountControl):

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -32,9 +32,11 @@ from contextlib import contextmanager
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import logger
+import tools
+# Needed because backintime.startApp() is not invoked.
+tools.initiate_translation()
 import config
 import snapshots
-import tools
 
 # mock notifyplugin to suppress notifications
 tools.registerBackintimePath('qt', 'plugins')

--- a/common/tools.py
+++ b/common/tools.py
@@ -125,24 +125,6 @@ def initiate_translation(language_code: str = None):
     translation.install()
 
 
-# Doesn't give valid values when using Gettext's class-based API
-# def get_current_used_language_code() -> str:
-#     # Example: /usr/share/locale/de/LC_MESSAGES/backintime.mo
-#     mo_file_path = gettext.find(
-#         domain=_GETTEXT_DOMAIN, localedir=_GETTEXT_LOCALE_DIR)
-
-#     mo_file_path = pathlib.Path(mo_file_path)
-
-#     # The third part from the right is the language code
-#     if mo_file_path.parts[-2:] == ('LC_MESSAGES', 'backintime.mo'):
-#         return mo_file_path.parts[-3]
-
-#     # Might happen if distro maintainers don't stick to our Makefile
-#     print(mo_file_path.parts)
-#     raise RuntimeError('Unexpected path to po-file. It is '
-#                        f'"{mo_file_path}". Please open a bug report.')
-
-
 # |------------------------------------|
 # | Miscellaneous, not categorized yet |
 # |------------------------------------|

--- a/common/tools.py
+++ b/common/tools.py
@@ -1,5 +1,6 @@
 #    Back In Time
-#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze, Taylor Raack
+#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey,
+#    Germar Reitze, Taylor Raack
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -14,8 +15,6 @@
 #    You should have received a copy of the GNU General Public License along
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-
 import os
 import sys
 import pathlib
@@ -26,6 +25,7 @@ import re
 import errno
 import gzip
 import tempfile
+import gettext
 try:
     from collections.abc import MutableSet
 except ImportError:
@@ -70,11 +70,15 @@ from exceptions import Timeout, InvalidChar, InvalidCmd, LimitExceeded, Permissi
 
 DISK_BY_UUID = '/dev/disk/by-uuid'
 
-def sharePath():
-    """
-    Get BackInTimes installation base path.
+# |-----------------|
+# | Handling pathes |
+# |-----------------|
 
-    If running from source return default '/usr/share'
+
+def sharePath():
+    """Get path where Back In Time is installed.
+
+    If running from source return default ``/usr/share``.
 
     Returns:
         str:    share path like::
@@ -83,11 +87,65 @@ def sharePath():
                     /usr/local/share
                     /opt/usr/share
     """
-    share = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir, os.pardir))
+    share = os.path.abspath(
+        os.path.join(__file__, os.pardir, os.pardir, os.pardir)
+    )
+
     if os.path.basename(share) == 'share':
         return share
-    else:
-        return '/usr/share'
+
+    return '/usr/share'
+
+
+# |---------------------------------------------------|
+# | Internationalization (i18n) & localization (L10n) |
+# |---------------------------------------------------|
+_GETTEXT_DOMAIN = 'backintime'
+_GETTEXT_LOCALE_DIR = os.path.join(sharePath(), 'locale')
+
+
+def initiate_translation(language_code: str = None):
+    """Initiate Class-based API of GNU gettext.
+
+    Args:
+        language_code: Language code to use (based on ISO-639-1).
+
+    It installs the ``_()`` in the ``builtins`` namespace and eliminates the
+    need to ``import gettext`` and declare ``_()`` in each module. The systems
+    current local is used if no language code is provided.
+    """
+    # language_code = 'ja'  # DEBUG
+
+    translation = gettext.translation(
+        domain=_GETTEXT_DOMAIN,
+        localedir=_GETTEXT_LOCALE_DIR,
+        languages=[language_code, ] if language_code else None,
+        fallback=True
+    )
+    translation.install()
+
+
+# Doesn't give valid values when using Gettext's class-based API
+# def get_current_used_language_code() -> str:
+#     # Example: /usr/share/locale/de/LC_MESSAGES/backintime.mo
+#     mo_file_path = gettext.find(
+#         domain=_GETTEXT_DOMAIN, localedir=_GETTEXT_LOCALE_DIR)
+
+#     mo_file_path = pathlib.Path(mo_file_path)
+
+#     # The third part from the right is the language code
+#     if mo_file_path.parts[-2:] == ('LC_MESSAGES', 'backintime.mo'):
+#         return mo_file_path.parts[-3]
+
+#     # Might happen if distro maintainers don't stick to our Makefile
+#     print(mo_file_path.parts)
+#     raise RuntimeError('Unexpected path to po-file. It is '
+#                        f'"{mo_file_path}". Please open a bug report.')
+
+
+# |------------------------------------|
+# | Miscellaneous, not categorized yet |
+# |------------------------------------|
 
 def backintimePath(*path):
     """

--- a/qt/app.py
+++ b/qt/app.py
@@ -24,7 +24,6 @@ if not os.getenv('DISPLAY', ''):
     os.putenv('DISPLAY', ':0.0')
 
 import datetime
-import gettext
 import re
 import subprocess
 import shutil
@@ -32,8 +31,15 @@ import signal
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 
+# We need to import common/tools.py
+import qttools_path
+qttools_path.registerBackintimePath('common')
+
+# Workaround until the codebase is rectified/equalized.
+import tools
+tools.initiate_translation()
+
 import qttools
-qttools.registerBackintimePath('common')
 
 import backintime
 import tools
@@ -53,9 +59,6 @@ import snapshotsdialog
 import logviewdialog
 from restoredialog import RestoreDialog
 import messagebox
-
-
-_=gettext.gettext
 
 
 class MainWindow(QMainWindow):

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -16,8 +16,6 @@
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-import gettext
-
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtCore import *
@@ -28,8 +26,6 @@ import encfstools
 import snapshotlog
 import tools
 import messagebox
-
-_=gettext.gettext
 
 
 class LogViewDialog(QDialog):

--- a/qt/messagebox.py
+++ b/qt/messagebox.py
@@ -14,13 +14,11 @@
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-import gettext
 from PyQt5.QtCore import QTimer, Qt
 from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog, QLineEdit,\
     QDialog, QVBoxLayout, QLabel, QDialogButtonBox, QScrollArea
 import qttools
 
-_ = gettext.gettext
 
 def askPasswordDialog(parent, title, prompt, timeout = None):
     if parent is None:

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -18,11 +18,8 @@
 
 import sys
 import os
-import gettext
 import subprocess
 import signal
-
-_=gettext.gettext
 
 if not os.getenv('DISPLAY', ''):
     os.putenv('DISPLAY', ':0.0')

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -30,7 +30,6 @@
 """
 import os
 import sys
-import gettext
 
 from PyQt5.QtGui import (QFont, QColor, QKeySequence, QIcon)
 from PyQt5.QtCore import (QDir, Qt, pyqtSlot, pyqtSignal, QModelIndex,
@@ -44,23 +43,7 @@ from datetime import (datetime, date, timedelta)
 from calendar import monthrange
 from packaging.version import Version
 
-
-_ = gettext.gettext
-
-
-def backintimePath(*path):
-    return os.path.abspath(os.path.join(__file__, os.pardir, os.pardir, *path))
-
-
-def registerBackintimePath(*path):
-    """Find duplicate in common/tools.py
-    """
-    path = backintimePath(*path)
-
-    if path not in sys.path:
-        sys.path.insert(0, path)
-
-
+from qttools_path import registerBackintimePath
 registerBackintimePath('common')
 import snapshots  # noqa: E402
 import tools  # noqa: E402
@@ -280,15 +263,23 @@ def createQApplication(app_name='Back In Time'):
     return qapp
 
 
-def translator():
-    """Creating an Qt related translator beside the primarily used GNU gettext
-    is needed because Qt need to translate its own default elements like
-    Yes/No-buttons.
+def translator(language_code: str = None) -> QTranslator:
+    """Creating an Qt related translator.
+
+    Args:
+        language_code: Language code to use (based on ISO-639-1).
+
+    This is done beside the primarily used GNU gettext because Qt need to
+    translate its own default elements like Yes/No-buttons. The systems
+    current local is used when no language code is provided.
     """
 
     translator = QTranslator()
-    locale = QLocale.system().name()
-    translator.load(f'qt_{locale}',
+
+    if not language_code:
+        language_code = QLocale.system().name()
+
+    translator.load(f'qt_{language_code}',
                     QLibraryInfo.location(QLibraryInfo.TranslationsPath))
 
     return translator

--- a/qt/qttools_path.py
+++ b/qt/qttools_path.py
@@ -1,0 +1,41 @@
+#    Back In Time
+#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar
+#    Reitze
+#
+#    This program is free software; you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation; either version 2 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License along
+#    with this program; if not, write to the Free Software Foundation, Inc.,
+#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Helper functions extracted from qt/qttools.py file.
+
+Extraction happend of problems with import dependencies. The whole path
+manipulation will become obsolete when migrating to state of the art Python
+packaging standards. This module is a workround and will get refactored in
+the future.
+"""
+import os
+import sys
+import gettext
+
+def backintimePath(*path):
+    return os.path.abspath(os.path.join(__file__, os.pardir, os.pardir, *path))
+
+
+def registerBackintimePath(*path):
+    """Find duplicate in common/tools.py
+    """
+    path = backintimePath(*path)
+
+    if path not in sys.path:
+        sys.path.insert(0, path)
+

--- a/qt/restoredialog.py
+++ b/qt/restoredialog.py
@@ -17,18 +17,14 @@
 
 
 import os
-import gettext
-
-import tools
 
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 from PyQt5.QtCore import *
 
+import tools
 import qttools
 
-
-_=gettext.gettext
 
 class RestoreDialog(QDialog):
     def __init__(self, parent, sid, what, where = '', **kwargs):

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -19,7 +19,6 @@
 
 import os
 import datetime
-import gettext
 import copy
 import grp
 import re
@@ -68,8 +67,6 @@ import snapshots
 import sshtools
 import logger
 from exceptions import MountException, NoPubKeyLogin, KnownHost
-
-_ = gettext.gettext
 
 
 class SettingsDialog(QDialog):

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -17,7 +17,6 @@
 
 
 import os
-import gettext
 import subprocess
 import shlex
 
@@ -31,7 +30,6 @@ import messagebox
 import qttools
 import snapshots
 
-_=gettext.gettext
 
 if tools.checkCommand('meld'):
     DIFF_CMD = 'meld'


### PR DESCRIPTION
This PR introduce the class-based API for GNU gettext ([docu](https://docs.python.org/3/library/gettext.html#class-based-api) & [example](https://docs.python.org/3/library/gettext.html#localizing-your-application)). It eliminates the need to `import gettext` and declaring `_()` in each module. Now it is done on a global level (in `builtins` namespace). The behavior of BIT do not change. It is just refactoring.

_Why we need this_: I want to introduce a feature to modify the language used by BIT. This puts more value to the translations because there are areas in the world where it is not unusual to use multiple languages on the same computer system independent from the locale that is setup in the OS. It also helps with manual GUI testing.

~There might be a problem with `qt/qtsystrayicon.py`. [I'm not sure how it is invoked or where it is used](https://mail.python.org/archives/list/bit-dev@python.org/message/V3TLXN3QXZTDMFQZV72SYXUTM2TL5NUK/). Depending on the answer the use of `gettext` need to be altered in that file, too.~

_Technical roadmap_: The language code will be stored via `config.Config`. That is why `tools.initiate_translation()` is done in the end of `config.Config.__init__()`. In the future the language code will be read from the config and handed over as an argument to `initiate_translation()`. IMHO it is not ideal doing this inside the `Config` class but it is a pragmatic solution without changing to much of the code(structure). Something similar will be done with `qt/qttools.py::translator()`.