### PR TITLE
feat: Diagnostic output using alternative os-release infos

### DIFF
--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -381,10 +381,11 @@ def _get_os_release():
 
     # read and parse the os-release file (first)
     fp = etc_path / 'os-release'
+
+    osrelease = {'os-release': _get_pretty_name_or_content(fp)}
+
     if fp in os_files:
         os_files.remove(fp)
-        osrelease = {
-            'os-release': _get_pretty_name_or_content(fp)}
 
     # alternative release files
     for fp in os_files:

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -353,14 +353,9 @@ def _get_os_release():
         files where found.
     """
 
-    try:
-        # content of /etc/os-release
-        return platform.freedesktop_os_release()  # since Python 3.10
-    except AttributeError:  # refactor: when we drop Python 3.9 support
-        pass
-
     def _get_pretty_name_or_content(fp):
-        """Extract value of PRETTY_NAME variable of the text"""
+        """Return value of PRETTY_NAME from a release file or return the whole
+        file content."""
 
         # Read content from file
         try:
@@ -378,9 +373,8 @@ def _get_os_release():
             # Return full content when no PRETTY_NAME was found
             return content
 
-    # read and parse the os-release file ourself
+    # read and parse the os-release file (first)
     fp = Path('/etc') / 'os-release'
-
     osrelease = {
         'os-release': _get_pretty_name_or_content(fp)}
 

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -7,6 +7,7 @@ and to enrich them with the necessary information as uncomplicated as possible.
 
 import sys
 import os
+import itertools
 from pathlib import Path
 import pwd
 import platform
@@ -373,13 +374,20 @@ def _get_os_release():
             # Return full content when no PRETTY_NAME was found
             return content
 
+    etc_path = Path('/etc')
+    os_files = list(itertools.chain(
+        etc_path.glob('*release*'),
+        etc_path.glob('*version*')))
+
     # read and parse the os-release file (first)
-    fp = Path('/etc') / 'os-release'
-    osrelease = {
-        'os-release': _get_pretty_name_or_content(fp)}
+    fp = etc_path / 'os-release'
+    if fp in os_files:
+        os_files.remove(fp)
+        osrelease = {
+            'os-release': _get_pretty_name_or_content(fp)}
 
     # alternative release files
-    for fp in Path('/etc').glob('*release'):
+    for fp in os_files:
 
         # This file was processed before
         if fp.name == 'os-release':

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -375,26 +375,23 @@ def _get_os_release():
             return content
 
     etc_path = Path('/etc')
-    os_files = list(itertools.chain(
-        etc_path.glob('*release*'),
-        etc_path.glob('*version*')))
+    os_files = list(filter(lambda p: p.is_file(),
+                           itertools.chain(
+                               etc_path.glob('*release*'),
+                               etc_path.glob('*version*'))
+                           ))
 
-    # read and parse the os-release file (first)
+    # "os-release" is standard and should be on top of the list
     fp = etc_path / 'os-release'
-
-    osrelease = {'os-release': _get_pretty_name_or_content(fp)}
-
-    if fp in os_files:
+    try:
         os_files.remove(fp)
+    except ValueError:
+        pass
+    else:
+        os_files = [fp] + os_files
 
-    # alternative release files
-    for fp in os_files:
-
-        # This file was processed before
-        if fp.name == 'os-release':
-            continue
-
-        osrelease[str(fp)] = _get_pretty_name_or_content(fp)
+    # each release/version file found
+    osrelease = {str(fp): _get_pretty_name_or_content(fp) for fp in os_files}
 
     # No alternative release files found
     if len(osrelease) == 1:

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -96,7 +96,6 @@ class Diagnostics_FakeFS(pyfakefs_ut.TestCase):
     def setUp(self):
         self.setUpPyfakefs(allow_root_user=False)
 
-
     def test_git_repo_info(self):
 
         # not a git repo

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -9,8 +9,6 @@ import diagnostics  # testing target
 
 
 class Diagnostics(unittest.TestCase):
-    """
-    """
 
     def test_minimal(self):
         """Minimal set of elements."""
@@ -99,10 +97,7 @@ class Diagnostics_FakeFS(pyfakefs_ut.TestCase):
         self.setUpPyfakefs(allow_root_user=False)
 
 
-
     def test_git_repo_info(self):
-        """
-        """
 
         # not a git repo
         self.assertEqual(diagnostics.get_git_repository_info(), None)


### PR DESCRIPTION
Because of #1517 I realized that GNU Linux distros have a lot of variants to identify them self. Sometimes they do not follow the standards and sometimes they violate them (like MX Linux in #1517 identifing itself as "Debian").

In addition to the former behavior BIT now add information from `/etc/*release` files if they are present.
I removed the use of `platform.freedesktop_os_release()` (added in Python 3.10) because it does nothing more then reading the /etc/os-release file what we can do our self.

Here is an output example of content from files I created myself because Debian do offer a "os-release" file.

![image](https://github.com/bit-team/backintime/assets/11861496/0a35b615-0721-4788-96bf-aa70e595553d)

In relation to #1517 on MX Linux the output would look like this:

```
"host-setup": {
    "OS": {
        "os-release": "Debian GNU/Linux 11 (bullseye)",
        "/etc/lsb-release": "MX Linux 21.3 etc pp",

```