### PR TITLE
Correction of fix #1429 (ignore wayland warning on Gnome)

### DIFF
--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -145,7 +145,7 @@ under certain conditions; type `backintime --license' for details.
             "WARNING: D-Bus message:",
             "WARNING: Udev-based profiles cannot be changed or checked",
             "WARNING: Inhibit Suspend failed",
-            "Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway"
+            "Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway"
         ]
 
         line_contains_to_exclude = [


### PR DESCRIPTION
see issue #1429 

corrects #1431 
