### PR TITLE
build: Ignore WARNING in specific unittest

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -30,6 +30,9 @@
   * [Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? I saw that it saves the names for uids and gids, so I assume it can restore correctly even if the ids change. Great! :-) Are there additional benefits?](#which-additional-features-on-top-of-a-gui-does-bit-provide-over-a-self-configured-rsync-backup-i-saw-that-it-saves-the-names-for-uids-and-gids-so-i-assume-it-can-restore-correctly-even-if-the-ids-change-great---are-there-additional-benefits)
   * [How to move snapshots to a new hard-drive?](#how-to-move-snapshots-to-a-new-hard-drive)
   * [How to move large directory in source without duplicating backup?](#how-to-move-large-directory-in-source-without-duplicating-backup)
+- [Testing & Building](#testing--building)
+  * [SSH related tests are skipped](#ssh-related-tests-are-skipped)
+  * [Setup SSH Server to run unit tests](#setup-ssh-server-to-run-unit-tests)
 <!-- TOC end -->
 ## Restore
 
@@ -901,7 +904,7 @@ moving the file/folder in the last snapshot, too.
 Some of the tests need an available SSH server.
 They get skipped if this is not the case.
 Plese see
-[Setup SSH Server to run unit tests](#setup_SSH_Server_to_run_unit_tests).
+[Setup SSH Server to run unit tests](#setup-ssh-server-to-run-unit-tests).
 
 ## Setup SSH Server to run unit tests
 The goal is to log into the SSH server via `ssh localhost` without using

--- a/FAQ.md
+++ b/FAQ.md
@@ -909,7 +909,8 @@ Plese see
 ## Setup SSH Server to run unit tests
 The goal is to log into the SSH server via `ssh localhost` without using
 a password.
-- Generate an RSA keypair executing `ssh-keygen`.
+- Generate an RSA keypair executing `ssh-keygen`. Use the default file name
+  and don't use a passphrase for the key.
 - Populate the public key to the server executing `ssh-copy-id`.
 - Make the `ssh` instance run.
 - The port `22` (SSH default) should be avaialbe.

--- a/FAQ.md
+++ b/FAQ.md
@@ -893,3 +893,23 @@ moving the file/folder in the last snapshot, too.
 
 1. remove the overlast snapshot (the one where you moved the folder manually)
    to avoid problems with permissions when you try to restore from that snapshot
+
+
+# Testing & Building
+
+## SSH related tests are skipped
+Some of the tests need an available SSH server.
+They get skipped if this is not the case.
+Plese see
+[Setup SSH Server to run unit tests](#setup_SSH_Server_to_run_unit_tests).
+
+## Setup SSH Server to run unit tests
+The goal is to log into the SSH server via `ssh localhost` without using
+a password.
+- Generate an RSA keypair executing `ssh-keygen`.
+- Populate the public key to the server executing `ssh-copy-id`.
+- Make the `ssh` instance run.
+- The port `22` (SSH default) should be avaialbe.
+To test the connection just execute `ssh localhost` and you should see an
+SSH shell without being asked for a password.
+

--- a/common/applicationinstance.py
+++ b/common/applicationinstance.py
@@ -134,6 +134,10 @@ class ApplicationInstance:
         """
         Create an exclusive lock to block a second instance while
         the first instance is starting.
+
+        Dev note (buhtz: 2023-09)
+        Not sure but just log an ERROR without doing anything else is
+        IMHO not enough.
         """
         try:
             self.flock = open(self.pidFile + '.flock', 'w')

--- a/common/test/test_applicationinstance.py
+++ b/common/test/test_applicationinstance.py
@@ -247,6 +247,18 @@ class TestApplicationInstance(generic.TestCase):
 
     @patch('builtins.open')
     def test_flock_exclusive_fail(self, mock_open):
+        """Dev note (buhtz: 2023-09)
+        Nothing is tested here.
+        Looking into flockExclusive() there is only the opportunity to
+        test for ERROR log output. Log output shouldn't be tested.
+
+        The behavior to test is unclear.
+
+        Proposal:
+          - Remove the test.
+          - Refactor flockExclusive() and related code to make its behavior
+            clear.
+        """
         mock_open.side_effect = OSError()
         self.app_instance.flockExclusiv()
 

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -141,12 +141,8 @@ under certain conditions; type `backintime --license' for details.
         #       The same goes with Gtk warnings.
 
         line_beginnings_to_exclude = [
-            "WARNING: Failed to connect to Udev serviceHelper",
-            "WARNING: D-Bus message:",
-            "WARNING: Udev-based profiles cannot be changed or checked",
-            "WARNING: Inhibit Suspend failed",
-            "Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway",
-            "WARNING: PyQt was not able to install a translator for language code",
+            "WARNING",
+            "Warning",
         ]
 
         line_contains_to_exclude = [

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -145,6 +145,13 @@ under certain conditions; type `backintime --license' for details.
             "Warning",
         ]
 
+        # Warnings currently known:
+        # - "WARNING: D-Bus message:"
+        # - "WARNING: Udev-based profiles cannot be changed or checked"
+        # - "WARNING: Inhibit Suspend failed"
+        # - "Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use
+        #    QT_QPA_PLATFORM=wayland to run on Wayland anyway"
+
         line_contains_to_exclude = [
             "Gtk-WARNING",
             "qt.qpa.plugin: Could not find the Qt platform plugin"


### PR DESCRIPTION
As discussed in #1539 the test `TestBackInTime::test_local_snapshot_is_successful()` now do ignore all log entries beginning with `Warning` or `WARNING`.

Also slightly improved SSH Server related testing code in `generic.py` and added a FAQ entry for it. The background is that I wasn't able to get my SSH tests run. The reasons was that I do use none-RSA keys.

Fix #1539 
IMHO no need for a CHANGELOG entry.