### PR TITLE
feat!: Remove "fuse" user group handling and checking

### DIFF
--- a/common/configure
+++ b/common/configure
@@ -12,23 +12,17 @@ UNINSTALL_DIRS="$(mktemp)"
 
 #set default options
 PYTHON="--python3"
-FUSE_GROUP="--no-fuse-group"
 
 USR_BIN_FILES="backintime backintime-askpass"
-FUSE_FILES="mount.py"
 
 usage () {
     echo "Usage:"
-    echo "$0 [--python | --python3], [--fuse-group | --no-fuse-group]"
+    echo "$0 [--python | --python3]"
     echo ""
     echo "--python"
     echo "\tuse 'python' to start Python3"
     echo "--python3"
     echo "\tuse 'python3' to start Python3"
-    echo "--no-fuse-group"
-    echo "\tdo not check for 'fuse' group membership (if not necessary on destination platform)"
-    echo "--fuse-group"
-    echo "\tmake sure user is in the group 'fuse' to be able to use fuse-based file-systems"
 }
 
 addInstallFiles () {
@@ -120,7 +114,6 @@ unknown_args=""
 for arg in $*; do
     case $arg in
         --python | --python3) PYTHON=$arg;;
-        --fuse-group | --no-fuse-group) FUSE_GROUP=$arg;;
         --help | -h) usage; exit 0;;
         *) unknown_args="$unknown_args $arg";;
     esac
@@ -139,15 +132,6 @@ esac
 sed -e "s/^python3\? /python${PYVERSION} /g" \
     -e "s/^ssh-agent python3\? /ssh-agent python${PYVERSION} /g" \
     -i $USR_BIN_FILES
-
-#patch check for 'fuse' group
-#Some distributions require user to be in group 'fuse' to use sshfs and encfs
-case $FUSE_GROUP in
-    --fuse-group)    CHECKFUSE="True" ;;
-    --no-fuse-group) CHECKFUSE="False";;
-esac
-sed -e "s/CHECK_FUSE_GROUP = \(True\|False\)/CHECK_FUSE_GROUP = ${CHECKFUSE}/" \
-    -i $FUSE_FILES
 
 #check languages
 mos=""

--- a/common/mount.py
+++ b/common/mount.py
@@ -673,7 +673,7 @@ class MountControl(object):
 
     def checkFuse(self):
         """
-        Check if command in self.mountproc is installed.
+        Check if command in ``self.mountproc`` is installed.
 
         Raises:
             exceptions.MountException: If either command is not available.

--- a/common/mount.py
+++ b/common/mount.py
@@ -329,8 +329,6 @@ class MountControl(object):
                                 mountpoints
     """
 
-    CHECK_FUSE_GROUP = False
-
     def __init__(self,
                  cfg = None,
                  profile_id = None,
@@ -501,7 +499,7 @@ class MountControl(object):
         overwritten by backends which subclasses :py:class:`MountControl`.
 
         Raises:
-            exceptions.MountException:  if unmount failed
+            exceptions.MountException: If unmount failed.
         """
         try:
             subprocess.check_call(['fusermount', '-u', self.currentMountpoint])
@@ -584,41 +582,20 @@ class MountControl(object):
 
     def checkFuse(self):
         """
-        Check if command in self.mountproc is installed and user is part of
-        group ``fuse``.
+        Check if command in self.mountproc is installed.
 
         Raises:
-            exceptions.MountException:  if either command is not available or
-                                        user is not in group fuse
+            exceptions.MountException: If either command is not available.
         """
-        logger.debug('Check fuse', self)
 
         if not tools.checkCommand(self.mountproc):
             logger.debug('%s is missing' % self.mountproc, self)
+
             raise MountException(
-                '{}  not found. Please install e.g. {}'
+                '{} not found. Please install e.g. {}'
                 .format(self.mountproc,
                         "'apt-get install %s'" % self.mountproc)
             )
-
-        if self.CHECK_FUSE_GROUP:
-            user = self.config.user()
-
-            try:
-                fuse_grp_members = grp.getgrnam('fuse')[3]
-
-            except KeyError:
-                #group fuse doesn't exist. So most likely it isn't used by this distribution
-                logger.debug("Group fuse doesn't exist. Skip test", self)
-                return
-
-            if not user in fuse_grp_members:
-                logger.debug('User %s is not in group fuse' % user, self)
-                raise MountException(
-                    "{user} is not member of group 'fuse'. Run 'sudo adduser "
-                    "{user} fuse'. To apply changes logout and login again."
-                    "\nLook at 'man backintime' for further instructions."
-                    .format(user=user))
 
     def mounted(self):
         """

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -200,9 +200,11 @@ class SSH(MountControl):
 
         err = proc.communicate()[1]
 
-        if proc.returncode:
-            raise MountException(
-                "Can't mount %s" % " ".join(sshfs) + "\n\n" + err)
+        if proc.returncode == 0:
+            return
+
+       raise MountException("Can't mount {}\n\n{}"
+                            .format(" ".join(sshfs), err))
 
     def preMountCheck(self, first_run=False):
         """

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -200,8 +200,8 @@ class SSH(MountControl):
         if proc.returncode == 0:
             return
 
-       raise MountException("Can't mount {}\n\n{}"
-                            .format(" ".join(sshfs), err))
+        raise MountException("Can't mount {}\n\n{}"
+                             .format(" ".join(sshfs), err))
 
     def preMountCheck(self, first_run=False):
         """

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -21,7 +21,6 @@ import os
 import datetime
 import gettext
 import copy
-import grp
 import re
 
 from PyQt5.QtGui import QIcon, QFont, QPalette, QBrush, QColor
@@ -2109,32 +2108,17 @@ class RestoreConfigDialog(QDialog):
             snapshots.SID(datetime.datetime.now(), self.config).sid
         )
 
-        # inform user to join group fuse if he hasn't already.
-        # If there is no group fuse than it is most likely not necessary.
-        addFuse = ''
-
-        try:
-            user = self.config.user()
-            fuse_grp_members = grp.getgrnam('fuse')[3]
-
-            if user not in fuse_grp_members:
-                addFuse = _(' and add your user to group \'fuse\'')
-
-        except KeyError:
-            pass
-
         label = QLabel(_(
             "Please navigate to the snapshot from which you want to restore "
             "{appName}'s configuration. The path may look like:\n"
             "{samplePath}\n\nIf your snapshots are on a remote drive or if "
             "they are encrypted you need to manually mount them first. "
             "If you use Mode SSH you also may need to set up public key "
-            "login to the remote host{addFuse}.\n"
+            "login to the remote host.\n"
             "Take a look at 'man backintime'.")
             .format(
                 appName=self.config.APP_NAME,
-                samplePath=samplePath,
-                addFuse=addFuse),
+                samplePath=samplePath),
             self
         )
         label.setWordWrap(True)


### PR DESCRIPTION
The following behavior, introduced in 2013 via 26474f8, was removed: While installing (in configure script) and when mounting (see mount.py::MountControl.checkFuse()) the existence of the user group "fuse" was checked. The reasons and arguments described in #1450.

The exclamation mark (in "feat!:") is used even if it isn't a breaking change for real. The behavior shouldn't change because of the assumption that the code is not reached in any situation. But if the assumption is wrong it might be easier to find the relevant commit message.

Close #1450