### PR TITLE
fix: Set toogle button value before connecting it to its slot

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Back In Time
 
 Version 1.4.1-dev (development of upcoming release)
-* wip
+* Fix bug: GUI didn't start when show hidden files button was on (#1535).
 
 Version 1.4.0 (2023-09-14)
 * Project: Renamed branch "master" to "main" and started "gitflow" branching model.

--- a/qt/app.py
+++ b/qt/app.py
@@ -596,9 +596,9 @@ class MainWindow(QMainWindow):
         self.act_pause_take_snapshot.setVisible(False)
         self.act_resume_take_snapshot.setVisible(False)
         self.act_stop_take_snapshot.setVisible(False)
-        self.act_show_hidden.toggled.connect(self.btnShowHiddenFilesToggled)
         self.act_show_hidden.setCheckable(True)
         self.act_show_hidden.setChecked(self.showHiddenFiles)
+        self.act_show_hidden.toggled.connect(self.btnShowHiddenFilesToggled)
 
     def _create_shortcuts_without_actions(self):
         """Create shortcuts that are not related to a visual element in the


### PR DESCRIPTION
This might fix #1535 .

Problem was that the value/state of the button "Show hidden files" was set **after** it was connected to its slot. This happened before the main window construction was finished. But it triggered some other events in the main window that couldn't be processed correct because that window itself is not finished with its construction.

Solution: Set the value of that button first and then connect it to its slot.