### PR TITLE
fix: Translate not before language setup is done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,12 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# editor backup
+# editor backup and temp files
 *~
 *.sic
 *.swp
 \#*\#
+.\#*
 
 # packaging
 *.deb

--- a/common/config.py
+++ b/common/config.py
@@ -95,24 +95,6 @@ class Config(configfile.ConfigFileWithProfiles):
     DISK_UNIT_MB = 10
     DISK_UNIT_GB = 20
 
-    REMOVE_OLD_BACKUP_UNITS = {
-                DAY: _('Day(s)'),
-                WEEK: _('Week(s)'),
-                YEAR: _('Year(s)')
-                }
-
-    REPEATEDLY_UNITS = {
-                HOUR: _('Hour(s)'),
-                DAY: _('Day(s)'),
-                WEEK: _('Week(s)'),
-                MONTH: _('Month(s)')
-                }
-
-    MIN_FREE_SPACE_UNITS = {
-        DISK_UNIT_MB: 'MiB',
-        DISK_UNIT_GB : 'GiB'
-    }
-
     # Used when new snapshot profile is created.
     DEFAULT_EXCLUDE = [
         '.gvfs',

--- a/common/config.py
+++ b/common/config.py
@@ -340,6 +340,9 @@ class Config(configfile.ConfigFileWithProfiles):
         # Workaround
         self.default_profile_name = _('Main profile')
 
+        # TODO
+        # --- INIT CONSTANTS HERE ---
+
     def save(self):
         self.setIntValue('config.version', self.CONFIG_VERSION)
         return super(Config, self).save(self._LOCAL_CONFIG_PATH)
@@ -397,7 +400,7 @@ class Config(configfile.ConfigFileWithProfiles):
                         self.notifyError(
                             '{}\n{}'.format(
                                 _('Profile: "{name}"').format(
-                                    name=self.currentProfile()),
+                                    name=profile_name),
                                 _("Backup sub-folder cannot be included.")
                             )
                         )

--- a/common/config.py
+++ b/common/config.py
@@ -129,22 +129,6 @@ class Config(configfile.ConfigFileWithProfiles):
     DEFAULT_REDIRECT_STDOUT_IN_CRON = True
     DEFAULT_REDIRECT_STDERR_IN_CRON = False
 
-    SSH_CIPHERS = {
-        'default': _('Default'),
-        'aes128-ctr': 'AES128-CTR',
-        'aes192-ctr': 'AES192-CTR',
-        'aes256-ctr': 'AES256-CTR',
-        'arcfour256': 'ARCFOUR256',
-        'arcfour128': 'ARCFOUR128',
-        'aes128-cbc': 'AES128-CBC',
-        '3des-cbc': '3DES-CBC',
-        'blowfish-cbc': 'Blowfish-CBC',
-        'cast128-cbc': 'Cast128-CBC',
-        'aes192-cbc': 'AES192-CBC',
-        'aes256-cbc': 'AES256-CBC',
-        'arcfour': 'ARCFOUR'
-    }
-
     ENCODE = encfstools.Bounce()
     PLUGIN_MANAGER = pluginmanager.PluginManager()
 
@@ -320,6 +304,22 @@ class Config(configfile.ConfigFileWithProfiles):
                         _('SSH private key'),
                         _('Encryption')
                     )
+        }
+
+        self.SSH_CIPHERS = {
+            'default': _('Default'),
+            'aes128-ctr': 'AES128-CTR',
+            'aes192-ctr': 'AES192-CTR',
+            'aes256-ctr': 'AES256-CTR',
+            'arcfour256': 'ARCFOUR256',
+            'arcfour128': 'ARCFOUR128',
+            'aes128-cbc': 'AES128-CBC',
+            '3des-cbc': '3DES-CBC',
+            'blowfish-cbc': 'Blowfish-CBC',
+            'cast128-cbc': 'Cast128-CBC',
+            'aes192-cbc': 'AES192-CBC',
+            'aes256-cbc': 'AES256-CBC',
+            'arcfour': 'ARCFOUR'
         }
 
     def save(self):

--- a/common/config.py
+++ b/common/config.py
@@ -147,31 +147,6 @@ class Config(configfile.ConfigFileWithProfiles):
     DEFAULT_REDIRECT_STDOUT_IN_CRON = True
     DEFAULT_REDIRECT_STDERR_IN_CRON = False
 
-    SNAPSHOT_MODES = {
-                # mode: (
-                #     <mounttools>,
-                #     'ComboBox Text',
-                #     need_pw|lbl_pw_1,
-                #     need_2_pw|lbl_pw_2
-                # ),
-                'local': (
-                    None, _('Local'), False, False),
-                'ssh': (
-                    sshtools.SSH, 'SSH', _('SSH private key'), False),
-                'local_encfs': (
-                    encfstools.EncFS_mount,
-                    '{} {}'.format(_('Local'), _('encrypted')),
-                    _('Encryption'),
-                    False
-                ),
-                'ssh_encfs': (
-                    encfstools.EncFS_SSH,
-                    _('SSH encrypted'),
-                    _('SSH private key'),
-                    _('Encryption')
-                )
-    }
-
     SSH_CIPHERS = {
         'default': _('Default'),
         'aes128-ctr': 'AES128-CTR',
@@ -340,8 +315,30 @@ class Config(configfile.ConfigFileWithProfiles):
         # Workaround
         self.default_profile_name = _('Main profile')
 
-        # TODO
-        # --- INIT CONSTANTS HERE ---
+        self.SNAPSHOT_MODES = {
+                    # mode: (
+                    #     <mounttools>,
+                    #     'ComboBox Text',
+                    #     need_pw|lbl_pw_1,
+                    #     need_2_pw|lbl_pw_2
+                    # ),
+                    'local': (
+                        None, _('Local'), False, False),
+                    'ssh': (
+                        sshtools.SSH, 'SSH', _('SSH private key'), False),
+                    'local_encfs': (
+                        encfstools.EncFS_mount,
+                        '{} {}'.format(_('Local'), _('encrypted')),
+                        _('Encryption'),
+                        False
+                    ),
+                    'ssh_encfs': (
+                        encfstools.EncFS_SSH,
+                        _('SSH encrypted'),
+                        _('SSH private key'),
+                        _('Encryption')
+                    )
+        }
 
     def save(self):
         self.setIntValue('config.version', self.CONFIG_VERSION)

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -663,7 +663,7 @@ class SettingsDialog(QDialog):
         layout.addWidget(self.comboFreeSpaceUnit, 1, 2)
         MIN_FREE_SPACE_UNITS = {
             config.Config.DISK_UNIT_MB: 'MiB',
-            config.Config.DISK_UNIT_GB : 'GiB'
+            config.Config.DISK_UNIT_GB: 'GiB'
         }
 
         self.fillCombo(self.comboFreeSpaceUnit,

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -462,8 +462,14 @@ class SettingsDialog(QDialog):
         hlayout.addWidget(self.spbScheduleRepeatedPeriod)
 
         self.comboScheduleRepeatedUnit = QComboBox(self)
+        REPEATEDLY_UNITS = {
+            config.Config.HOUR: _('Hour(s)'),
+            config.Config.DAY: _('Day(s)'),
+            config.Config.WEEK: _('Week(s)'),
+            config.Config.MONTH: _('Month(s)')}
+
         self.fillCombo(self.comboScheduleRepeatedUnit,
-                       self.config.REPEATEDLY_UNITS)
+                       REPEATEDLY_UNITS)
         hlayout.addWidget(self.comboScheduleRepeatedUnit)
         hlayout.addStretch()
         glayout.addLayout(hlayout, 7, 1)
@@ -633,8 +639,13 @@ class SettingsDialog(QDialog):
 
         self.comboRemoveOlderUnit = QComboBox(self)
         layout.addWidget(self.comboRemoveOlderUnit, 0, 2)
-        self.fillCombo(self.comboRemoveOlderUnit,
-                       self.config.REMOVE_OLD_BACKUP_UNITS)
+
+        REMOVE_OLD_BACKUP_UNITS = {
+            config.Config.DAY: _('Day(s)'),
+            config.Config.WEEK: _('Week(s)'),
+            config.Config.YEAR: _('Year(s)')}
+
+        self.fillCombo(self.comboRemoveOlderUnit, REMOVE_OLD_BACKUP_UNITS)
 
         # min free space
         enabled, value, unit = self.config.minFreeSpace()
@@ -650,8 +661,13 @@ class SettingsDialog(QDialog):
 
         self.comboFreeSpaceUnit = QComboBox(self)
         layout.addWidget(self.comboFreeSpaceUnit, 1, 2)
+        MIN_FREE_SPACE_UNITS = {
+            config.Config.DISK_UNIT_MB: 'MiB',
+            config.Config.DISK_UNIT_GB : 'GiB'
+        }
+
         self.fillCombo(self.comboFreeSpaceUnit,
-                       self.config.MIN_FREE_SPACE_UNITS)
+                       MIN_FREE_SPACE_UNITS)
 
         # min free inodes
         self.cbFreeInodes = QCheckBox(


### PR DESCRIPTION
Translations via gettext starting after the language setup is finished and using the setup language. It is relevant when a language was setup in BIT different from the operating systems used local.

Technically class variables from Config class are moved into the instance of Config or elsewhere.

Because it is a minor but not related to an existing release I decided not to make a changelog entry.

Fix #1523 