### PR TITLE
feat: Rearrange menu bar in main window

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,2 @@
+Don't forget the changelog entry! ;)
+

--- a/CHANGES
+++ b/CHANGES
@@ -11,15 +11,17 @@ Version 1.3.4-dev (development of upcoming release)
 * Fix bug: Generation of config-manpage caused an error with Debian's Lintian (#1398).
 * Fix bug: Return empty list in smartRemove (#1392, Debian Bug Report 973760)
 * Breaking change: Minimal Python version 3.8 required (#1358).
+* Removed: Handling and checking of user group "fuse" (#1472).
 * Feature: Exclude /swapfile by default (#1053)
+# Feature: Rearranged menu bar and its entries in the main window (#1487, #1478).
 * Documentation: Removed outdated docbook (#1345).
 * Build: Introduced .readthedocs.yaml as asked by ReadTheDocs.org (#1443).
 * Dependency: The oxygen icons should be installed with the BiT Qt GUI since they are used as fallback in case of missing icons
 * Fix bug: Add support for ChainerBackend class as keyring which iterates over all supported keyring backends (#1410)
 * Translation: Strings to translate now easier to understand for translators (#1448, #1457, #1462).
 * Translation: Updated and completed "German" (#1454).
-* Translation: Remove language Canadian English, British English and Javanese (#1455).
-* Translation: Persian and Vietnamese added (#1460).
+* Removed: Translation in Canadian English, British English and Javanese (#1455).
+* Added: Tranlsation in Persian and Vietnamese (#1460).
 
 Version 1.3.3 (2023-01-04)
 * New feature: Command line argument "--diagnostics" to show helpful info for better issue support (#1100)

--- a/CHANGES
+++ b/CHANGES
@@ -21,7 +21,7 @@ Version 1.3.4-dev (development of upcoming release)
 * Translation: Strings to translate now easier to understand for translators (#1448, #1457, #1462).
 * Translation: Updated and completed "German" (#1454).
 * Removed: Translation in Canadian English, British English and Javanese (#1455).
-* Added: Tranlsation in Persian and Vietnamese (#1460).
+* Added: Translation in Persian and Vietnamese (#1460).
 
 Version 1.3.3 (2023-01-04)
 * New feature: Command line argument "--diagnostics" to show helpful info for better issue support (#1100)

--- a/qt/app.py
+++ b/qt/app.py
@@ -429,13 +429,14 @@ class MainWindow(QMainWindow):
             #     tooltip
             #),
             'act_take_snapshot': (
-                icon.TAKE_SNAPSHOT, _('Take snapshot'),
-                self.btnTakeSnapshotClicked, ['Ctrl+S'], None),
+                icon.TAKE_SNAPSHOT, _('Take a snapshot'),
+                self.btnTakeSnapshotClicked, ['Ctrl+S'],
+                _('Use modification time & size for file change detection.')),
 
             'act_take_snapshot_checksum': (
-                icon.TAKE_SNAPSHOT, _('Take snapshot with checksums'),
+                icon.TAKE_SNAPSHOT, _('Take a snapshot (checksum mode)'),
                 self.btnTakeSnapshotChecksumClicked, ['Ctrl+Shift+S'],
-                _('Use checksum to detect changes')),
+                _('Use checksums for file change detection.')),
 
             'act_pause_take_snapshot': (
                 icon.PAUSE, _('Pause snapshot process'),
@@ -451,27 +452,27 @@ class MainWindow(QMainWindow):
                 self.btnStopTakeSnapshotClicked, None,
                 None),
             'act_update_snapshots': (
-                icon.REFRESH_SNAPSHOT, _('Refresh snapshots list'),
+                icon.REFRESH_SNAPSHOT, _('Refresh snapshot list'),
                 self.btnUpdateSnapshotsClicked, ['F5', 'Ctrl+R'],
                 None),
             'act_name_snapshot': (
-                icon.SNAPSHOT_NAME, _('Snapshot Name'),
+                icon.SNAPSHOT_NAME, _('Name snapshot'),
                 self.btnNameSnapshotClicked, ['F2'],
                 None),
             'act_remove_snapshot': (
-                icon.REMOVE_SNAPSHOT, _('Remove Snapshot'),
+                icon.REMOVE_SNAPSHOT, _('Remove snapshot'),
                 self.btnRemoveSnapshotClicked, ['Delete'],
                 None),
             'act_snapshot_logview': (
-                icon.VIEW_SNAPSHOT_LOG, _('View Snapshot Log'),
+                icon.VIEW_SNAPSHOT_LOG, _('View snapshot log'),
                 self.btnSnapshotLogViewClicked, None,
                 None),
             'act_last_logview': (
-                icon.VIEW_LAST_LOG, _('View Last Log'),
+                icon.VIEW_LAST_LOG, _('View last log'),
                 self.btnLastLogViewClicked, None,
                 None),
             'act_settings': (
-                icon.SETTINGS, _('Settings'),
+                icon.SETTINGS, _('Manage profiles…'),
                 self.btnSettingsClicked, ['Ctrl+Shift+,'],
                 None),
             'act_shutdown': (
@@ -487,7 +488,7 @@ class MainWindow(QMainWindow):
                 self.btnHelpClicked, ['F1'],
                 None),
             'act_help_configfile': (
-                icon.HELP, _('Config File Help'),
+                icon.HELP, _('Profiles config file'),
                 self.btnHelpConfigClicked, None, None),
             'act_help_website': (
                 icon.WEBSITE, _('Website'),
@@ -534,7 +535,7 @@ class MainWindow(QMainWindow):
                 icon.SHOW_HIDDEN, _('Show hidden files'),
                 None, ['Ctrl+H'], None),
             'act_snapshots_dialog': (
-                icon.SNAPSHOTS, _('Snapshots'),
+                icon.SNAPSHOTS, _('Compare snapshots…'),
                 self.btnSnapshotsClicked, None, None),
         }
 
@@ -590,22 +591,20 @@ class MainWindow(QMainWindow):
         """Create the menubar and connect it to actions."""
 
         menu_dict = {
-            _('&Snapshot'): (
-                self.act_take_snapshot,
-                self.act_take_snapshot_checksum,
-                self.act_update_snapshots,
-                self.act_name_snapshot,
-                self.act_remove_snapshot,
-                self.act_settings,
+            'Back In &Time': (
                 self.act_shutdown,
                 self.act_quit,
             ),
-            _('&View'): (
-                self.act_folder_up,
-                self.act_show_hidden,
+            _('&Backup'): (
+                self.act_take_snapshot,
+                self.act_take_snapshot_checksum,
+                self.act_settings,
+                self.act_snapshots_dialog,
+                self.act_name_snapshot,
+                self.act_remove_snapshot,
                 self.act_snapshot_logview,
                 self.act_last_logview,
-                self.act_snapshots_dialog,
+                self.act_update_snapshots,
             ),
             _('&Restore'): (
                 self.act_restore,
@@ -638,12 +637,9 @@ class MainWindow(QMainWindow):
         # fine tuning.
         # Attention: Take care of the actions() index here when modifying the
         # main menu!
-        snapshot = self.menuBar().actions()[0].menu()
-        snapshot.insertSeparator(self.act_settings)
-        snapshot.insertSeparator(self.act_shutdown)
-        view = self.menuBar().actions()[1].menu()
-        view.insertSeparator(self.act_snapshot_logview)
-        view.insertSeparator(self.act_snapshots_dialog)
+        backup = self.menuBar().actions()[1].menu()
+        backup.insertSeparator(self.act_settings)
+        backup.insertSeparator(self.act_snapshot_logview)
         help = self.menuBar().actions()[-1].menu()
         help.insertSeparator(self.act_help_website)
         help.insertSeparator(self.act_help_about)

--- a/qt/app.py
+++ b/qt/app.py
@@ -473,7 +473,7 @@ class MainWindow(QMainWindow):
                 None),
             'act_settings': (
                 icon.SETTINGS, _('Manage profiles…'),
-                self.btnSettingsClicked, ['Ctrl+Shift+,'],
+                self.btnSettingsClicked, ['Ctrl+Shift+P'],
                 None),
             'act_shutdown': (
                 icon.SHUTDOWN, _('Shutdown'),

--- a/qt/app.py
+++ b/qt/app.py
@@ -627,6 +627,7 @@ class MainWindow(QMainWindow):
         for key in menu_dict:
             menu = self.menuBar().addMenu(key)
             menu.addActions(menu_dict[key])
+            menu.setToolTipsVisible(True)
 
         # The action of the restore menu. It is used by the menuBar and by the
         # files toolbar.


### PR DESCRIPTION
Rearrange the menu bar in main window and its entries. Some labels and tooltips are modified.

I would say the entry for a Language Selection and maybe for Diagnostics can be handled in a separate PR.

Different from our discussion in #1482 I modified the order of the entries in the sub menus a bit. It is just a proposal and easy to modify.
![Peek 2023-07-26 11-38](https://github.com/bit-team/backintime/assets/11861496/50c6f55d-2374-4fe7-92f4-b0e0b452985e)

Close #1482