### PR TITLE
fix: More clear diagnostic output for rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ You only need to specify 3 things:
 
 ## Maintenance status
 
-The development of this project has been dormant for a while. But a small team has started
-in summer 2022 to get things moving again. Stick with us, we all ♥️ _Back In Time_. 😁
+A small team has started in summer 2022 to get things moving again after the
+development of this project has been dormant for a while.
+Stick with us, we all ♥️ _Back In Time_. 😁
 
 We are currently focusing on fixing
 [major issues](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%3Aopen+label%3AHigh)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ see [CONTRIBUTING](CONTRIBUTING.md) and have a look on
 those labeld as [good first](https://github.com/bit-team/backintime/labels/GOOD%20FIRST%20ISSUE)
 and [help wanted](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%3Aopen+label%3AHELP-WANTED).
 
-[help wanted](issues?q=is%3Aissue+is%3Aopen+label%3AHELP-WANTED).
-
 ## Index
 
 - [Documentation, FAQs, Support](#documentation-faqs-support)

--- a/README.md
+++ b/README.md
@@ -27,9 +27,17 @@ You only need to specify 3 things:
 The development of this project has been dormant for a while. But a small team has started
 in summer 2022 to get things moving again. Stick with us, we all ♥️ _Back In Time_. 😁
 
-We are currently trying to fix the [major issues](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%3Aopen+label%3AHigh)
-while not implementing new features. If you are interested in the development,
-please see [CONTRIBUTING](CONTRIBUTING.md).
+We are currently focusing on fixing
+[major issues](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%3Aopen+label%3AHigh)
+instead of implementing new
+[features](https://github.com/bit-team/backintime/labels/Feature).
+If you are interested in the development, please
+see [CONTRIBUTING](CONTRIBUTING.md) and have a look on
+[open issues](https://github.com/bit-team/backintime/issues) especially
+those labeld as [good first](https://github.com/bit-team/backintime/labels/GOOD%20FIRST%20ISSUE)
+and [help wanted](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%3Aopen+label%3AHELP-WANTED).
+
+[help wanted](issues?q=is%3Aissue+is%3Aopen+label%3AHELP-WANTED).
 
 ## Index
 

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -136,7 +136,8 @@ def collect_diagnostics():
     result['external-programs'] = {}
 
     # rsync
-    # rsync >= 3.2.6: -VV return a json
+    # rsync >= 3.2.7: -VV return a json
+    # rsync == 3.2.6: Not tested what -VV returns here.
     # rsync <= 3.2.5 and > (somewhere near) 3.1.3: -VV return the same as -V
     # rsync <= (somewhere near) 3.1.3: -VV doesn't exists
     # rsync == 3.1.3 (Ubuntu 20 LTS) doesn't even know '-V'
@@ -156,6 +157,14 @@ def collect_diagnostics():
             ['rsync', '--version'],
             r'rsync  version (.*)  protocol version'
         )
+    else:
+        # Rsync provided its informations in JSON format.
+        # Remove some irrelevant informatons.
+        for key in ['program', 'copyright', 'url', 'license', 'caveat']:
+            try:
+                del result['external-programs']['rsync'][key]
+            except KeyError:
+                pass
 
     # ssh
     result['external-programs']['ssh'] = _get_extern_versions(['ssh', '-V'])

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -137,8 +137,7 @@ def collect_diagnostics():
 
     # rsync
     # rsync >= 3.2.7: -VV return a json
-    # rsync == 3.2.6: Not tested what -VV returns here.
-    # rsync <= 3.2.5 and > (somewhere near) 3.1.3: -VV return the same as -V
+    # rsync <= 3.2.6 and > (somewhere near) 3.1.3: -VV return the same as -V
     # rsync <= (somewhere near) 3.1.3: -VV doesn't exists
     # rsync == 3.1.3 (Ubuntu 20 LTS) doesn't even know '-V'
 

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -149,6 +149,8 @@ def collect_diagnostics():
         try_json=True,
         error_pattern=r'unknown option'
     )
+    print(result['external-programs']['rsync'])
+    sys.exit()
 
     # When -VV was unknown use -V and parse the human readable output
     if not result['external-programs']['rsync']:
@@ -157,9 +159,9 @@ def collect_diagnostics():
             ['rsync', '--version'],
             r'rsync  version (.*)  protocol version'
         )
-    else:
-        # Rsync provided its informations in JSON format.
-        # Remove some irrelevant informatons.
+    elif isinstance(result['external-programs']['rsync'], dict):
+        # Rsync (>= 3.2.7)provided its information in JSON format.
+        # Remove some irrelevant informaton.
         for key in ['program', 'copyright', 'url', 'license', 'caveat']:
             try:
                 del result['external-programs']['rsync'][key]

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -149,8 +149,6 @@ def collect_diagnostics():
         try_json=True,
         error_pattern=r'unknown option'
     )
-    print(result['external-programs']['rsync'])
-    sys.exit()
 
     # When -VV was unknown use -V and parse the human readable output
     if not result['external-programs']['rsync']:


### PR DESCRIPTION
Rsync 3.2.7 and higher is bit too verbose with `-VV` option. This PR does remove some of the information from the `--diagnostic` output. This was discovered as a side note in #1495 .

Add info and links about two new Issues tags to README.md. The tags "help-wanted" and "good first issue" are used by 24pullrequests.com to choose and offer relevant issues to their users.