### PR TITLE
fix: "no-member" (E1101) in MountControl and derived classes

### DIFF
--- a/common/encfstools.py
+++ b/common/encfstools.py
@@ -38,8 +38,13 @@ class EncFS_mount(MountControl):
     Mount encrypted paths with encfs.
     """
     def __init__(self, *args, **kwargs):
-        #init MountControl
+        # init MountControl
         super(EncFS_mount, self).__init__(*args, **kwargs)
+
+        # Workaround for some linters.
+        self.path = None
+        self.reverse = None
+        self.config_path = None
 
         self.setattrKwargs('path', self.config.localEncfsPath(self.profile_id), **kwargs)
         self.setattrKwargs('reverse', False, **kwargs)

--- a/common/mount.py
+++ b/common/mount.py
@@ -429,6 +429,13 @@ class MountControl(object):
                  symlink = True,
                  *args,
                  **kwargs):
+        # The following members should get valid values from the inheriting
+        # class.
+        self.mode = None
+        self.log_command = None
+        self.mountproc = None
+        self.symlink_subfolder = None
+
         self.config = cfg
         if self.config is None:
             self.config = config.Config()
@@ -466,16 +473,17 @@ class MountControl(object):
         for arg in args:
             self.destination += ' %s' % self.all_kwargs[arg]
 
-        #unique id for every different mount settings. Similar settings even in
-        #different profiles will generate the same hash_id and so share the same
-        #mountpoint
+        # Unique id for every different mount settings. Similar settings even
+        # in different profiles will generate the same hash_id and so share
+        # the same mountpoint.
         if self.hash_id is None:
             self.hash_id = self.hash(self.destination)
 
         self.mount_root = self.config._LOCAL_MOUNT_ROOT
-        self.snapshots_path = self.config.snapshotsPath(profile_id = self.profile_id,
-                                                             mode = self.mode,
-                                                             tmp_mount = self.tmp_mount)
+        self.snapshots_path = self.config.snapshotsPath(
+            profile_id = self.profile_id,
+            mode = self.mode,
+            tmp_mount = self.tmp_mount)
 
         self.hash_id_path = self.hashIdPath()
         self.currentMountpoint = self.mountpoint()

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -97,6 +97,17 @@ class SSH(MountControl):
         # init MountControl
         super(SSH, self).__init__(*args, **kwargs)
 
+        # Workaround for linters
+        self.user = None
+        self.host = None
+        self.port = None
+        self.cipher = None
+        self.nice = None
+        self.ionice = None
+        self.nocache = None
+        self.private_key_file = None
+        self.password = None
+
         self.setattrKwargs(
             'user', self.config.sshUser(self.profile_id), **kwargs)
         self.setattrKwargs(


### PR DESCRIPTION
PyLint gave me "no-member" errors in `class MountControl` and `EncFS_mount` and 'SSH'. The PR fix it in preparation for #1562.

This where the errors:
```
************* Module mount
mount.py:477:68: E1101: Instance of 'MountControl' has no 'mode' member (no-member)
mount.py:530:30: E1101: Instance of 'MountControl' has no 'log_command' member (no-member)
mount.py:570:42: E1101: Instance of 'MountControl' has no 'log_command' member (no-member)
mount.py:601:37: E1101: Instance of 'MountControl' has no 'mountproc' member (no-member)
mount.py:683:34: E1101: Instance of 'MountControl' has no 'mountproc' member (no-member)
mount.py:684:28: E1101: Instance of 'MountControl' has no 'mountproc' member (no-member)
mount.py:688:24: E1101: Instance of 'MountControl' has no 'mountproc' member (no-member)
mount.py:689:44: E1101: Instance of 'MountControl' has no 'mountproc' member (no-member)
mount.py:987:45: E1101: Instance of 'MountControl' has no 'mode' member (no-member)
mount.py:991:11: E1101: Instance of 'MountControl' has no 'symlink_subfolder' member (no-member)
mount.py:994:43: E1101: Instance of 'MountControl' has no 'symlink_subfolder' member (no-member)
mount.py:1017:56: E1101: Instance of 'MountControl' has no 'mode' member (no-member)

encfstools.py:54:50: E1101: Instance of 'EncFS_mount' has no 'path' member (no-member)
encfstools.py:69:15: E1101: Instance of 'EncFS_mount' has no 'reverse' member (no-member)
encfstools.py:73:22: E1101: Instance of 'EncFS_mount' has no 'path' member (no-member)
encfstools.py:115:11: E1101: Instance of 'EncFS_mount' has no 'config_path' member (no-member)
encfstools.py:116:31: E1101: Instance of 'EncFS_mount' has no 'path' member (no-member)
encfstools.py:118:31: E1101: Instance of 'EncFS_mount' has no 'config_path' member (no-member)
encfstools.py:163:11: E1101: Instance of 'EncFS_mount' has no 'reverse' member (no-member)

sshtools.py:133:28: E1101: Instance of 'SSH' has no 'user' member (no-member)                                                                                                                      sshtools.py:134:52: E1101: Instance of 'SSH' has no 'host' member (no-member)                                                                                                                      sshtools.py:136:36: E1101: Instance of 'SSH' has no 'user' member (no-member)                                                                                                                      sshtools.py:136:47: E1101: Instance of 'SSH' has no 'host' member (no-member)                                                                                                                      sshtools.py:142:57: E1101: Instance of 'SSH' has no 'private_key_file' member (no-member)                                                                                                          sshtools.py:152:38: E1101: Instance of 'SSH' has no 'private_key_file' member (no-member)                                                                                                          sshtools.py:154:43: E1101: Instance of 'SSH' has no 'private_key_file' member (no-member)                                                                                                          sshtools.py:169:28: E1101: Instance of 'SSH' has no 'port' member (no-member)                                                                                                                      sshtools.py:171:15: E1101: Instance of 'SSH' has no 'cipher' member (no-member)                                                                                                                    sshtools.py:172:47: E1101: Instance of 'SSH' has no 'cipher' member (no-member)
sshtools.py:322:57: E1101: Instance of 'SSH' has no 'private_key_file' member (no-member)
sshtools.py:347:20: E1101: Instance of 'SSH' has no 'password' member (no-member)
sshtools.py:430:46: E1101: Instance of 'SSH' has no 'port' member (no-member)
sshtools.py:470:61: E1101: Instance of 'SSH' has no 'cipher' member (no-member)
sshtools.py:567:21: E1101: Instance of 'SSH' has no 'host' member (no-member)
sshtools.py:828:11: E1101: Instance of 'SSH' has no 'nice' member (no-member)
sshtools.py:834:11: E1101: Instance of 'SSH' has no 'ionice' member (no-member)
sshtools.py:840:11: E1101: Instance of 'SSH' has no 'nocache' member (no-member)
[...snipped...]
```