### PR TITLE
fix: SyntaxWarnings about invalid escape sequence / config man page

### DIFF
--- a/common/create-manpage-backintime-config.py
+++ b/common/create-manpage-backintime-config.py
@@ -65,7 +65,7 @@ SORT = True  # True = sort by alphabet; False = sort by line numbering
 c_list = re.compile(r'.*?self\.(?!set)((?:profile)?)(List)Value ?\( ?[\'"](.*?)[\'"], ?((?:\(.*\)|[^,]*)), ?[\'"]?([^\'",\)]*)[\'"]?')
 c = re.compile(r'.*?self\.(?!set)((?:profile)?)(.*?)Value ?\( ?[\'"](.*?)[\'"] ?(%?[^,]*?), ?[\'"]?([^\'",\)]*)[\'"]?')
 
-HEADER = '''.TH backintime-config 1 "%s" "version %s" "USER COMMANDS"
+HEADER = r'''.TH backintime-config 1 "%s" "version %s" "USER COMMANDS"
 .SH NAME
 config \- BackInTime configuration files.
 .SH SYNOPSIS
@@ -88,7 +88,7 @@ Run 'backintime check-config' to verify the configfile, create the snapshot fold
 .SH POSSIBLE KEYWORDS
 ''' % (strftime('%b %Y', gmtime()), VERSION)
 
-FOOTER = '''.SH SEE ALSO
+FOOTER = r'''.SH SEE ALSO
 backintime, backintime-qt.
 .PP
 Back In Time also has a website: https://github.com/bit-team/backintime
@@ -293,7 +293,7 @@ def main():
                             'int',
                             '%s.size' % name,
                             var,
-                            '\-1',
+                            r'\-1',
                             'Quantity of %s.<I> entries.' % name,
                             values,
                             force_var,

--- a/common/create-manpage-backintime-config.py
+++ b/common/create-manpage-backintime-config.py
@@ -93,7 +93,7 @@ backintime, backintime-qt.
 .PP
 Back In Time also has a website: https://github.com/bit-team/backintime
 .SH AUTHOR
-This manual page was written by BIT Team(<bit\-team@lists.launchpad.net>).
+This manual page was written by BIT Team(<bit-dev@python.org>).
 '''
 
 INSTANCE = 'instance'
@@ -268,6 +268,10 @@ def main():
                 # becomes
                 # ('profile', 'Bool', 'snapshots.use_checksum', '', 'False')
                 m = c.match(line)
+
+            # Ignore undocumented (without "#?" comments) variables.
+            if m and not commentline:
+                continue
 
             if m:
                 profile, instance, name, var, default = m.groups()

--- a/common/man/C/backintime-config.1
+++ b/common/man/C/backintime-config.1
@@ -1,4 +1,4 @@
-.TH backintime-config 1 "Oct 2023" "version 1.4.2-dev" "USER COMMANDS"
+.TH backintime-config 1 "Nov 2023" "version 1.4.2-dev" "USER COMMANDS"
 .SH NAME
 config \- BackInTime configuration files.
 .SH SYNOPSIS
@@ -19,15 +19,6 @@ Arguments don't need to be quoted. All characters are allowed except '='.
 .PP
 Run 'backintime check-config' to verify the configfile, create the snapshot folder and crontab entries.
 .SH POSSIBLE KEYWORDS
-.IP "\fIconfig.version\fR" 6
-.RS
-Type: int       Allowed Values: 0-99999
-.br
-
-.PP
-Default: 6
-.RE
-
 .IP "\fIglobal.hash_collision\fR" 6
 .RS
 Type: int       Allowed Values: 0-99999
@@ -819,4 +810,4 @@ backintime, backintime-qt.
 .PP
 Back In Time also has a website: https://github.com/bit-team/backintime
 .SH AUTHOR
-This manual page was written by BIT Team(<bit\-team@lists.launchpad.net>).
+This manual page was written by BIT Team(<bit-dev@python.org>).


### PR DESCRIPTION
Fixed invalid escape sequences in strings related to the config-man-page generator script.

About the escape sequences I will do further tests on a VM with Python 3.12 installed.

Accidentally discovered some minor problems with the man page generator script that I fixed. Config variables without official comments (means comments starting with `#?`) are ignored and not part of the man page. That affects `config.version` (should not be edited by the user) and `internal.manual_starts_countdown`.

It seems that PyLint W1401 does catch the "invalid escape sequence" problem. I will activate that check later when #1562 and this PR is merged.

Might close #1563.