### PR TITLE
fix: Unittest poluted with warning about missing Qt translations

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Back In Time
 
 Version 1.4.1-dev (development of upcoming release)
-* wip
+* Build: Warnings about missing Qt translation now are ignored while testing.
 
 Version 1.4.0 (2023-09-14)
 * Project: Renamed branch "master" to "main" and started "gitflow" branching model.

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -145,7 +145,8 @@ under certain conditions; type `backintime --license' for details.
             "WARNING: D-Bus message:",
             "WARNING: Udev-based profiles cannot be changed or checked",
             "WARNING: Inhibit Suspend failed",
-            "Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway"
+            "Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway",
+            "WARNING: PyQt was not able to install a translator for language code",
         ]
 
         line_contains_to_exclude = [


### PR DESCRIPTION
While running unittest warning messages about missing qt translations are now ignored.

@graysky2 : Does this help with ARCH?

Note: I will refactor that whole test and create a check-output-but-ignore-the-rest-function() after the next release.