### PR TITLE
refactor: Menus, Toolbars and Actions in MainWindow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ debian/backintime-qt
 # compressed files
 *.gz
 
-# Translations
+# Compiled translations
 *.mo
 
 # Makefile
@@ -36,6 +36,10 @@ qt/Makefile
 # coveralls.io status
 .coverage
 
+# coverage result files (raw data and reports)
+# .coverage  # already ignored, see above
+**/htmlcov/**
+
 # sphinx doc build
 common/doc-dev/_build/doctrees
 common/doc-dev/_build/html
@@ -43,6 +47,5 @@ common/doc-dev/_build/html
 # PyCharm IDE project settings
 .idea
 
-# coverage result files (raw data and reports)
-# .coverage  # already ignored, see above
-**/htmlcov/**
+# Linter configuration
+.flake8

--- a/qt/app.py
+++ b/qt/app.py
@@ -125,19 +125,6 @@ class MainWindow(QMainWindow):
         self.firstUpdateAll = True
         self.disableProfileChanged = False
 
-        # Sub-Menu: Take snapshot
-        takeSnapshotMenu = QMenu(self)
-        takeSnapshotMenu.setToolTipsVisible(True)
-        takeSnapshotMenu.addAction(self.act_take_snapshot)
-        takeSnapshotMenu.addAction(self.act_take_snapshot_checksum)
-
-        # Fix it. See original:
-        # https://github.com/bit-team/backintime/blob/1003d360d758bce78c6cd528ea41df3734fec95b/qt/app.py#L94-L101
-        for action in takeSnapshotMenu.actions():
-            # What is this?
-            # Isn't this by default?
-            action.setIconVisibleInMenu(True)
-
         # Menu: Snapshot
         menuSnapshot = self.menuBar().addMenu(_('&Snapshot'))
         menuSnapshot.addAction(self.act_quit)
@@ -719,13 +706,14 @@ class MainWindow(QMainWindow):
         for act in actions_for_toolbar:
             toolbar.addAction(act)
 
-        # sub menu: take snapshot
+        # toolbar sub menu: take snapshot
         submenu_take_snapshot = QMenu(self)
-        submenu_take_snapshot.setToolTipsVisible(True)
         submenu_take_snapshot.addAction(self.act_take_snapshot)
         submenu_take_snapshot.addAction(self.act_take_snapshot_checksum)
-        # get the toolbar buttons widget and add the menu to it
+        submenu_take_snapshot.setToolTipsVisible(True)
+        # get the toolbar buttons widget...
         button_take_snapshot = toolbar.widgetForAction(self.act_take_snapshot)
+        # ...and add the menu to it
         button_take_snapshot.setMenu(submenu_take_snapshot)
         button_take_snapshot.setPopupMode(QToolButton.MenuButtonPopup)
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -53,6 +53,7 @@ from PyQt5.QtWidgets import (QWidget,
                              QAction,
                              QFrame,
                              QMainWindow,
+                             QToolButton,
                              QLabel,
                              QLineEdit,
                              QCheckBox,
@@ -125,10 +126,13 @@ class MainWindow(QMainWindow):
         self.disableProfileChanged = False
 
         # Sub-Menu: Take snapshot
-        takeSnapshotMenu = qttools.Menu()
+        takeSnapshotMenu = QMenu(self)
+        takeSnapshotMenu.setToolTipsVisible(True)
         takeSnapshotMenu.addAction(self.act_take_snapshot)
         takeSnapshotMenu.addAction(self.act_take_snapshot_checksum)
 
+        # Fix it. See original:
+        # https://github.com/bit-team/backintime/blob/1003d360d758bce78c6cd528ea41df3734fec95b/qt/app.py#L94-L101
         for action in takeSnapshotMenu.actions():
             # What is this?
             # Isn't this by default?
@@ -206,7 +210,9 @@ class MainWindow(QMainWindow):
         self.filesViewToolbar.addSeparator()
 
         # FileView Toolbar Menu: Restore
-        self.menuRestore = qttools.Menu(self)
+        # self.menuRestore = qttools.Menu(self)
+        self.menuRestore = QMenu(self)
+        self.menuRestore.setToolTipsVisible(True)
         self.btnRestore = self.menuRestore.addAction(
             icon.RESTORE, _('Restore'))
         self.btnRestore.setToolTip(_(
@@ -712,6 +718,16 @@ class MainWindow(QMainWindow):
 
         for act in actions_for_toolbar:
             toolbar.addAction(act)
+
+        # sub menu: take snapshot
+        submenu_take_snapshot = QMenu(self)
+        submenu_take_snapshot.setToolTipsVisible(True)
+        submenu_take_snapshot.addAction(self.act_take_snapshot)
+        submenu_take_snapshot.addAction(self.act_take_snapshot_checksum)
+        # get the toolbar buttons widget and add the menu to it
+        button_take_snapshot = toolbar.widgetForAction(self.act_take_snapshot)
+        button_take_snapshot.setMenu(submenu_take_snapshot)
+        button_take_snapshot.setPopupMode(QToolButton.MenuButtonPopup)
 
         # separators and stretchers
         toolbar.insertSeparator(self.act_settings)

--- a/qt/app.py
+++ b/qt/app.py
@@ -160,22 +160,18 @@ class MainWindow(QMainWindow):
         # Toolbar: files toolbar
         self.filesViewToolbar = QToolBar(self)
         self.filesViewToolbar.setFloatable(False)
-
-        self.btnFolderUp = self.filesViewToolbar.addAction(icon.UP, _('Up'))
-        self.btnFolderUp.setShortcuts([QKeySequence(Qt.ALT + Qt.Key_Up), Qt.Key_Backspace])
-        self.btnFolderUp.triggered.connect(self.btnFolderUpClicked)
-
+        self.filesViewToolbar.addAction(self.act_folder_up)
         self.editCurrentPath = QLineEdit(self)
         self.editCurrentPath.setReadOnly(True)
         self.filesViewToolbar.addWidget(self.editCurrentPath)
 
         # show hidden files
         self.showHiddenFiles = self.config.boolValue('qt.show_hidden_files', False)
-        self.btnShowHiddenFiles = self.filesViewToolbar.addAction(icon.SHOW_HIDDEN, _('Show hidden files'))
-        self.btnShowHiddenFiles.setShortcut(QKeySequence(Qt.CTRL + Qt.Key_H))
-        self.btnShowHiddenFiles.setCheckable(True)
-        self.btnShowHiddenFiles.setChecked(self.showHiddenFiles)
-        self.btnShowHiddenFiles.toggled.connect(self.btnShowHiddenFilesToggled)
+        self.filesViewToolbar.addAction(self.act_show_hidden)
+        self.act_show_hidden.setCheckable(True)
+        self.act_show_hidden.setChecked(self.showHiddenFiles)
+        self.act_show_hidden.toggled.connect(
+            self.btnShowHiddenFilesToggled)
 
         self.filesViewToolbar.addSeparator()
 
@@ -183,33 +179,13 @@ class MainWindow(QMainWindow):
         # self.menuRestore = qttools.Menu(self)
         self.menuRestore = QMenu(self)
         self.menuRestore.setToolTipsVisible(True)
-        self.btnRestore = self.menuRestore.addAction(
-            icon.RESTORE, _('Restore'))
-        self.btnRestore.setToolTip(_(
-            'Restore the selected files or folders to the '
-            'original destination.'))
-        self.btnRestore.triggered.connect(self.restoreThis)
-        self.btnRestoreTo = self.menuRestore.addAction(
-            icon.RESTORE_TO, _('Restore to ...'))
-        self.btnRestoreTo.setToolTip(_(
-            'Restore the selected files or folders to a new destination.'))
-        self.btnRestoreTo.triggered.connect(self.restoreThisTo)
+        self.menuRestore.addAction(self.act_restore)
+        self.menuRestore.addAction(self.act_restore_to)
         self.menuRestore.addSeparator()
-        self.btnRestoreParent = self.menuRestore.addAction(icon.RESTORE, '')
-        self.btnRestoreParent.setToolTip(_('Restore the currently shown '
-                                           'folder and all its contents to '
-                                           'the original destination.'))
-        self.btnRestoreParent.triggered.connect(self.restoreParent)
-        self.btnRestoreParentTo = self.menuRestore.addAction(
-            icon.RESTORE_TO, '')
-        self.btnRestoreParentTo.setToolTip(_('Restore the currently shown '
-                                             'folder and all its contents '
-                                             'to a new destination.'))
-        self.btnRestoreParentTo.triggered.connect(self.restoreParentTo)
+        self.menuRestore.addAction(self.act_restore_parent)
+        self.menuRestore.addAction(self.act_restore_parent_to)
         self.menuRestore.addSeparator()
 
-        for action in self.menuRestore.actions():
-            action.setIconVisibleInMenu(True)
         self.btnRestoreMenu = self.filesViewToolbar.addAction(
             icon.RESTORE, _('Restore'))
         self.btnRestoreMenu.setMenu(self.menuRestore)
@@ -238,8 +214,8 @@ class MainWindow(QMainWindow):
 
         # Menu: View
         menuView = self.menuBar().addMenu(_('&View'))
-        menuView.addAction(self.btnFolderUp)
-        menuView.addAction(self.btnShowHiddenFiles)
+        menuView.addAction(self.act_folder_up)
+        menuView.addAction(self.act_show_hidden)
         menuView.addSeparator()
         menuView.addAction(self.act_snapshot_logview)
         menuView.addAction(self.act_last_logview)
@@ -248,24 +224,24 @@ class MainWindow(QMainWindow):
 
         # Menu: Restore
         self.menuRestore = self.menuBar().addMenu(_('&Restore'))
-        self.menuRestore.addAction(self.btnRestore)
-        self.menuRestore.addAction(self.btnRestoreTo)
+        self.menuRestore.addAction(self.act_restore)
+        self.menuRestore.addAction(self.act_restore_to)
         self.menuRestore.addSeparator()
-        self.menuRestore.addAction(self.btnRestoreParent)
-        self.menuRestore.addAction(self.btnRestoreParentTo)
+        self.menuRestore.addAction(self.act_restore_parent)
+        self.menuRestore.addAction(self.act_restore_parent_to)
 
         # Menu: Help
-        self.menuHelp = self.menuBar().addMenu(_('&Help'))
-        self.menuHelp.addAction(self.btnHelp)
-        self.menuHelp.addAction(self.btnHelpConfig)
-        self.menuHelp.addSeparator()
-        self.menuHelp.addAction(self.btnWebsite)
-        self.menuHelp.addAction(self.btnChangelog)
-        self.menuHelp.addAction(self.btnFaq)
-        self.menuHelp.addAction(self.btnAskQuestion)
-        self.menuHelp.addAction(self.btnReportBug)
-        self.menuHelp.addSeparator()
-        self.menuHelp.addAction(self.btnAbout)
+        menuHelp = self.menuBar().addMenu(_('&Help'))
+        menuHelp.addAction(self.act_help_help)
+        menuHelp.addAction(self.act_help_configfile)
+        menuHelp.addSeparator()
+        menuHelp.addAction(self.act_help_website)
+        menuHelp.addAction(self.act_help_changelog)
+        menuHelp.addAction(self.act_help_faq)
+        menuHelp.addAction(self.act_help_question)
+        menuHelp.addAction(self.act_help_bugreport)
+        menuHelp.addSeparator()
+        menuHelp.addAction(self.act_help_about)
 
         # shortcuts without buttons
         self.shortcutPreviousFolder = QShortcut(QKeySequence(Qt.ALT + Qt.Key_Left), self)
@@ -367,8 +343,8 @@ class MainWindow(QMainWindow):
         self.filesView.setContextMenuPolicy(Qt.CustomContextMenu)
         self.filesView.customContextMenuRequested.connect(self.contextMenuClicked)
         self.contextMenu = QMenu(self)
-        self.contextMenu.addAction(self.btnRestore)
-        self.contextMenu.addAction(self.btnRestoreTo)
+        self.contextMenu.addAction(self.act_restore)
+        self.contextMenu.addAction(self.act_restore_to)
         self.contextMenu.addAction(self.btnSnapshots)
         self.contextMenu.addSeparator()
         self.btnAddInclude = self.contextMenu.addAction(icon.ADD, _('Add to Include'))
@@ -376,7 +352,7 @@ class MainWindow(QMainWindow):
         self.btnAddInclude.triggered.connect(self.btnAddIncludeClicked)
         self.btnAddExclude.triggered.connect(self.btnAddExcludeClicked)
         self.contextMenu.addSeparator()
-        self.contextMenu.addAction(self.btnShowHiddenFiles)
+        self.contextMenu.addAction(self.act_show_hidden)
 
         # ProgressBar
         layoutWidget = QWidget()
@@ -630,17 +606,17 @@ class MainWindow(QMainWindow):
             (
                 'act_help_website',
                 icon.WEBSITE, _('Website'),
-                self.btnHelpWebsiteClicked, None, None,
+                self.btnWebsiteClicked, None, None,
             ),
             (
                 'act_help_changelog',
                 icon.CHANGELOG, _('Changelog'),
-                self.btnHelpChangelogClicked, None, None,
+                self.btnChangelogClicked, None, None,
             ),
             (
                 'act_help_faq',
                 icon.FAQ, _('FAQ'),
-                self.btnHelpFAQClicked, None, None,
+                self.btnFaqClicked, None, None,
             ),
             (
                 'act_help_question',
@@ -658,6 +634,43 @@ class MainWindow(QMainWindow):
                 icon.ABOUT, _('About'),
                 self.btnAboutClicked, None, None,
             ),
+            (
+                'act_restore',
+                icon.RESTORE, _('Restore'),
+                self.restoreThis, None,
+                _('Restore the selected files or folders to the '
+                  'original destination.')
+            ),
+            (
+                'act_restore_to', icon.RESTORE_TO, _('Restore to …'),
+                self.restoreThisTo, None,
+                _('Restore the selected files or folders to a '
+                  'new destination.')
+            ),
+            (
+                'act_restore_parent', icon.RESTORE, 'RESTORE PARENT (DEBUG)',
+                self.restoreParent, None,
+                _('Restore the currently shown folder and all its contents '
+                  'to the original destination.')
+            ),
+            (
+                'act_restore_parent_to',
+                icon.RESTORE_TO, 'RESTORE PARENT TO (DEBUG)',
+                self.restoreParentTo, None,
+                _('Restore the currently shown folder and all its contents '
+                  'to a new destination.')
+            ),
+            (
+                'act_folder_up', icon.UP, _('Up'),
+                self.btnFolderUpClicked, ['Alt+Up', 'Backspace'], None
+            ),
+            (
+                'act_show_hidden', icon.SHOW_HIDDEN,
+                _('Show hidden files'),
+                None, ['Ctrl+H'], None
+            ),
+
+
         )
 
         for attr, ico, txt, slot, keys, tip in action_dict:
@@ -735,9 +748,6 @@ class MainWindow(QMainWindow):
         # separators and stretchers
         toolbar.insertSeparator(self.act_settings)
         toolbar.insertSeparator(self.act_shutdown)
-        empty = QWidget(self)
-        empty.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
-        toolbar.insertWidget(self.act_mystic_help, empty)
 
     def closeEvent(self, event):
         if self.shutdown.askBeforeQuit():
@@ -890,7 +900,7 @@ class MainWindow(QMainWindow):
         takeSnapshotMessage = self.snapshots.takeSnapshotMessage()
         if fake_busy:
             if takeSnapshotMessage is None:
-                takeSnapshotMessage = (0, '...')
+                takeSnapshotMessage = (0, '…')
         elif takeSnapshotMessage is None:
             takeSnapshotMessage = self.lastTakeSnapshotMessage
             if takeSnapshotMessage is None:
@@ -1381,7 +1391,7 @@ files that the receiver requests to be transferred.""")
         paths = [f for f, idx in self.multiFileSelected(fullPath = True)]
 
         with self.suspendMouseButtonNavigation():
-            restoreTo = qttools.getExistingDirectory(self, _('Restore to ...'))
+            restoreTo = qttools.getExistingDirectory(self, _('Restore to …'))
             if not restoreTo:
                 return
             restoreTo = self.config.preparePath(restoreTo)
@@ -1413,7 +1423,7 @@ files that the receiver requests to be transferred.""")
             return
 
         with self.suspendMouseButtonNavigation():
-            restoreTo = qttools.getExistingDirectory(self, _('Restore to ...'))
+            restoreTo = qttools.getExistingDirectory(self, _('Restore to …'))
             if not restoreTo:
                 return
             restoreTo = self.config.preparePath(restoreTo)
@@ -1592,20 +1602,18 @@ files that the receiver requests to be transferred.""")
         else:
             self.btnRestoreMenu.setEnabled(False)
             self.menuRestore.setEnabled(False)
-            self.btnRestore.setEnabled(False)
-            self.btnRestoreTo.setEnabled(False)
+            self.act_restore.setEnabled(False)
+            self.act_restore_to.setEnabled(False)
             self.btnSnapshots.setEnabled(False)
             self.stackFilesView.setCurrentWidget(self.lblFolderDontExists)
 
-        #show current path
+        # show current path
         self.editCurrentPath.setText(self.path)
-        self.btnRestoreParent.setText(
-            _('Restore {path}').format(path=self.path))
-        self.btnRestoreParentTo.setText(
-            _('Restore {path} to ...').format(path=self.path))
+        self.act_restore_parent.setText(_(f'Restore {self.path}'))
+        self.act_restore_parent_to.setText(_(f'Restore {self.path} to …'))
 
-        #update folder_up button state
-        self.btnFolderUp.setEnabled(len(self.path) > 1)
+        # update folder_up button state
+        self.act_folder_up.setEnabled(len(self.path) > 1)
 
     def dirListerCompleted(self):
         has_files = (self.filesViewProxyModel.rowCount(self.filesView.rootIndex()) > 0)
@@ -1614,8 +1622,8 @@ files that the receiver requests to be transferred.""")
         enable = not self.sid.isRoot and has_files
         self.btnRestoreMenu.setEnabled(enable)
         self.menuRestore.setEnabled(enable)
-        self.btnRestore.setEnabled(enable)
-        self.btnRestoreTo.setEnabled(enable)
+        self.act_restore.setEnabled(enable)
+        self.act_restore_to.setEnabled(enable)
 
         #update snapshots button state
         self.btnSnapshots.setEnabled(has_files)

--- a/qt/app.py
+++ b/qt/app.py
@@ -883,17 +883,19 @@ class MainWindow(QMainWindow):
             self.btnPauseTakeSnapshot.setVisible(not paused)
             self.btnResumeTakeSnapshot.setVisible(paused)
             self.btnStopTakeSnapshot.setVisible(True)
-        elif not self.btnTakeSnapshot.isEnabled():
+
+        elif not self.act_take_snapshot.isEnabled():
             force_update = True
 
-            self.btnTakeSnapshot.setEnabled(True)
-            self.btnTakeSnapshot.setVisible(True)
-            for btn in (self.btnPauseTakeSnapshot,
-                        self.btnResumeTakeSnapshot,
-                        self.btnStopTakeSnapshot):
+            self.act_take_snapshot.setEnabled(True)
+            self.act_take_snapshot.setVisible(True)
+            for action in (self.act_pause_take_snapshot,
+                           self.act_resume_take_snapshot,
+                           self.act_stop_take_snapshot):
                 btn.setVisible(False)
 
-            #TODO: check if there is a more elegant way than always get a new snapshot list which is very expensive (time)
+            # TODO: check if there is a more elegant way than always get a
+            # new snapshot list which is very expensive (time)
             snapshotsList = snapshots.listSnapshots(self.config)
 
             if snapshotsList != self.snapshotsList:

--- a/qt/app.py
+++ b/qt/app.py
@@ -134,15 +134,10 @@ class MainWindow(QMainWindow):
         self.timeLine.updateFilesView.connect(self.updateFilesView)
 
         # right widget
-        self.filesWidget = QGroupBox('W'*100, self)
+        self.filesWidget = QGroupBox(self)
         filesLayout = QVBoxLayout(self.filesWidget)
         left, top, right, bottom = filesLayout.getContentsMargins()
         filesLayout.setContentsMargins(0, 0, right, 0)
-        # DEBUG
-        # self.filesWidget.setSizePolicy(
-        #     QSizePolicy(QSizePolicy.Expanding,
-        #                 QSizePolicy.Expanding)
-        # )
 
         # main splitter
         self.mainSplitter = QSplitter(Qt.Horizontal, self)
@@ -1630,11 +1625,14 @@ files that the receiver requests to be transferred.""")
             tooltip = _('View the current disk content')
         else:
             name = self.sid.displayName
-            text = '{}: {}'.format(_('Snapshot'), name)
+            # buhtz (2023-07)3 blanks at the end of that string as a
+            # workaround to a visual issue where the last character was
+            # cutoff. Not sure if this is DE and/or theme related.
+            # Wasn't able to reproduc in an MWE. Remove after refactoring.
+            text = '{}: {}   '.format(_('Snapshot'), name)
             tooltip = _('View the snapshot made at {name}').format(name=name)
 
-        text = '{}{}'.format(text, '')  # 'W' * (35-len(text)))
-        self.filesWidget.setTitle(text)  # DEBUG
+        self.filesWidget.setTitle(text)
         self.filesWidget.setToolTip(tooltip)
 
         # try to keep old selected file

--- a/qt/app.py
+++ b/qt/app.py
@@ -417,181 +417,125 @@ class MainWindow(QMainWindow):
             (singular; without ``s`` at the end).
         """
 
-        action_dict = (
-            # (
-            #     'Name of action attribute in "self"',
-            #     ICON,
-            #     Label text,
+        action_dict = {
+            # 'Name of action attribute in "self"': (
+            #     ICON, Label text,
             #     trigger_handler_function,
-            #     keyboard shortcuts (always of type list[str])
+            #     keyboard shortcuts (type list[str])
             #     tooltip
-            # ),
-            (
-                'act_take_snapshot',
-                icon.TAKE_SNAPSHOT,
-                _('Take snapshot'),
-                self.btnTakeSnapshotClicked,
-                ['Ctrl+S'],
-                None
-            ),
-            (
-                'act_take_snapshot_checksum',
-                icon.TAKE_SNAPSHOT,
-                _('Take snapshot with checksums'),
-                self.btnTakeSnapshotChecksumClicked,
-                ['Ctrl+Shift+S'],
-                _('Use checksum to detect changes')
-            ),
-            (
-                'act_pause_take_snapshot',
+            #),
+            'act_take_snapshot': (
+                icon.TAKE_SNAPSHOT, _('Take snapshot'),
+                self.btnTakeSnapshotClicked, ['Ctrl+S'], None),
+
+            'act_take_snapshot_checksum': (
+                icon.TAKE_SNAPSHOT, _('Take snapshot with checksums'),
+                self.btnTakeSnapshotChecksumClicked, ['Ctrl+Shift+S'],
+                _('Use checksum to detect changes')),
+
+            'act_pause_take_snapshot': (
                 icon.PAUSE, _('Pause snapshot process'),
                 lambda: os.kill(self.snapshots.pid(), signal.SIGSTOP), None,
-                None
-            ),
-            (
-                'act_resume_take_snapshot',
+                None),
+
+            'act_resume_take_snapshot': (
                 icon.RESUME, _('Resume snapshot process'),
                 lambda: os.kill(self.snapshots.pid(), signal.SIGCONT), None,
-                None
-            ),
-            (
-                'act_stop_take_snapshot',
+                None),
+            'act_stop_take_snapshot': (
                 icon.STOP, _('Stop snapshot process'),
                 self.btnStopTakeSnapshotClicked, None,
-                None
-            ),
-            (
-                'act_update_snapshots',
+                None),
+            'act_update_snapshots': (
                 icon.REFRESH_SNAPSHOT, _('Refresh snapshots list'),
                 self.btnUpdateSnapshotsClicked, ['F5', 'Ctrl+R'],
-                None
-            ),
-            (
-                'act_name_snapshot',
+                None),
+            'act_name_snapshot': (
                 icon.SNAPSHOT_NAME, _('Snapshot Name'),
                 self.btnNameSnapshotClicked, ['F2'],
-                None
-            ),
-            (
-                'act_remove_snapshot',
+                None),
+            'act_remove_snapshot': (
                 icon.REMOVE_SNAPSHOT, _('Remove Snapshot'),
                 self.btnRemoveSnapshotClicked, ['Delete'],
-                None
-            ),
-            (
-                'act_snapshot_logview',
+                None),
+            'act_snapshot_logview': (
                 icon.VIEW_SNAPSHOT_LOG, _('View Snapshot Log'),
                 self.btnSnapshotLogViewClicked, None,
-                None
-            ),
-            (
-                'act_last_logview',
+                None),
+            'act_last_logview': (
                 icon.VIEW_LAST_LOG, _('View Last Log'),
                 self.btnLastLogViewClicked, None,
-                None
-            ),
-            (
-                'act_settings',
+                None),
+            'act_settings': (
                 icon.SETTINGS, _('Settings'),
                 self.btnSettingsClicked, ['Ctrl+Shift+,'],
-                None
-            ),
-            (
-                'act_shutdown',
+                None),
+            'act_shutdown': (
                 icon.SHUTDOWN, _('Shutdown'),
                 None, None,
-                _('Shut down system after snapshot has finished.')
-            ),
-            (
-                'act_quit',
+                _('Shut down system after snapshot has finished.')),
+            'act_quit': (
                 icon.EXIT, _('Exit'),
                 self.close, ['Ctrl+Q'],
-                None
-            ),
-            (
-                'act_help_help',
+                None),
+            'act_help_help': (
                 icon.HELP, _('Help'),
                 self.btnHelpClicked, ['F1'],
-                None,
-            ),
-            (
-                'act_help_configfile',
+                None),
+            'act_help_configfile': (
                 icon.HELP, _('Config File Help'),
-                self.btnHelpConfigClicked, None, None,
-            ),
-            (
-                'act_help_website',
+                self.btnHelpConfigClicked, None, None),
+            'act_help_website': (
                 icon.WEBSITE, _('Website'),
-                self.btnWebsiteClicked, None, None,
-            ),
-            (
-                'act_help_changelog',
+                self.btnWebsiteClicked, None, None),
+            'act_help_changelog': (
                 icon.CHANGELOG, _('Changelog'),
-                self.btnChangelogClicked, None, None,
-            ),
-            (
-                'act_help_faq',
+                self.btnChangelogClicked, None, None),
+            'act_help_faq': (
                 icon.FAQ, _('FAQ'),
-                self.btnFaqClicked, None, None,
-            ),
-            (
-                'act_help_question',
+                self.btnFaqClicked, None, None),
+            'act_help_question': (
                 icon.QUESTION, _('Ask a question'),
-                self.btnAskQuestionClicked, None, None,
-            ),
-
-            (
-                'act_help_bugreport',
+                self.btnAskQuestionClicked, None, None),
+            'act_help_bugreport': (
                 icon.BUG, _('Report a bug'),
-                self.btnReportBugClicked, None, None,
-            ),
-            (
-                'act_help_about',
+                self.btnReportBugClicked, None, None),
+            'act_help_about': (
                 icon.ABOUT, _('About'),
-                self.btnAboutClicked, None, None,
-            ),
-            (
-                'act_restore',
+                self.btnAboutClicked, None, None),
+            'act_restore': (
                 icon.RESTORE, _('Restore'),
                 self.restoreThis, None,
                 _('Restore the selected files or folders to the '
-                  'original destination.')
-            ),
-            (
-                'act_restore_to', icon.RESTORE_TO, _('Restore to …'),
+                  'original destination.')),
+            'act_restore_to': (
+                icon.RESTORE_TO, _('Restore to …'),
                 self.restoreThisTo, None,
                 _('Restore the selected files or folders to a '
-                  'new destination.')
-            ),
-            (
-                'act_restore_parent', icon.RESTORE, 'RESTORE PARENT (DEBUG)',
+                  'new destination.')),
+            'act_restore_parent': (
+                icon.RESTORE, 'RESTORE PARENT (DEBUG)',
                 self.restoreParent, None,
                 _('Restore the currently shown folder and all its contents '
-                  'to the original destination.')
-            ),
-            (
-                'act_restore_parent_to',
+                  'to the original destination.')),
+            'act_restore_parent_to': (
                 icon.RESTORE_TO, 'RESTORE PARENT TO (DEBUG)',
                 self.restoreParentTo, None,
                 _('Restore the currently shown folder and all its contents '
-                  'to a new destination.')
-            ),
-            (
-                'act_folder_up', icon.UP, _('Up'),
-                self.btnFolderUpClicked, ['Alt+Up', 'Backspace'], None
-            ),
-            (
-                'act_show_hidden', icon.SHOW_HIDDEN,
-                _('Show hidden files'),
-                None, ['Ctrl+H'], None
-            ),
-            (
-                'act_snapshots_dialog', icon.SNAPSHOTS, _('Snapshots'),
-                self.btnSnapshotsClicked, None, None
-            ),
-        )
+                  'to a new destination.')),
+            'act_folder_up': (
+                icon.UP, _('Up'),
+                self.btnFolderUpClicked, ['Alt+Up', 'Backspace'], None),
+            'act_show_hidden': (
+                icon.SHOW_HIDDEN, _('Show hidden files'),
+                None, ['Ctrl+H'], None),
+            'act_snapshots_dialog': (
+                icon.SNAPSHOTS, _('Snapshots'),
+                self.btnSnapshotsClicked, None, None),
+        }
 
-        for attr, ico, txt, slot, keys, tip in action_dict:
+        for attr in action_dict:
+            ico, txt, slot, keys, tip = action_dict[attr]
 
             # Create action (with icon)
             action = QAction(ico, txt, self) if ico else \
@@ -601,12 +545,7 @@ class MainWindow(QMainWindow):
             if slot:
                 action.triggered.connect(slot)
 
-            # Workaround for lousy PyQt API.
-            # Even one shortcut should be treated as a list.
-            if isinstance(keys, str):
-                keys = [keys]
-
-            # Add one or multiple key shortcuts
+            # Add keyboardshortcuts
             if keys:
                 action.setShortcuts(keys)
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -415,11 +415,10 @@ class MainWindow(QMainWindow):
             be created in this function.
 
         Note:
-            Shortcuts need be strings in a list even if it is only one entry.
-            It is done this way to spare one ``if...else`` statement deciding
-            between `QAction.setShortcuts()` and `QAction.setShortcut()`
-            (singular; without ``s`` at the end).
-
+            Shortcuts need to be strings in a list even if it is only one
+            entry. It is done this way to spare one ``if...else`` statement
+            deciding between `QAction.setShortcuts()` and
+            `QAction.setShortcut()` (singular; without ``s`` at the end).
         """
 
         action_dict = {

--- a/qt/app.py
+++ b/qt/app.py
@@ -17,8 +17,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import os
 import sys
-# When dropping Python 3.8: "from collections.abc import Callable"
-from typing import Callable, Union
 
 if not os.getenv('DISPLAY', ''):
     os.putenv('DISPLAY', ':0.0')
@@ -50,10 +48,47 @@ import mount
 import progress
 from exceptions import MountException
 
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
-from PyQt5.QtCore import *
-
+from PyQt5.QtGui import QKeySequence, QDesktopServices, QColor, QIcon
+from PyQt5.QtWidgets import (QWidget,
+                             QAction,
+                             QFrame,
+                             QMainWindow,
+                             QLabel,
+                             QLineEdit,
+                             QCheckBox,
+                             QListWidget,
+                             QTreeView,
+                             QTreeWidget,
+                             QTreeWidgetItem,
+                             QAbstractItemView,
+                             QStyledItemDelegate,
+                             QVBoxLayout,
+                             QHBoxLayout,
+                             QStackedLayout,
+                             QSplitter,
+                             QGroupBox,
+                             QMenu,
+                             QToolBar,
+                             QProgressBar,
+                             QMessageBox,
+                             QSizePolicy,
+                             QInputDialog,
+                             QDialog,
+                             QDialogButtonBox,
+                             QShortcut,
+                             QFileSystemModel,
+                             )
+from PyQt5.QtCore import (Qt,
+                          QObject,
+                          pyqtSlot,
+                          pyqtSignal,
+                          QTimer,
+                          QThread,
+                          QEvent,
+                          QSortFilterProxyModel,
+                          QDir,
+                          QSize,
+                          )
 import settingsdialog
 import snapshotsdialog
 import logviewdialog
@@ -72,7 +107,6 @@ class MainWindow(QMainWindow):
         self.lastTakeSnapshotMessage = None
         self.tmpDirs = []
 
-
         # "Magic" object handling shutdown procedure in different desktop
         # environments.
         self.shutdown = tools.ShutDown()
@@ -85,7 +119,7 @@ class MainWindow(QMainWindow):
         self.qapp.setWindowIcon(icon.BIT_LOGO)
 
         self._create_actions()
-        toolbar = self._main_toolbar()
+        self._create_main_toolbar()
 
         self.firstUpdateAll = True
         self.disableProfileChanged = False
@@ -651,30 +685,7 @@ class MainWindow(QMainWindow):
         self.act_resume_take_snapshot.setVisible(False)
         self.act_stop_take_snapshot.setVisible(False)
 
-
-    # def _setup_a_toolbar(self, toolbar, buttons):
-
-    #     for attrname, icon, label, handler, keyshortcuts, tooltip in buttons:
-
-    #         button = toolbar.addAction(icon, label)
-
-    #         if handler:
-    #             button.triggered.connect(handler)
-
-    #         if isinstance(keyshortcuts, str):
-    #             button.setShortcut(keyshortcuts)
-    #         elif isinstance(keyshortcuts, list):
-    #             button.setShortcuts(keyshortcuts)
-
-    #         if tooltip:
-    #             button.setToolTip(tooltip)
-
-    #         if attrname:
-    #             setattr(self, attrname, button)
-
-    #     return toolbar
-
-    def _main_toolbar(self):
+    def _create_main_toolbar(self):
         """Create the main toolbar and connect it to actions."""
 
         toolbar = self.addToolBar('main')
@@ -708,8 +719,6 @@ class MainWindow(QMainWindow):
         empty = QWidget(self)
         empty.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
         toolbar.insertWidget(self.act_mystic_help, empty)
-
-        return toolbar
 
     def closeEvent(self, event):
         if self.shutdown.askBeforeQuit():

--- a/qt/app.py
+++ b/qt/app.py
@@ -411,10 +411,15 @@ class MainWindow(QMainWindow):
         (menu entries, buttons) in later steps.
 
         Note:
+            All actions used in the main window and its child widgets should
+            be created in this function.
+
+        Note:
             Shortcuts need be strings in a list even if it is only one entry.
             It is done this way to spare one ``if...else`` statement deciding
             between `QAction.setShortcuts()` and `QAction.setShortcut()`
             (singular; without ``s`` at the end).
+
         """
 
         action_dict = {
@@ -569,7 +574,7 @@ class MainWindow(QMainWindow):
 
     def _create_shortcuts_without_actions(self):
         """Create shortcuts that are not related to a visual element in the
-        GUI.
+        GUI and don't have an QAction instance because of that.
         """
 
         shortcut_list = (
@@ -606,7 +611,6 @@ class MainWindow(QMainWindow):
             _('&Restore'): (
                 self.act_restore,
                 self.act_restore_to,
-                # self.menuRestore.addSeparator()
                 self.act_restore_parent,
                 self.act_restore_parent_to,
             ),
@@ -632,7 +636,9 @@ class MainWindow(QMainWindow):
         # See "self._enable_restore_ui_elements()" for details.
         self.act_restore_menu = self.menuBar().actions()[2]
 
-        # fine tuning
+        # fine tuning.
+        # Attention: Take care of the actions() index here when modifying the
+        # main menu!
         snapshot = self.menuBar().actions()[0].menu()
         snapshot.insertSeparator(self.act_settings)
         snapshot.insertSeparator(self.act_shutdown)
@@ -1614,6 +1620,11 @@ files that the receiver requests to be transferred.""")
     def _enable_restore_ui_elements(self, enable: bool):
         """Enable or disable all buttons and menu entries related to the
         restore feature.
+
+        If a sepcific snapshot is selected in the timeline widget then all
+        restore UI elements are enabled. If "Now" (the first/root) is selected
+        in the timeline all UI elements related to restoring should be
+        disabled.
         """
 
         # The whole sub-menu incl. its button/entry. The related UI elements

--- a/qt/app.py
+++ b/qt/app.py
@@ -291,7 +291,7 @@ class MainWindow(QMainWindow):
             'qt.last_path',
             self.config.strValue('qt.last_path', '/')
         )
-        self.wdg_current_path.setText(self.path)
+        self.widget_current_path.setText(self.path)
         self.path_history = tools.PathHistory(self.path)
 
         # restore size and position
@@ -713,9 +713,9 @@ class MainWindow(QMainWindow):
         toolbar.addActions(actions_for_toolbar)
 
         # LineEdit widget to display the current path
-        self.wdg_current_path = QLineEdit(self)
-        self.wdg_current_path.setReadOnly(True)
-        toolbar.insertWidget(self.act_show_hidden, self.wdg_current_path)
+        self.widget_current_path = QLineEdit(self)
+        self.widget_current_path.setReadOnly(True)
+        toolbar.insertWidget(self.act_show_hidden, self.widget_current_path)
 
         # Restore sub menu
         restore_sub_menu = self.act_restore_menu.menu()
@@ -840,7 +840,7 @@ class MainWindow(QMainWindow):
             if not path == self.path:
                 self.path = path
                 self.path_history.reset(self.path)
-                self.wdg_current_path.setText(self.path)
+                self.widget_current_path.setText(self.path)
 
             self.updateProfile()
 
@@ -1610,7 +1610,7 @@ files that the receiver requests to be transferred.""")
             self.stackFilesView.setCurrentWidget(self.lblFolderDontExists)
 
         # show current path
-        self.wdg_current_path.setText(self.path)
+        self.widget_current_path.setText(self.path)
         self.act_restore_parent.setText(_(f'Restore {self.path}'))
         self.act_restore_parent_to.setText(_(f'Restore {self.path} to …'))
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -131,34 +131,17 @@ class MainWindow(QMainWindow):
 
         # # Menu: Help
         menuHelp = QMenu(self)
-        self.btnHelp = menuHelp.addAction(icon.HELP, _('Help'))
-        self.btnHelp.setShortcuts([Qt.Key_F1])
-        self.btnHelp.triggered.connect(self.btnHelpClicked)
-        self.btnHelpConfig = menuHelp.addAction(icon.HELP, _('Config File Help'))
-        self.btnHelpConfig.triggered.connect(self.btnHelpConfigClicked)
+        menuHelp.addAction(self.act_help_help)
+        menuHelp.addAction(self.act_help_configfile)
         menuHelp.addSeparator()
-        self.btnWebsite = menuHelp.addAction(icon.WEBSITE, _('Website'))
-        self.btnWebsite.triggered.connect(self.btnWebsiteClicked)
-        self.btnChangelog = menuHelp.addAction(icon.CHANGELOG, _('Changelog'))
-        self.btnChangelog.triggered.connect(self.btnChangelogClicked)
-        self.btnFaq = menuHelp.addAction(icon.FAQ, _('FAQ'))
-        self.btnFaq.triggered.connect(self.btnFaqClicked)
-        self.btnAskQuestion = menuHelp.addAction(icon.QUESTION, _('Ask a question'))
-        self.btnAskQuestion.triggered.connect(self.btnAskQuestionClicked)
-        self.btnReportBug = menuHelp.addAction(icon.BUG, _('Report a bug'))
-        self.btnReportBug.triggered.connect(self.btnReportBugClicked)
+        menuHelp.addAction(self.act_help_website)
+        menuHelp.addAction(self.act_help_changelog)
+        menuHelp.addAction(self.act_help_faq)
+        menuHelp.addAction(self.act_help_question)
+        menuHelp.addAction(self.act_help_bugreport)
         menuHelp.addSeparator()
-        self.btnAbout = menuHelp.addAction(icon.ABOUT, _('About'))
-        self.btnAbout.triggered.connect(self.btnAboutClicked)
+        menuHelp.addAction(self.act_help_about)
 
-        # action = self.mainToolbar.addAction(icon.HELP, _('Help'))
-        # action.triggered.connect(self.btnHelpClicked)
-        # action.setMenu(menuHelp)
-
-        for action in menuHelp.actions():
-            action.setIconVisibleInMenu(True)
-
-        # main splitter
         self.mainSplitter = QSplitter(self)
         self.mainSplitter.setOrientation(Qt.Horizontal)
 
@@ -628,20 +611,53 @@ class MainWindow(QMainWindow):
                 _('Shut down system after snapshot has finished.')
             ),
             (
-                # "Mystic" because there is a second "Help" button somewhere
-                # else. Need to investigate this.
-                'act_mystic_help',
-                icon.HELP, _('Help'),
-                self.btnHelpClicked, None,
-                None
-            ),
-            (
                 'act_quit',
                 icon.EXIT, _('Exit'),
                 self.close, ['Ctrl+Q'],
                 None
             ),
+            (
+                'act_help_help',
+                icon.HELP, _('Help'),
+                self.btnHelpClicked, ['F1'],
+                None,
+            ),
+            (
+                'act_help_configfile',
+                icon.HELP, _('Config File Help'),
+                self.btnHelpConfigClicked, None, None,
+            ),
+            (
+                'act_help_website',
+                icon.WEBSITE, _('Website'),
+                self.btnHelpWebsiteClicked, None, None,
+            ),
+            (
+                'act_help_changelog',
+                icon.CHANGELOG, _('Changelog'),
+                self.btnHelpChangelogClicked, None, None,
+            ),
+            (
+                'act_help_faq',
+                icon.FAQ, _('FAQ'),
+                self.btnHelpFAQClicked, None, None,
+            ),
+            (
+                'act_help_question',
+                icon.QUESTION, _('Ask a question'),
+                self.btnAskQuestionClicked, None, None,
+            ),
 
+            (
+                'act_help_bugreport',
+                icon.BUG, _('Report a bug'),
+                self.btnReportBugClicked, None, None,
+            ),
+            (
+                'act_help_about',
+                icon.ABOUT, _('About'),
+                self.btnAboutClicked, None, None,
+            ),
         )
 
         for attr, ico, txt, slot, keys, tip in action_dict:
@@ -700,7 +716,6 @@ class MainWindow(QMainWindow):
             self.act_last_logview,
             self.act_settings,
             self.act_shutdown,
-            self.act_mystic_help,  # DEBUG !!!
         ]
 
         for act in actions_for_toolbar:

--- a/qt/icon.py
+++ b/qt/icon.py
@@ -23,7 +23,6 @@ from PyQt5.QtGui import QIcon
 for theme in ('ubuntu-mono-dark', 'gnome', 'oxygen'):
     if not QIcon.fromTheme('document-save').isNull():
         break
-    print(f'setThemeName({theme=})')
     QIcon.setThemeName(theme)
 
 #BackInTime Logo

--- a/qt/icon.py
+++ b/qt/icon.py
@@ -23,6 +23,7 @@ from PyQt5.QtGui import QIcon
 for theme in ('ubuntu-mono-dark', 'gnome', 'oxygen'):
     if not QIcon.fromTheme('document-save').isNull():
         break
+    print(f'setThemeName({theme=})')
     QIcon.setThemeName(theme)
 
 #BackInTime Logo

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -605,21 +605,24 @@ class ProfileCombo(SortedComboBox):
                 break
 
 
-class Menu(QMenu):
-    """
-    Subclass QMenu to add ToolTips
-    """
+# Since Qt 5.1 not needed anymore.
+# Use menu.setToolTipsVisible(True).
+# See https://bugreports.qt.io/browse/QTBUG-13663
+# class Menu(QMenu):
+#     """
+#     Subclass QMenu to add ToolTips
+#     """
 
-    def event(self, e):
-        action = self.activeAction()
+#     def event(self, e):
+#         action = self.activeAction()
 
-        if (e.type() == QEvent.ToolTip
-                and action
-                and action.toolTip() != action.text()):
+#         if (e.type() == QEvent.ToolTip
+#                 and action
+#                 and action.toolTip() != action.text()):
 
-            QToolTip.showText(e.globalPos(), self.activeAction().toolTip())
+#             QToolTip.showText(e.globalPos(), self.activeAction().toolTip())
 
-        else:
-            QToolTip.hideText()
+#         else:
+#             QToolTip.hideText()
 
-        return super(Menu, self).event(e)
+#         return super(Menu, self).event(e)


### PR DESCRIPTION
Partly reorganized code in MainWindow related to generation of menus, toolbars and the actions behind it. Also fixed some minor issues. The issues came up on the fly. I saw no way to separate them in a different Issue. But I keep to declare this PR/commit as "refactor" and not as "fix" because the Issues are tiny and didn't cause harm. See detailed list below.

I checked aryodas branch [`1306_tray_icon_master_issue`](https://github.com/aryoda/backintime/tree/issue/1306_tray_icon_master_issue) and can't find potential merge conflicts. But I'll wait for your feedback on that.

My first intention was to add a new menu to give the user the opportunity to modify the UI language. That is why the branch name is that way. But I realized I have to reorganize the code before doing this.

- The code try to follow the Qt concept of separate "actions" (e.g. start snapshot) from visual UI elements (buttons, menus and their entries). An action is not equal to a slot or signal. Good example to see its advantage is how the menu and toolbar elements related to restoring a snapshot are enabled/disabled.
- Generation of actions, menus and buttons are separated into multiple methods to reduce the amount of code in `__init__()`.
- Used underscores (`_`) for variable names (e.g. actions) because it is PEP8 convention. Camel case is suited for class names only.
- Removed some instance attributes `self.*` because there is no need of them. Qt elements are managed by QMainWindow (or components of it) in the back. No need to keep references of them just to keep them alive.
- Removed `qttools.Menu` class, which was a workaround to offer tooltips for menu entries. Qt 5.1 is able to do it itself.
- The buttons "Take snapshot" (main toolbar) and "Restore" (file view toolbar) now have drop-down menus. It was not my idea. As I could see in the "old" code it was intended to be a dropdown button in the past. But it never (?) worked. I just fixed it and made it work. See my comparing screenshots below.
- Main menu -> Snapshots: Removed the "Take Snapshots" submenu and integrated its only entry (Take snapshot with checksum) into the Snapshots menu.
- Removed the Help button from main toolbar. All its content is present in the main menus "Help" menu. It was also drop-down tool button which dropdown menu doesn't work. I wasn't motivated to fix it. I just removed it. I can re-add it without problem if someone like.

This screencast do illustrate the drop-down toolbar buttons and the new "Snapshots" menu.

![Peek 2023-07-17 14-09](https://github.com/bit-team/backintime/assets/11861496/599f8926-8d5d-4c84-8c85-1c582a51f6f3)

Let's compare this with this screenshot of an older version of BIT. Take a look at the three red circles. There are "down arrows" on each of that buttons. But they didn't work in the current BIT version because the drop down menu setup code wasn't finished. It might be that it worked in an older version with Qt4 or something like that.

![image](https://github.com/bit-team/backintime/assets/11861496/24b4c2d0-9736-4741-92c5-fa59af40886e)
