### PR TITLE
feat: Language in config file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,7 +13,8 @@ Version 1.3.4-dev (development of upcoming release)
 * Breaking change: Minimal Python version 3.8 required (#1358).
 * Removed: Handling and checking of user group "fuse" (#1472).
 * Feature: Exclude /swapfile by default (#1053)
-# Feature: Rearranged menu bar and its entries in the main window (#1487, #1478).
+* Feature: Rearranged menu bar and its entries in the main window (#1487, #1478).
+* Feature: Configure user interface language via config file.
 * Documentation: Removed outdated docbook (#1345).
 * Build: Introduced .readthedocs.yaml as asked by ReadTheDocs.org (#1443).
 * Dependency: The oxygen icons should be installed with the BiT Qt GUI since they are used as fallback in case of missing icons

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -27,7 +27,7 @@ import json
 import tools
 # Workaround for situations where startApp() is not invoked.
 # E.g. when using --diagnostics and other argparse.Action
-tools.initiate_translation()
+tools.initiate_translation(None)
 
 import config
 import logger

--- a/common/config.py
+++ b/common/config.py
@@ -560,7 +560,7 @@ class Config(configfile.ConfigFileWithProfiles):
         return self.strValue('global.language', '')
 
     def setLanguage(self, language: str):
-        self.setStrValue('globl.language', language)
+        self.setStrValue('global.language', language)
 
     # SSH
     def sshSnapshotsPath(self, profile_id = None):

--- a/common/config.py
+++ b/common/config.py
@@ -192,6 +192,9 @@ class Config(configfile.ConfigFileWithProfiles):
     PLUGIN_MANAGER = pluginmanager.PluginManager()
 
     def __init__(self, config_path=None, data_path=None):
+        # Note: The main profiles name here is translated using the systems
+        # current locale because the language code in the config file wasn't
+        # read yet.
         configfile.ConfigFileWithProfiles.__init__(self, _('Main profile'))
 
         self._APP_PATH = tools.backintimePath()
@@ -326,7 +329,10 @@ class Config(configfile.ConfigFileWithProfiles):
         self.inhibitCookie = None
         self.setupUdev = tools.SetupUdev()
 
-        tools.initiate_translation()
+        tools.initiate_translation(self.language())
+
+        # Workaround
+        self.default_profile_name = _('Main profile')
 
     def save(self):
         self.setIntValue('config.version', self.CONFIG_VERSION)
@@ -545,6 +551,16 @@ class Config(configfile.ConfigFileWithProfiles):
     def incrementHashCollision(self):
         value = self.hashCollision() + 1
         self.setIntValue('global.hash_collision', value)
+
+    def language(self) -> str:
+        #?Language code (ISO 639) used to translate the user interface.
+        #?If empty the operating systems current local is used. If 'en' the
+        #?translation is not active and the original English source strings
+        #?are used. It is the same if the value is unknown.
+        return self.strValue('global.language', '')
+
+    def setLanguage(self, language: str):
+        self.setStrValue('globl.language', language)
 
     # SSH
     def sshSnapshotsPath(self, profile_id = None):

--- a/common/man/C/backintime-config.1
+++ b/common/man/C/backintime-config.1
@@ -1,4 +1,4 @@
-.TH backintime-config 1 "May 2023" "version 1.3.4-dev" "USER COMMANDS"
+.TH backintime-config 1 "Aug 2023" "version 1.3.4-dev" "USER COMMANDS"
 .SH NAME
 config \- BackInTime configuration files.
 .SH SYNOPSIS
@@ -35,6 +35,15 @@ Type: int       Allowed Values: 0-99999
 Internal value used to prevent hash collisions on mountpoints. Do not change this.
 .PP
 Default: 0
+.RE
+
+.IP "\fIglobal.language\fR" 6
+.RS
+Type: str       Allowed Values: text
+.br
+Language code (ISO 639) used to translate the user interface. If empty the operating systems current local is used. If 'en' the translation is not active and the original English source strings are used. It is the same if the value is unknown.
+.PP
+Default: ''
 .RE
 
 .IP "\fIglobal.use_flock\fR" 6

--- a/common/password.py
+++ b/common/password.py
@@ -264,9 +264,13 @@ class Password(object):
                 password = ''
             return password
 
-        password = messagebox.askPasswordDialog(parent, self.config.APP_NAME,
-                    prompt = prompt,
-                    timeout = 300)
+        password = messagebox.askPasswordDialog(
+            parent=parent,
+            title=self.config.APP_NAME,
+            prompt=prompt,
+            language_code=self.config.language(),
+            timeout=300)
+
         return password
 
     def setPasswordDb(self, service_name, user_name, password):

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -34,7 +34,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import logger
 import tools
 # Needed because backintime.startApp() is not invoked.
-tools.initiate_translation()
+tools.initiate_translation(None)
 import config
 import snapshots
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -104,17 +104,22 @@ _GETTEXT_DOMAIN = 'backintime'
 _GETTEXT_LOCALE_DIR = os.path.join(sharePath(), 'locale')
 
 
-def initiate_translation(language_code: str = None):
+def initiate_translation(language_code: str):
     """Initiate Class-based API of GNU gettext.
 
     Args:
         language_code: Language code to use (based on ISO-639-1).
 
-    It installs the ``_()`` in the ``builtins`` namespace and eliminates the
-    need to ``import gettext`` and declare ``_()`` in each module. The systems
-    current local is used if no language code is provided.
+    It installs the ``_()`` (and ``ngettext()`` for plural forms)  in the
+    ``builtins`` namespace and eliminates the need to ``import gettext``
+    and declare ``_()`` in each module. The systems current local is used
+    if the language code is None.
     """
-    # language_code = 'ja'  # DEBUG
+
+    if language_code:
+        logger.debug(f'Language code "{language_code}".')
+    else:
+        logger.debug(f'No language code. Use systems current locale.')
 
     translation = gettext.translation(
         domain=_GETTEXT_DOMAIN,
@@ -123,6 +128,9 @@ def initiate_translation(language_code: str = None):
         fallback=True
     )
     translation.install(names=['ngettext'])
+
+    # logger.debug('Translate test: "{}" -> "{}"'
+    #              .format('Disabled', _('Disabled')))
 
 
 # |------------------------------------|

--- a/qt/app.py
+++ b/qt/app.py
@@ -34,7 +34,7 @@ qttools_path.registerBackintimePath('common')
 
 # Workaround until the codebase is rectified/equalized.
 import tools
-tools.initiate_translation()
+tools.initiate_translation(None)
 
 import qttools
 
@@ -1896,7 +1896,7 @@ if __name__ == '__main__':
 
     logger.openlog()
     qapp = qttools.createQApplication(cfg.APP_NAME)
-    translator = qttools.translator()
+    translator = qttools.initiate_translator(cfg.language())
     qapp.installTranslator(translator)
 
     mainWindow = MainWindow(cfg, appInstance, qapp)

--- a/qt/messagebox.py
+++ b/qt/messagebox.py
@@ -20,10 +20,10 @@ from PyQt5.QtWidgets import QApplication, QMessageBox, QInputDialog, QLineEdit,\
 import qttools
 
 
-def askPasswordDialog(parent, title, prompt, timeout = None):
+def askPasswordDialog(parent, title, prompt, language_code, timeout):
     if parent is None:
         app = qttools.createQApplication()
-        translator = qttools.translator()
+        translator = qttools.initate_translator(language_code)
         app.installTranslator(translator)
 
     import icon

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -55,7 +55,7 @@ class QtSysTrayIcon:
                                %sys.argv[1], self)
 
         self.qapp = qttools.createQApplication(self.config.APP_NAME)
-        translator = qttools.translator()
+        translator = qttools.initiate_translator(self.config.language())
         self.qapp.installTranslator(translator)
         self.qapp.setQuitOnLastWindowClosed(False)
 

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -263,7 +263,7 @@ def createQApplication(app_name='Back In Time'):
     return qapp
 
 
-def translator(language_code: str = None) -> QTranslator:
+def initiate_translator(language_code: str) -> QTranslator:
     """Creating an Qt related translator.
 
     Args:
@@ -271,16 +271,27 @@ def translator(language_code: str = None) -> QTranslator:
 
     This is done beside the primarily used GNU gettext because Qt need to
     translate its own default elements like Yes/No-buttons. The systems
-    current local is used when no language code is provided.
+    current local is used when no language code is provided. Translation is
+    deactivated if language code is unknown.
     """
 
     translator = QTranslator()
 
-    if not language_code:
+    if language_code:
+        logger.debug(f'Language code "{language_code}".')
+    else:
+        logger.debug(f'No language code. Use systems current locale.')
         language_code = QLocale.system().name()
 
-    translator.load(f'qt_{language_code}',
-                    QLibraryInfo.location(QLibraryInfo.TranslationsPath))
+    rc = translator.load(
+        f'qt_{language_code}',
+        QLibraryInfo.location(QLibraryInfo.TranslationsPath))
+
+    if rc == False:
+        logger.warning(
+            'PyQt was not able to install a translator for language code '
+            f'"{language_code}". Deactivate translation and falling back to '
+            'the source language (English).')
 
     return translator
 


### PR DESCRIPTION
New key "global.language" in config file to customize the UI language.

Language codes are used as values. If empty (or key not present) the systems current locale is used. If "en" or unknown the sources strings (in English) are used as fallback.

No matter that it hurt me I decided against creating a unit test for "global.language" config value. I have a refactoring about the config-file handling in my mind which will ease up a lot of things including unit testing.