### PR TITLE
Correct spelling of initiate_translator in qt/messagebox.py

### DIFF
--- a/qt/messagebox.py
+++ b/qt/messagebox.py
@@ -23,7 +23,7 @@ import qttools
 def askPasswordDialog(parent, title, prompt, language_code, timeout):
     if parent is None:
         app = qttools.createQApplication()
-        translator = qttools.initate_translator(language_code)
+        translator = qttools.initiate_translator(language_code)
         app.installTranslator(translator)
 
     import icon


### PR DESCRIPTION
this small typo slipped in when initiate_translator was added

