### PR TITLE
fix(doc): Install sphinx_rtd_theme explicit

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,4 +22,5 @@ python:
   install:
   - method: pip
     path: .
-    extra_requirements: sphinx_rtd_theme
+    extra_requirements:
+    - sphinx_rtd_theme

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3"
   jobs:
     post_create_environment:
-      - pip install sphinx_rtd_theme
+      - python -m pip install sphinx_rtd_theme
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: common/doc-dev/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,10 @@ build:
   tools:
     python: "3"
   jobs:
+    # Workaround: See PR #1554 for details.
+    # When migrating to use a pyprojects.toml file switch from this
+    # workaround to the use of "python: install: extra_requirements..."
+    # See also: https://docs.readthedocs.io/en/stable/config-file/v2.html#packages
     post_create_environment:
       - python -m pip install sphinx_rtd_theme
 # Build documentation in the docs/ directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,7 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#   - requirements: docs/requirements.txt
+python:
+  install:
+  - method: pip
+    extra_requirements: sphinx_rtd_theme

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,4 +21,5 @@ sphinx:
 python:
   install:
   - method: pip
+    path: .
     extra_requirements: sphinx_rtd_theme

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3"
-
+  jobs:
+    post_create_environment:
+      - pip install sphinx_rtd_theme
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: common/doc-dev/conf.py
@@ -18,9 +20,9 @@ sphinx:
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-  - method: pip
-    path: .
-    extra_requirements:
-    - sphinx_rtd_theme
+# python:
+#  install:
+#  - method: pip
+#    path: .
+#    extra_requirements:
+#    - foo

--- a/common/doc-dev/conf.py
+++ b/common/doc-dev/conf.py
@@ -160,7 +160,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-html_last_updated_fmt = '%b %d, %Y, %H:%M'
+html_last_updated_fmt = '%b %d, %Y, %H:%M (%Z)'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.


### PR DESCRIPTION
This fix installs spinx_rtd_them package via pip while building the docs on readthedocs.org.

Previous problem was broken doc builds because of that package missing. This was cased by modified behavior on ReadTheDocs build servers.

I avoid to use a "requirements.txt" file as stated in the docs of RTD. This file is "old-schoold" and its information redundant to a "state of the art" "pyprojects.toml" file. But we do not have one yet. So the current solution is kind of a workaround until we migrate the project to a more modern layout.

Additionally added the timezone (strftime format %Z) to the last-updated-timestamp. Opened a FeatureRequest at Sphinx to improve this. https://github.com/sphinx-doc/sphinx/issues/11738