### PR TITLE
fix: Naming of actions/buttons variables in MainWindow

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -9,7 +9,7 @@
   * [If I edit my crontab and add additional entries, will that be a problem for BIT as long as I don't touch its entries? What does it look for in the crontab to find its own entries?](#if-i-edit-my-crontab-and-add-additional-entries-will-that-be-a-problem-for-bit-as-long-as-i-dont-touch-its-entries-what-does-it-look-for-in-the-crontab-to-find-its-own-entries)
 - [Known Errors and Warnings](#known-errors-and-warnings)
   * [WARNING: A backup is already running](#warning-a-backup-is-already-running)
-  * [The application is already running!](#the-application-is-already-running---pid--1234567-)
+  * [The application is already running!](#the-application-is-already-running-pid-1234567)
 - [Error Handling](#error-handling)
   * [What happens if I hibernate the computer while a backup is running?](#what-happens-if-i-hibernate-the-computer-while-a-backup-is-running)
   * [What happens if I power down the computer while a backup is running, or if a power outage happens?](#what-happens-if-i-power-down-the-computer-while-a-backup-is-running-or-if-a-power-outage-happens)

--- a/FAQ.md
+++ b/FAQ.md
@@ -126,7 +126,7 @@ call the gui options!`` which will prevent *Back In Time* to remove user defined
 schedules.
 
 ## Known Errors and Warnings
-## WARNING: A backup is already running
+### WARNING: A backup is already running
 _Back In Time_ uses signal files like `worker.lock` to avoid starting the same backup twice.
 Normally it is deleted as soon as the backup finishes. In some case something went wrong
 so that _Back In Time_ was forcefully stopped without having the chance to delete
@@ -142,6 +142,13 @@ ps aux | grep -i backintime
 
 If the output shows a running instance of _Back In Time_ it must be waited until it finishes
 or killed via `kill <process id>`.
+
+### The application is already running! (pid: 1234567)
+This message occurs when _Back In Time_ did not finish regularly and wasn't able
+to delete its application lock file. Before deleting that file make sure
+no backintime process is running via `ps aux | grep -i backintime`. Otherwise
+kill the process. After that lock into the folder
+`~/.local/share/backintime` for the file `app.loc.pid` and delete it.
 
 ## Error Handling
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -148,7 +148,7 @@ or killed via `kill <process id>`.
 This message occurs when _Back In Time_ did not finish regularly and wasn't able
 to delete its application lock file. Before deleting that file make sure
 no backintime process is running via `ps aux | grep -i backintime`. Otherwise
-kill the process. After that lock into the folder
+kill the process. After that look into the folder
 `~/.local/share/backintime` for the file `app.loc.pid` and delete it.
 
 ## Error Handling

--- a/FAQ.md
+++ b/FAQ.md
@@ -9,6 +9,7 @@
   * [If I edit my crontab and add additional entries, will that be a problem for BIT as long as I don't touch its entries? What does it look for in the crontab to find its own entries?](#if-i-edit-my-crontab-and-add-additional-entries-will-that-be-a-problem-for-bit-as-long-as-i-dont-touch-its-entries-what-does-it-look-for-in-the-crontab-to-find-its-own-entries)
 - [Known Errors and Warnings](#known-errors-and-warnings)
   * [WARNING: A backup is already running](#warning-a-backup-is-already-running)
+  * [The application is already running!](#the-application-is-already-running---pid--1234567-)
 - [Error Handling](#error-handling)
   * [What happens if I hibernate the computer while a backup is running?](#what-happens-if-i-hibernate-the-computer-while-a-backup-is-running)
   * [What happens if I power down the computer while a backup is running, or if a power outage happens?](#what-happens-if-i-power-down-the-computer-while-a-backup-is-running-or-if-a-power-outage-happens)

--- a/qt/app.py
+++ b/qt/app.py
@@ -862,6 +862,7 @@ class MainWindow(QMainWindow):
             self.forceWaitLockCounter = 10
 
         busy = self.snapshots.busy()
+
         if busy:
             self.forceWaitLockCounter = 0
             paused = tools.processPaused(self.snapshots.pid())
@@ -875,9 +876,11 @@ class MainWindow(QMainWindow):
 
         message = _('Working:')
         takeSnapshotMessage = self.snapshots.takeSnapshotMessage()
+
         if fake_busy:
             if takeSnapshotMessage is None:
                 takeSnapshotMessage = (0, '…')
+
         elif takeSnapshotMessage is None:
             takeSnapshotMessage = self.lastTakeSnapshotMessage
             if takeSnapshotMessage is None:
@@ -885,19 +888,19 @@ class MainWindow(QMainWindow):
 
         force_update = False
 
-        if fake_busy:
-            if self.btnTakeSnapshot.isEnabled():
-                self.btnTakeSnapshot.setEnabled(False)
+        if fake_busy:  # What is this?
+            if self.act_take_snapshot.isEnabled():
+                self.act_take_snapshot.setEnabled(False)
 
-            if not self.btnStopTakeSnapshot.isVisible():
-                for btn in (self.btnPauseTakeSnapshot,
-                            self.btnResumeTakeSnapshot,
-                            self.btnStopTakeSnapshot):
-                    btn.setEnabled(True)
-            self.btnTakeSnapshot.setVisible(False)
-            self.btnPauseTakeSnapshot.setVisible(not paused)
-            self.btnResumeTakeSnapshot.setVisible(paused)
-            self.btnStopTakeSnapshot.setVisible(True)
+            if not self.act_stop_take_snapshot.isVisible():
+                for action in (self.act_pause_take_snapshot,
+                            self.act_resume_take_snapshot,
+                            self.act_stop_take_snapshot):
+                    action.setEnabled(True)
+            self.act_take_snapshot.setVisible(False)
+            self.act_pause_take_snapshot.setVisible(not paused)
+            self.act_resume_take_snapshot.setVisible(paused)
+            self.act_stop_take_snapshot.setVisible(True)
 
         elif not self.act_take_snapshot.isEnabled():
             force_update = True
@@ -907,7 +910,7 @@ class MainWindow(QMainWindow):
             for action in (self.act_pause_take_snapshot,
                            self.act_resume_take_snapshot,
                            self.act_stop_take_snapshot):
-                btn.setVisible(False)
+                action.setVisible(False)
 
             # TODO: check if there is a more elegant way than always get a
             # new snapshot list which is very expensive (time)
@@ -1095,9 +1098,9 @@ class MainWindow(QMainWindow):
 
     def btnStopTakeSnapshotClicked(self):
         os.kill(self.snapshots.pid(), signal.SIGKILL)
-        self.btnStopTakeSnapshot.setEnabled(False)
-        self.btnPauseTakeSnapshot.setEnabled(False)
-        self.btnResumeTakeSnapshot.setEnabled(False)
+        self.act_stop_take_snapshot.setEnabled(False)
+        self.act_pause_take_snapshot.setEnabled(False)
+        self.act_resume_take_snapshot.setEnabled(False)
         self.snapshots.setTakeSnapshotMessage(0, 'Snapshot terminated')
 
     def btnUpdateSnapshotsClicked(self):
@@ -1601,9 +1604,10 @@ files that the receiver requests to be transferred.""")
 
             # TODO: find a signal for this
             self.dirListerCompleted()
+
         else:
             self._enable_restore_ui_elements(False)
-            self.btnSnapshots.setEnabled(False)
+            self.act_snapshots_dialog.setEnabled(False)
             self.stackFilesView.setCurrentWidget(self.lblFolderDontExists)
 
         # show current path


### PR DESCRIPTION
Fix naming of action variables in main window.

This was introduced via refactoring buttons/actions in the main window.