### PR TITLE
fix: Check SSH login works on machines with limited commands (#1442)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Back In Time
 Version 1.3.4-dev (development of upcoming release)
 * Project: Renamed branch "master" to "main" and started "gitflow" branching model.
 * Refactoring: Renamed qt4plugin.py to systrayiconplugin.py (we are using Qt5 for years now ;-)
+* Fix bug: Check SSH login works on machines with limited commands (#1442)
 * Fix bug: Missing icon in SSH private key button (#1364)
 * Fix bug: Master issue for missing or empty system-tray icon (#1306)
 * Fix bug: System-tray icon missing or empty (GUI and cron) (#1236)

--- a/common/config.py
+++ b/common/config.py
@@ -385,7 +385,7 @@ class Config(configfile.ConfigFileWithProfiles):
                 if path == snapshots_path:
                     self.notifyError(
                         '{}\n{}'.format(
-                            _('Profile: "{name}"').format(name=f'"{profile_name}"'),
+                            _('Profile: "{name}"').format(name=profile_name),
                             _("Backup folder cannot be included.")
                         )
                     )

--- a/common/config.py
+++ b/common/config.py
@@ -397,7 +397,7 @@ class Config(configfile.ConfigFileWithProfiles):
                         self.notifyError(
                             '{}\n{}'.format(
                                 _('Profile: "{name}"').format(
-                                    name=f'"{self.currentProfile()}"'),
+                                    name=self.currentProfile()),
                                 _("Backup sub-folder cannot be included.")
                             )
                         )

--- a/common/config.py
+++ b/common/config.py
@@ -47,7 +47,7 @@ except ImportError:
 # The bigger problem with config.py is that it do use translatebale strings.
 # Strings like this do not belong into a config file or its context.
 try:
-    _('Cancel')
+    _('Warning')
 except NameError:
     _ = lambda val: val
 
@@ -385,7 +385,7 @@ class Config(configfile.ConfigFileWithProfiles):
                 if path == snapshots_path:
                     self.notifyError(
                         '{}\n{}'.format(
-                            _('Profile: {name}').format(name=f'"{profile_name}"'),
+                            _('Profile: "{name}"').format(name=f'"{profile_name}"'),
                             _("Backup folder cannot be included.")
                         )
                     )
@@ -396,7 +396,7 @@ class Config(configfile.ConfigFileWithProfiles):
                     if path[: len(snapshots_path2)] == snapshots_path2:
                         self.notifyError(
                             '{}\n{}'.format(
-                                _('Profile: {name}').format(
+                                _('Profile: "{name}"').format(
                                     name=f'"{self.currentProfile()}"'),
                                 _("Backup sub-folder cannot be included.")
                             )

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -688,7 +688,7 @@ class ConfigFileWithProfiles(ConfigFile):
 
             if self.profileName(profile_id) == name:
                 self.notifyError(_(
-                    'Profile "{name}" already exists!').format(name=name))
+                    'Profile "{name}" already exists.').format(name=name))
 
                 return None
 
@@ -787,7 +787,7 @@ class ConfigFileWithProfiles(ConfigFile):
 
                 if profile[0] != profile_id:
                     self.notifyError(_(
-                        'Profile "{name}" already exists!').format(name=name))
+                        'Profile "{name}" already exists.').format(name=name))
 
                     return False
 

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -464,7 +464,7 @@ class SSH(MountControl):
 
             logger.debug('Check cipher', self)
 
-            ssh = self.config.sshCommand(cmd=['echo', '"Hello"'],
+            ssh = self.config.sshCommand(cmd=['exit'],
                                          custom_args=[
                                               '-o',
                                               'Ciphers=%s' % self.cipher,

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -422,7 +422,7 @@ class SSH(MountControl):
 
         logger.debug('Check login', self)
 
-        ssh = self.config.sshCommand(cmd=['echo', '"Hello"'],
+        ssh = self.config.sshCommand(cmd=['exit'],
                                      custom_args=[
                                           '-o',
                                           'PreferredAuthentications=publickey',
@@ -794,7 +794,7 @@ class SSH(MountControl):
                 out, err = proc.communicate()
 
                 if err or proc.returncode:
-                    logger.debug('rsync command returned error: %s' % err, self)
+                    logger.debug(f'rsync command returned error: {err}', self)
 
                     raise MountException(
                         "Remote host {host} doesn't support '{command}:\n"

--- a/qt/languagedialog.py
+++ b/qt/languagedialog.py
@@ -84,7 +84,7 @@ class LanguageDialog(QDialog):
 
         # Entry: System default language
         label = 'System default'
-        translated_label = _(label)
+        translated_label = _('System default')
         if label != translated_label:
             label = f'| {translated_label}'
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1009,14 +1009,14 @@ class SettingsDialog(QDialog):
         # additional rsync options
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
+        tooltip = _('Options must be quoted e.g. {example}.').format(
+            example='--exclude-from="/path/to/my exclude file"')
         self.cbRsyncOptions = QCheckBox(
             _('Paste additional options to rsync'), self)
+        self.cbRsyncOptions.setToolTip(tooltip)
         hlayout.addWidget(self.cbRsyncOptions)
         self.txtRsyncOptions = QLineEdit(self)
-        self.txtRsyncOptions.setToolTip(
-            _('Options must be quoted e.g. {example}.')
-            .format(example='--exclude-from="/path/to/my exclude file"')
-        )
+        self.txtRsyncOptions.setToolTip(tooltip)
         hlayout.addWidget(self.txtRsyncOptions)
 
         enabled = lambda state: self.txtRsyncOptions.setEnabled(state)
@@ -1026,21 +1026,22 @@ class SettingsDialog(QDialog):
         # ssh prefix
         hlayout = QHBoxLayout()
         layout.addLayout(hlayout)
+        tooltip = _(
+            'Prefix to run before every command on remote host.\n'
+            'Variables need to be escaped with \\$FOO.\n'
+            'This doesn\'t touch rsync. So to add a prefix\n'
+            'for rsync use "%(cbRsyncOptions)s" with\n'
+            '%(rsync_options_value)s\n\n'
+            '%(default)s: %(def_value)s') % {
+                'cbRsyncOptions': self.cbRsyncOptions.text(),
+                'rsync_options_value': '--rsync-path="FOO=bar:\\$FOO /usr/bin/rsync"',
+                'default': _('default'),
+                'def_value': self.config.DEFAULT_SSH_PREFIX}
         self.cbSshPrefix = QCheckBox(_('Add prefix to SSH commands'), self)
+        self.cbSshPrefix.setToolTip(tooltip)
         hlayout.addWidget(self.cbSshPrefix)
         self.txtSshPrefix = QLineEdit(self)
-        self.txtSshPrefix.setToolTip(
-            _('Prefix to run before every command on remote host.\n'
-              'Variables need to be escaped with \\$FOO.\n'
-              'This doesn\'t touch rsync. So to add a prefix\n'
-              'for rsync use "%(cbRsyncOptions)s" with\n'
-              '%(rsync_options_value)s\n\n'
-              '%(default)s: %(def_value)s') % {
-                  'cbRsyncOptions': self.cbRsyncOptions.text(),
-                  'rsync_options_value': '--rsync-path="FOO=bar:\\$FOO /usr/bin/rsync"',
-                  'default': _('default'),
-                  'def_value': self.config.DEFAULT_SSH_PREFIX}
-        )
+        self.txtSshPrefix.setToolTip(tooltip)
         hlayout.addWidget(self.txtSshPrefix)
 
         enabled = lambda state: self.txtSshPrefix.setEnabled(state)


### PR DESCRIPTION
Two functions checking login and cipher on a SSH remote host now using `exit` command instead of `echo`. This should work on machines with limited commands (e.g. Hetzer storage boxes) also.

Fix #1442