### PR TITLE
fix: Schedule dropdown menu used "minutes" instead of "hours"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Back In Time
 
 Version 1.4.2-dev (development of upcoming release)
 * Fix bug: RTE: module 'qttools' has no attribute 'initate_translator' with encFS when prompting the user for a password (#1553)
+* Fix bug: Schedule dropdown menu used "minutes" instead of "hours".
 * Build: Use PyLint in unit testing to catch E1101 (no-member) errors.
 * Translation: Minor modifications in source strings and updating language files.
 

--- a/common/languages.py
+++ b/common/languages.py
@@ -1,4 +1,4 @@
-# Generated at Tue Nov 14 14:02:37 2023 with help of package "babel" and "polib".
+# Generated at Wed Nov 15 10:12:14 2023 with help of package "babel" and "polib".
 # https://babel.pocoo.org
 # https://github.com/python-babel/babel
 
@@ -2082,7 +2082,7 @@ completeness = {
   'ca': 93,
   'cs': 66,
   'da': 28,
-  'de': 97,
+  'de': 98,
   'el': 26,
   'en': 100,
   'eo': 26,

--- a/common/languages.py
+++ b/common/languages.py
@@ -1,4 +1,4 @@
-# Generated at Wed Nov 15 10:12:14 2023 with help of package "babel" and "polib".
+# Generated at Wed Nov 15 10:12:43 2023 with help of package "babel" and "polib".
 # https://babel.pocoo.org
 # https://github.com/python-babel/babel
 
@@ -2077,9 +2077,9 @@ names = {
 
 completeness = {
  'ar': 42,
-  'bg': 93,
+  'bg': 92,
   'bs': 18,
-  'ca': 93,
+  'ca': 92,
   'cs': 66,
   'da': 28,
   'de': 98,
@@ -2092,19 +2092,19 @@ completeness = {
   'fa': 66,
   'fi': 43,
   'fo': 17,
-  'fr': 93,
+  'fr': 92,
   'gl': 71,
   'he': 64,
   'hr': 20,
   'hu': 26,
   'id': 65,
-  'is': 76,
-  'it': 97,
+  'is': 75,
+  'it': 96,
   'ja': 68,
   'ko': 55,
-  'lt': 71,
+  'lt': 70,
   'nb': 25,
-  'nl': 93,
+  'nl': 92,
   'nn': 15,
   'pl': 65,
   'pt': 23,
@@ -2117,7 +2117,7 @@ completeness = {
   'sv': 47,
   'th': 58,
   'tr': 68,
-  'uk': 97,
+  'uk': 96,
   'vi': 71,
   'zh_CN': 52,
   'zh_TW': 15}

--- a/common/po/ar.po
+++ b/common/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-19 19:53+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Arabic <https://translate.codeberg.org/projects/backintime/common/ar/>\n"
@@ -1079,8 +1079,6 @@ msgid "At every boot/reboot"
 msgstr "في كل اقلاع/اعادة اقلاع"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1094,6 +1092,18 @@ msgstr[5] "كل {n} دقائق"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "كل ساعة"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "كل ساعتان"
+msgstr[1] "كل ساعتان"
+msgstr[2] "كل ساعتان"
+msgstr[3] "كل ساعتان"
+msgstr[4] "كل ساعتان"
+msgstr[5] "كل ساعتان"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1789,10 +1799,6 @@ msgstr ""
 
 #~ msgid "Every 6 hours"
 #~ msgstr "كل ٦ ساعات"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "كل ساعتان"
 
 #~ msgid "List only different snapshots"
 #~ msgstr "سرد لقطات المُختلفة فقط"

--- a/common/po/bg.po
+++ b/common/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Bulgarian <https://translate.codeberg.org/projects/backintime/common/bg/>\n"
@@ -1079,8 +1079,6 @@ msgid "At every boot/reboot"
 msgstr "При всяко зареждане/рестартиране"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1090,6 +1088,14 @@ msgstr[1] "На всеки {n} минути"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "На всеки час"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "На всеки {n} часа"
+msgstr[1] "На всеки {n} часа"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1755,10 +1761,6 @@ msgstr "Изключете {path} от бъдещите моментни арх�
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "На всеки 5 минути"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "На всеки {n} часа"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/bs.po
+++ b/common/po/bs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Bosnian <https://translate.codeberg.org/projects/backintime/common/bs/>\n"
@@ -1029,8 +1029,6 @@ msgid "At every boot/reboot"
 msgstr ""
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1041,6 +1039,15 @@ msgstr[2] "Svakih {n} minuta"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr ""
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Svakih {n} sati"
+msgstr[1] "Svakih {n} sati"
+msgstr[2] "Svakih {n} sati"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1643,10 +1650,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Svakih 5 minuta"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Svakih {n} sati"
 
 #, fuzzy, python-brace-format
 #~ msgid "Profile: {name}"

--- a/common/po/ca.po
+++ b/common/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-09-26 10:59+0000\n"
 "Last-Translator: buhtz <c.buhtz@posteo.jp>\n"
 "Language-Team: Catalan <https://translate.codeberg.org/projects/backintime/common/ca/>\n"
@@ -1085,8 +1085,6 @@ msgid "At every boot/reboot"
 msgstr "En cada inici/reinici"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1096,6 +1094,14 @@ msgstr[1] "Cada {n} minuts"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Cada hora"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Cada {n} hores"
+msgstr[1] "Cada {n} hores"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1810,10 +1816,6 @@ msgstr "Exclou {path} de les instantànies futures?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Cada 6 hores"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Cada {n} hores"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/cs.po
+++ b/common/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Czech <https://translate.codeberg.org/projects/backintime/common/cs/>\n"
@@ -1125,8 +1125,6 @@ msgid "At every boot/reboot"
 msgstr "Při každém startu/restartu počítače"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1137,6 +1135,15 @@ msgstr[2] "Každých {n} minut"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Každou hodinu"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Každých {n} hodin"
+msgstr[1] "Každých {n} hodin"
+msgstr[2] "Každých {n} hodin"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1902,10 +1909,6 @@ msgstr "Vynechat „{path}“ z budoucích zachycených stavů?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Každých 6 hodin"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Každých {n} hodin"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/da.po
+++ b/common/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Danish <https://translate.codeberg.org/projects/backintime/common/da/>\n"
@@ -1055,8 +1055,6 @@ msgid "At every boot/reboot"
 msgstr "Ved hver opstart/genstart"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1066,6 +1064,14 @@ msgstr[1] "Hver {n} minutter"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Hver time"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Hver {n} time"
+msgstr[1] "Hver {n} time"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1752,10 +1758,6 @@ msgstr ""
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Hver 6. time"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Hver {n} time"
 
 #, python-format
 #~ msgid ""

--- a/common/po/de.po
+++ b/common/po/de.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Back In Time 0.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
 "POT-Creation-Date: 2023-11-14 14:02+0100\n"
-"PO-Revision-Date: 2023-11-13 00:13+0000\n"
+"PO-Revision-Date: 2023-11-15 09:11+0000\n"
 "Last-Translator: buhtz <c.buhtz@posteo.jp>\n"
 "Language-Team: German <https://translate.codeberg.org/projects/backintime/common/de/>\n"
 "Language: de\n"
@@ -519,9 +519,8 @@ msgid "View last log"
 msgstr "Letztes Protokoll ansehen"
 
 #: qt/app.py:496
-#, fuzzy
 msgid "Manage profiles…"
-msgstr "Profile verwalten"
+msgstr "Profile verwalten…"
 
 #: qt/app.py:500
 msgid "Shutdown"
@@ -532,9 +531,8 @@ msgid "Shut down system after snapshot has finished."
 msgstr "Rechner herunterfahren, nachdem der Schnappschuss erstellt wurde."
 
 #: qt/app.py:504
-#, fuzzy
 msgid "Setup language…"
-msgstr "Sprache einstellen"
+msgstr "Sprache einstellen…"
 
 #: qt/app.py:508
 msgid "Exit"
@@ -619,9 +617,8 @@ msgid "Show hidden files"
 msgstr "Versteckte Dateien anzeigen"
 
 #: qt/app.py:566
-#, fuzzy
 msgid "Compare snapshots…"
-msgstr "Schnappschüsse vergleichen"
+msgstr "Schnappschüsse vergleichen…"
 
 #: qt/app.py:627
 msgid "&Backup"
@@ -692,11 +689,10 @@ msgid "Snapshot Name"
 msgstr "Schnappschussname"
 
 #: qt/app.py:1202
-#, fuzzy
 msgid "Are you sure you want to remove this snapshot?"
 msgid_plural "Are you sure you want to remove these snapshots?"
-msgstr[0] "Sind Sie sicher, dass Sie den Schnappschuss löschen wollen"
-msgstr[1] "Sind Sie sicher, dass Sie den Schnappschuss löschen wollen"
+msgstr[0] "Sind Sie sicher, dass Sie den Schnappschuss löschen wollen?"
+msgstr[1] "Sind Sie sicher, dass Sie diese Schnappschüsse löschen wollen?"
 
 #: qt/app.py:1294
 #, python-brace-format
@@ -1098,7 +1094,6 @@ msgid "Every hour"
 msgstr "Jede Stunde"
 
 #: qt/settingsdialog.py:372
-#, fuzzy
 msgid "Custom hours"
 msgstr "Benutzerdefinierte Stunden"
 

--- a/common/po/de.po
+++ b/common/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Back In Time 0.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-11-15 09:11+0000\n"
 "Last-Translator: buhtz <c.buhtz@posteo.jp>\n"
 "Language-Team: German <https://translate.codeberg.org/projects/backintime/common/de/>\n"
@@ -1081,8 +1081,6 @@ msgid "At every boot/reboot"
 msgstr "Bei jedem Hochfahren/Neustart"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1092,6 +1090,14 @@ msgstr[1] "Alle {n} Minuten"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Jede Stunde"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Alle {n} Stunden"
+msgstr[1] "Alle {n} Stunden"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1834,10 +1840,6 @@ msgstr "»{path}« von zukünftigen Schnappschüssen ausschließen?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Alle 6 Stunden"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Alle {n} Stunden"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/el.po
+++ b/common/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Greek <https://translate.codeberg.org/projects/backintime/common/el/>\n"
@@ -1048,8 +1048,6 @@ msgid "At every boot/reboot"
 msgstr "Σε κάθε εκκίνηση/επανεκκίνηση"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1059,6 +1057,14 @@ msgstr[1] "Κάθε {n} λεπτά"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Κάθε ώρα"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Κάθε {n} ώρες"
+msgstr[1] "Κάθε {n} ώρες"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1704,10 +1710,6 @@ msgstr ""
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Κάθε 6 ώρες"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Κάθε {n} ώρες"
 
 #~ msgid "Local encrypted"
 #~ msgstr "Τοπικό κρυπτογραφημένο"

--- a/common/po/eo.po
+++ b/common/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Esperanto <https://translate.codeberg.org/projects/backintime/common/eo/>\n"
@@ -1033,8 +1033,6 @@ msgid "At every boot/reboot"
 msgstr "Je ĉiu startigo/restartigo"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1044,6 +1042,14 @@ msgstr[1] "Je ĉiuj {n} minutoj"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Ĉiu horon"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Ĉiu {n} horojn"
+msgstr[1] "Ĉiu {n} horojn"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1638,10 +1644,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Je ĉiuj 5 minutoj"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Ĉiu {n} horojn"
 
 #, fuzzy, python-brace-format
 #~ msgid "Profile: {name}"

--- a/common/po/es.po
+++ b/common/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-11-01 09:13+0000\n"
 "Last-Translator: gallegonovato <fran-carro@hotmail.es>\n"
 "Language-Team: Spanish <https://translate.codeberg.org/projects/backintime/common/es/>\n"
@@ -1082,8 +1082,6 @@ msgid "At every boot/reboot"
 msgstr "En cada arranque/reinicio"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1093,6 +1091,14 @@ msgstr[1] "Cada {n} minutos"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Cada hora"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Cada {n} horas"
+msgstr[1] "Cada {n} horas"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1779,10 +1785,6 @@ msgstr "¿Excluir \"{path}\" de futuras instantáneas?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Cada 6 horas"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Cada {n} horas"
 
 #, python-format
 #~ msgid ""

--- a/common/po/et.po
+++ b/common/po/et.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Estonian <https://translate.codeberg.org/projects/backintime/common/et/>\n"
@@ -1044,8 +1044,6 @@ msgid "At every boot/reboot"
 msgstr "Igal käivitamisel/taaskäivitamisel"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1056,6 +1054,14 @@ msgstr[1] "Iga {n} minuti tagant"
 #, fuzzy
 msgid "Every hour"
 msgstr "Iga tund"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Iga {n} tunni tagant"
+msgstr[1] "Iga {n} tunni tagant"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1680,10 +1686,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Iga 5 minuti tagant"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Iga {n} tunni tagant"
 
 #, fuzzy, python-brace-format
 #~ msgid "Profile: {name}"

--- a/common/po/eu.po
+++ b/common/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-09-26 10:59+0000\n"
 "Last-Translator: buhtz <c.buhtz@posteo.jp>\n"
 "Language-Team: Basque <https://translate.codeberg.org/projects/backintime/common/eu/>\n"
@@ -1080,8 +1080,6 @@ msgid "At every boot/reboot"
 msgstr "Abiatze/berrabiaratze guztietan"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1091,6 +1089,14 @@ msgstr[1] "{n} minututik behin"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Orduro"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "{n} ordutik behin"
+msgstr[1] "{n} ordutik behin"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1839,10 +1845,6 @@ msgstr "Baztertu {path} hurrengo babeskopietan?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "6 ordutan behin"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "{n} ordutik behin"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/fa.po
+++ b/common/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Back In Time 1.3.4-dev\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-09-11 07:08+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Persian <https://translate.codeberg.org/projects/backintime/common/fa/>\n"
@@ -1090,8 +1090,6 @@ msgid "At every boot/reboot"
 msgstr "در هر بوت/ریبوت"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1101,6 +1099,14 @@ msgstr[1] "هر {n} دقیقه"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "هر ساعت"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "هر {n} ساعت"
+msgstr[1] "هر {n} ساعت"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1766,10 +1772,6 @@ msgstr "\"{path}\" را مورد استثنا قرار میدهی از اسنپ�
 
 #~ msgid "Diff Options"
 #~ msgstr "گزینه‌های مقایسه"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "هر {n} ساعت"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/fi.po
+++ b/common/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Finnish <https://translate.codeberg.org/projects/backintime/common/fi/>\n"
@@ -1118,8 +1118,6 @@ msgid "At every boot/reboot"
 msgstr "Käynnistysten yhteydessä"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1129,6 +1127,14 @@ msgstr[1] "{n} minuutin välein"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Tunnin välein"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "{n} tunnin välein"
+msgstr[1] "{n} tunnin välein"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1880,10 +1886,6 @@ msgstr "Jätetäänkö ”{path}” pois myöhemmistä otoksista?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "6 tunnin välein"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "{n} tunnin välein"
 
 #, python-format
 #~ msgid ""

--- a/common/po/fo.po
+++ b/common/po/fo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Faroese <https://translate.codeberg.org/projects/backintime/common/fo/>\n"
@@ -1039,8 +1039,6 @@ msgid "At every boot/reboot"
 msgstr "Við hvørjari byrjan/endurbyrjan"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1050,6 +1048,14 @@ msgstr[1] "Hvønn {n} minutt"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr ""
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Hvønn {n} tími"
+msgstr[1] "Hvønn {n} tími"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1664,10 +1670,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Hvønn 5 minutt"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Hvønn {n} tími"
 
 #, fuzzy, python-brace-format
 #~ msgid "Profile: {name}"

--- a/common/po/fr.po
+++ b/common/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Back In Time 0.8.8\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-09-18 21:13+0000\n"
 "Last-Translator: tootai <devel@tootai.net>\n"
 "Language-Team: French <https://translate.codeberg.org/projects/backintime/common/fr/>\n"
@@ -1094,8 +1094,6 @@ msgid "At every boot/reboot"
 msgstr "À chaque démarrage/re-démarrage"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1105,6 +1103,14 @@ msgstr[1] "Toutes les {n} minutes"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Toutes les heures"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Toutes les {n} heures"
+msgstr[1] "Toutes les {n} heures"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1851,10 +1857,6 @@ msgstr "Exclure {path} des futurs instantanés ?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Toutes les 6 heures"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Toutes les {n} heures"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/gl.po
+++ b/common/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Galician <https://translate.codeberg.org/projects/backintime/common/gl/>\n"
@@ -1101,8 +1101,6 @@ msgid "At every boot/reboot"
 msgstr "En todos os arranques"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1112,6 +1110,14 @@ msgstr[1] "Cada {n} minutos"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Cada hora"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Cada {n} horas"
+msgstr[1] "Cada {n} horas"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1860,10 +1866,6 @@ msgstr "Excluír «{path}» de instantáneas futuras?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Cada 6 horas"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Cada {n} horas"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/he.po
+++ b/common/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Hebrew <https://translate.codeberg.org/projects/backintime/common/he/>\n"
@@ -1073,8 +1073,6 @@ msgid "At every boot/reboot"
 msgstr "בכל טעינה/הפעלה מחדש של מערכת"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1084,6 +1082,14 @@ msgstr[1] "כל {n} דקות"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "כל שעה"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "כל {n} שעות"
+msgstr[1] "כל {n} שעות"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1769,10 +1775,6 @@ msgstr "האם להמנע מ-\"{path}\" בגיבויים עתידיים?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "כל 6 שעות"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "כל {n} שעות"
 
 #~ msgid "Local encrypted"
 #~ msgstr "מוצפן מקומית"

--- a/common/po/hr.po
+++ b/common/po/hr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Croatian <https://translate.codeberg.org/projects/backintime/common/hr/>\n"
@@ -1044,8 +1044,6 @@ msgid "At every boot/reboot"
 msgstr "Pri svakom paljenju/podizanju"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1056,6 +1054,15 @@ msgstr[2] "Svakih {n} minuta"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr ""
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Svakih {n} sati"
+msgstr[1] "Svakih {n} sati"
+msgstr[2] "Svakih {n} sati"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1679,10 +1686,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Svakih 5 minuta"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Svakih {n} sati"
 
 #~ msgid "List only different snapshots"
 #~ msgstr "Prikaži samo različite snimke"

--- a/common/po/hu.po
+++ b/common/po/hu.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Hungarian <https://translate.codeberg.org/projects/backintime/common/hu/>\n"
@@ -1077,8 +1077,6 @@ msgid "At every boot/reboot"
 msgstr "Minden (újra)indításkor"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1088,6 +1086,14 @@ msgstr[1] "{n} percenként"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Óránként"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "{n} óránként"
+msgstr[1] "{n} óránként"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1806,10 +1812,6 @@ msgstr "Kizárjam a \"{path}\"-t a jövőbeli pillanatképekből?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Hatóránként"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "{n} óránként"
 
 #, python-format
 #~ msgid ""

--- a/common/po/id.po
+++ b/common/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Indonesian <https://translate.codeberg.org/projects/backintime/common/id/>\n"
@@ -1103,8 +1103,6 @@ msgid "At every boot/reboot"
 msgstr "Pada setiap boot/reboot"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1113,6 +1111,13 @@ msgstr[0] "Setiap {n} menit"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Setiap jam"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Setiap {n} jam"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1871,10 +1876,6 @@ msgstr "Jangan ikutkan \"{path}\" dari snapshot berikutnya?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Setiap 6 jam"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Setiap {n} jam"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/is.po
+++ b/common/po/is.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Icelandic (Back In Time)\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-16 18:53+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Icelandic <https://translate.codeberg.org/projects/backintime/common/is/>\n"
@@ -1024,8 +1024,6 @@ msgid "At every boot/reboot"
 msgstr "Við hverja ræsingu/endurræsingu"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1035,6 +1033,14 @@ msgstr[1] "Á {n} mínútna fresti"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Á klukkustundar fresti"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Á klukkustundar fresti"
+msgstr[1] "Á klukkustundar fresti"
 
 #: qt/settingsdialog.py:372
 #, fuzzy

--- a/common/po/it.po
+++ b/common/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-11-13 00:13+0000\n"
 "Last-Translator: ctrlaltca <ctrlaltca@gmail.com>\n"
 "Language-Team: Italian <https://translate.codeberg.org/projects/backintime/common/it/>\n"
@@ -1084,8 +1084,6 @@ msgid "At every boot/reboot"
 msgstr "Ad ogni avvio/riavvio"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1095,6 +1093,14 @@ msgstr[1] "Ogni {n} minuti"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Ogni ora"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Ogni {n} ore"
+msgstr[1] "Ogni {n} ore"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1838,10 +1844,6 @@ msgstr "Escludere \"{path}\" dalle istantanee future?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Ogni 6 ore"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Ogni {n} ore"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/ja.po
+++ b/common/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-16 18:53+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Japanese <https://translate.codeberg.org/projects/backintime/common/ja/>\n"
@@ -1055,8 +1055,6 @@ msgid "At every boot/reboot"
 msgstr "起動/再起動毎に"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1065,6 +1063,13 @@ msgstr[0] "{n}分毎"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "毎時"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "{n}時間毎"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1695,10 +1700,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "5分毎"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "{n}時間毎"
 
 #~ msgid "List only different snapshots"
 #~ msgstr "異なるスナップショットだけを列挙"

--- a/common/po/ko.po
+++ b/common/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Korean <https://translate.codeberg.org/projects/backintime/common/ko/>\n"
@@ -1059,8 +1059,6 @@ msgid "At every boot/reboot"
 msgstr "부팅/재부팅 할 때 마다"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1069,6 +1067,13 @@ msgstr[0] "매 {n}분 마다"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "1시간마다"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "매 {n}시간마다"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1740,10 +1745,6 @@ msgstr "다음 스냅샷부터 \"{path}\"를 제외하시겠습니까?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "6시간마다"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "매 {n}시간마다"
 
 #, python-format
 #~ msgid "Ping %s failed. Host is down or wrong address."

--- a/common/po/lt.po
+++ b/common/po/lt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Lithuanian <https://translate.codeberg.org/projects/backintime/common/lt/>\n"
@@ -1098,8 +1098,6 @@ msgid "At every boot/reboot"
 msgstr "Po kiekvieno operacinės sistemos paleidimo/perkrovimo"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1110,6 +1108,15 @@ msgstr[2] "Kas {n} minutes"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Kas valandą"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Kas {n} valandos"
+msgstr[1] "Kas {n} valandos"
+msgstr[2] "Kas {n} valandos"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1788,10 +1795,6 @@ msgstr "Ištraukti \"{path}\" iš momentinių nuotraukų ateityje?"
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Kas 5 minutės"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Kas {n} valandos"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/messages.pot
+++ b/common/po/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \"Back In Time\" \"1.4.2-dev\"\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1003,8 +1003,6 @@ msgid "At every boot/reboot"
 msgstr ""
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1014,6 +1012,14 @@ msgstr[1] ""
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr ""
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] ""
+msgstr[1] ""
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"

--- a/common/po/nb.po
+++ b/common/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-24 13:13+0000\n"
 "Last-Translator: turbotopia <thomasalarsen10@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <https://translate.codeberg.org/projects/backintime/common/nb_NO/>\n"
@@ -1039,8 +1039,6 @@ msgid "At every boot/reboot"
 msgstr "For hver start/omstart"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1050,6 +1048,14 @@ msgstr[1] "Hvert {n}. minutt"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Hver time"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Hver {n}. time"
+msgstr[1] "Hver {n}. time"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1716,10 +1722,6 @@ msgstr ""
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Hver sjette time"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Hver {n}. time"
 
 #~ msgid "Local encrypted"
 #~ msgstr "Lokal kryptert"

--- a/common/po/nl.po
+++ b/common/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-11-07 09:13+0000\n"
 "Last-Translator: jpb <jpbeltman@live.nl>\n"
 "Language-Team: Dutch <https://translate.codeberg.org/projects/backintime/common/nl/>\n"
@@ -1084,8 +1084,6 @@ msgid "At every boot/reboot"
 msgstr "Bĳ elke opstart/herstart"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1095,6 +1093,14 @@ msgstr[1] "Iedere {n} minuten"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Ieder uur"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Iedere {n} uur"
+msgstr[1] "Iedere {n} uur"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1840,10 +1846,6 @@ msgstr "{path} uitsluiten van toekomstige momentopnames?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Elke 6 uren"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Iedere {n} uur"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/nn.po
+++ b/common/po/nn.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Norwegian Nynorsk <https://translate.codeberg.org/projects/backintime/common/nn/>\n"
@@ -1042,8 +1042,6 @@ msgid "At every boot/reboot"
 msgstr "Ved kvar start/omstart"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1053,6 +1051,14 @@ msgstr[1] "Kvart {n}. minutt"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Kvar time"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Kvar {n}. time"
+msgstr[1] "Kvar {n}. time"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1657,10 +1663,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Kvart 5. minutt"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Kvar {n}. time"
 
 #, fuzzy, python-brace-format
 #~ msgid "Profile: {name}"

--- a/common/po/pl.po
+++ b/common/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Polish <https://translate.codeberg.org/projects/backintime/common/pl/>\n"
@@ -1045,8 +1045,6 @@ msgid "At every boot/reboot"
 msgstr "Przy każdym uruchomieniu / restarcie"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1057,6 +1055,15 @@ msgstr[2] "Co {n} minut"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Co godzinę"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Co {n} godzin"
+msgstr[1] "Co {n} godzin"
+msgstr[2] "Co {n} godzin"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1729,10 +1736,6 @@ msgstr "Wykluczyć {path} z przyszłych migawek?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Co 6 godzin"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Co {n} godzin"
 
 #~ msgid "Key File"
 #~ msgstr "Plik klucza"

--- a/common/po/pt.po
+++ b/common/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Portuguese <https://translate.codeberg.org/projects/backintime/common/pt/>\n"
@@ -1051,8 +1051,6 @@ msgid "At every boot/reboot"
 msgstr "A cada arranque/reinício"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1062,6 +1060,14 @@ msgstr[1] "A cada {n} minutos"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "A cada hora"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "A cada {n} horas"
+msgstr[1] "A cada {n} horas"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1749,10 +1755,6 @@ msgstr ""
 
 #~ msgid "Every 6 hours"
 #~ msgstr "A cada 6 horas"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "A cada {n} horas"
 
 #~ msgid "Local encrypted"
 #~ msgstr "Local encriptado"

--- a/common/po/pt_BR.po
+++ b/common/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-09-27 20:53+0000\n"
 "Last-Translator: buhtz <c.buhtz@posteo.jp>\n"
 "Language-Team: Portuguese (Brazil) <https://translate.codeberg.org/projects/backintime/common/pt_BR/>\n"
@@ -1088,8 +1088,6 @@ msgid "At every boot/reboot"
 msgstr "Em cada início/reinício"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1099,6 +1097,14 @@ msgstr[1] "A cada {n} minutos"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "A cada hora"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "A cada {n} horas"
+msgstr[1] "A cada {n} horas"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1825,10 +1831,6 @@ msgstr "Excluir {path} de snapshots futuros?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "A cada 6 horas"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "A cada {n} horas"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/ro.po
+++ b/common/po/ro.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Romanian <https://translate.codeberg.org/projects/backintime/common/ro/>\n"
@@ -1097,8 +1097,6 @@ msgid "At every boot/reboot"
 msgstr "La fiecare pornire/restart"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1110,6 +1108,15 @@ msgstr[2] "La fiecare {n} minute"
 #, fuzzy
 msgid "Every hour"
 msgstr "La fiecare ora"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "La fiecare {n} ore"
+msgstr[1] "La fiecare {n} ore"
+msgstr[2] "La fiecare {n} ore"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1745,10 +1752,6 @@ msgstr "Excludeti \"{path}\" din viitoarele replici?"
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "La fiecare 5 minute"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "La fiecare {n} ore"
 
 #~ msgid "Local encrypted"
 #~ msgstr "Criptat Local"

--- a/common/po/ru.po
+++ b/common/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-09-18 19:32+0000\n"
 "Last-Translator: buhtz <c.buhtz@posteo.jp>\n"
 "Language-Team: Russian <https://translate.codeberg.org/projects/backintime/common/ru/>\n"
@@ -1081,8 +1081,6 @@ msgid "At every boot/reboot"
 msgstr "При каждой загрузке системы"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1093,6 +1091,15 @@ msgstr[2] "Каждые {n} минут"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Каждый час"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Каждые {n} часа"
+msgstr[1] "Каждые {n} часа"
+msgstr[2] "Каждые {n} часа"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1824,10 +1831,6 @@ msgstr "Исключить {path} из будущих снимков?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Каждые 6 часов"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Каждые {n} часа"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/sk.po
+++ b/common/po/sk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Slovak <https://translate.codeberg.org/projects/backintime/common/sk/>\n"
@@ -1056,8 +1056,6 @@ msgid "At every boot/reboot"
 msgstr "Pri každom štarte/reštartu"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1068,6 +1066,15 @@ msgstr[2] "Každých {n} minút"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr ""
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Každých {n} hodín"
+msgstr[1] "Každých {n} hodín"
+msgstr[2] "Každých {n} hodín"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1694,10 +1701,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Každých 5 minút"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Každých {n} hodín"
 
 #~ msgid "List only different snapshots"
 #~ msgstr "Zoznam iba rozdielnych snímok"

--- a/common/po/sl.po
+++ b/common/po/sl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Back In Time 0.9.10\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Slovenian <https://translate.codeberg.org/projects/backintime/common/sl/>\n"
@@ -1088,8 +1088,6 @@ msgid "At every boot/reboot"
 msgstr "Ob vsakem zagonu/ponovnem zagonu"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1101,6 +1099,16 @@ msgstr[3] "Vsakih {n} minut"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Vsako uro"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Vsakih {n} ur"
+msgstr[1] "Vsakih {n} ur"
+msgstr[2] "Vsakih {n} ur"
+msgstr[3] "Vsakih {n} ur"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1785,10 +1793,6 @@ msgstr ""
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Vsakih 6 ur"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Vsakih {n} ur"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/sr.po
+++ b/common/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Serbian <https://translate.codeberg.org/projects/backintime/common/sr/>\n"
@@ -1063,8 +1063,6 @@ msgid "At every boot/reboot"
 msgstr "При сваком покретању/рестарту"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1075,6 +1073,15 @@ msgstr[2] "Сваких {n} минута"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Свакх сат времена"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Сваких {n} сати"
+msgstr[1] "Сваких {n} сати"
+msgstr[2] "Сваких {n} сати"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1710,10 +1717,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Svakih 5 minuta"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Сваких {n} сати"
 
 #~ msgid "List only different snapshots"
 #~ msgstr "Izlistaj samo različite snimke"

--- a/common/po/sv.po
+++ b/common/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Swedish <https://translate.codeberg.org/projects/backintime/common/sv/>\n"
@@ -1128,8 +1128,6 @@ msgid "At every boot/reboot"
 msgstr "Vid varje start/omstart"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1139,6 +1137,14 @@ msgstr[1] "Var {n}:e minut"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Varje timme"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Var {n}:e timme"
+msgstr[1] "Var {n}:e timme"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1914,10 +1920,6 @@ msgstr "Exkludera \"{path}\" från framtida ögonblicksbilder?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "Var 6:e timme"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Var {n}:e timme"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/th.po
+++ b/common/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Thai <https://translate.codeberg.org/projects/backintime/common/th/>\n"
@@ -1085,8 +1085,6 @@ msgid "At every boot/reboot"
 msgstr "ทุกครั้งที่เปิดเครื่อง/เริ่มรีบูต"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1095,6 +1093,13 @@ msgstr[0] "ทุก {n} นาที"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "ทุกชั่วโมง"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "ทุก {n} ชั่วโมง"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1731,10 +1736,6 @@ msgstr "ยกเว้น \"{path}\" จากสแนปช็อตในอ
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "ทุก 5 นาที"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "ทุก {n} ชั่วโมง"
 
 #~ msgid "Local encrypted"
 #~ msgstr "การเข้ารหัสท้องถิ่น"

--- a/common/po/tr.po
+++ b/common/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Turkish <https://translate.codeberg.org/projects/backintime/common/tr/>\n"
@@ -1096,8 +1096,6 @@ msgid "At every boot/reboot"
 msgstr "Her Başlatıldığında/Yeniden Başlatıldığında"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1107,6 +1105,14 @@ msgstr[1] "{n} Dakikada Bir"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Saatte Bir"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "{n} Saatte Bir"
+msgstr[1] "{n} Saatte Bir"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1841,10 +1847,6 @@ msgstr "\"{path}\" yolu gelecek anlık görüntülerden dışlansın mı?"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "6 saatte bir"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "{n} Saatte Bir"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/uk.po
+++ b/common/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-11-13 00:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Ukrainian <https://translate.codeberg.org/projects/backintime/common/uk/>\n"
@@ -1064,8 +1064,6 @@ msgid "At every boot/reboot"
 msgstr "При кожному запуску/перезапуску"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1076,6 +1074,15 @@ msgstr[2] "Кожні {n} хвилин"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Щогодини"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Кожні {n} годин"
+msgstr[1] "Кожні {n} годин"
+msgstr[2] "Кожні {n} годин"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1738,10 +1745,6 @@ msgstr "Виключити {path} з майбутніх резервних ко�
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "Кожні 5 хвилин"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Кожні {n} годин"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/vi.po
+++ b/common/po/vi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Back In Time 1.3.4-dev\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Vietnamese <https://translate.codeberg.org/projects/backintime/common/vi/>\n"
@@ -1085,8 +1085,6 @@ msgid "At every boot/reboot"
 msgstr "Mỗi lần khởi động máy"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1095,6 +1093,13 @@ msgstr[0] "Mỗi {n} phút"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "Mỗi giờ"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "Mỗi {n} giờ"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1747,10 +1752,6 @@ msgstr "Loại trừ “{path}” ra khỏi các snapshot trong tương lai?"
 
 #~ msgid "Diff Options"
 #~ msgstr "Cài đặt Diff"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "Mỗi {n} giờ"
 
 #~ msgid ""
 #~ "Full system backup can only create a snapshot to be restored to the same physical disk(s) with the same disk partitioning as from the source; restoring to new physical disks or the same disks with different partitioning will yield a potentially broken and unusable system.\n"

--- a/common/po/zh_CN.po
+++ b/common/po/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Chinese (Simplified) <https://translate.codeberg.org/projects/backintime/common/zh_Hans/>\n"
@@ -1049,8 +1049,6 @@ msgid "At every boot/reboot"
 msgstr "每次启动/重启时"
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1059,6 +1057,13 @@ msgstr[0] "每{n}分钟"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr "每小时"
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "每{n}小时"
 
 #: qt/settingsdialog.py:372
 #, fuzzy
@@ -1750,10 +1755,6 @@ msgstr "在未来的快照中排除 \"{path}\"？"
 
 #~ msgid "Every 6 hours"
 #~ msgstr "每6小时"
-
-#, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "每{n}小时"
 
 #, python-format
 #~ msgid ""

--- a/common/po/zh_TW.po
+++ b/common/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: backintime\n"
 "Report-Msgid-Bugs-To: https://github.com/bit-team/backintime\n"
-"POT-Creation-Date: 2023-11-14 14:02+0100\n"
+"POT-Creation-Date: 2023-11-15 10:12+0100\n"
 "PO-Revision-Date: 2023-10-28 19:13+0000\n"
 "Last-Translator: SomeTr <SomeTr@users.noreply.translate.codeberg.org>\n"
 "Language-Team: Chinese (Traditional) <https://translate.codeberg.org/projects/backintime/common/zh_Hant/>\n"
@@ -1039,8 +1039,6 @@ msgid "At every boot/reboot"
 msgstr ""
 
 #: qt/settingsdialog.py:358 qt/settingsdialog.py:360 qt/settingsdialog.py:362
-#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
-#: qt/settingsdialog.py:371
 #, fuzzy, python-brace-format
 msgid "Every {n} minute"
 msgid_plural "Every {n} minutes"
@@ -1049,6 +1047,13 @@ msgstr[0] "每五分鐘"
 #: qt/settingsdialog.py:363
 msgid "Every hour"
 msgstr ""
+
+#: qt/settingsdialog.py:365 qt/settingsdialog.py:367 qt/settingsdialog.py:369
+#: qt/settingsdialog.py:371
+#, fuzzy, python-brace-format
+msgid "Every {n} hour"
+msgid_plural "Every {n} hours"
+msgstr[0] "每月"
 
 #: qt/settingsdialog.py:372
 msgid "Custom hours"
@@ -1669,10 +1674,6 @@ msgstr ""
 
 #~ msgid "Every 5 minutes"
 #~ msgstr "每五分鐘"
-
-#, fuzzy, python-brace-format
-#~ msgid "Every {n} hours"
-#~ msgstr "每月"
 
 #, fuzzy, python-brace-format
 #~ msgid "Profile: {name}"

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -362,13 +362,13 @@ class SettingsDialog(QDialog):
                 'Every {n} minute', 'Every {n} minutes', 30).format(n=30),
             config.Config._1_HOUR: _('Every hour'),
             config.Config._2_HOURS: ngettext(
-                'Every {n} minute', 'Every {n} minutes', 2).format(n=2),
+                'Every {n} hour', 'Every {n} hours', 2).format(n=2),
             config.Config._4_HOURS: ngettext(
-                'Every {n} minute', 'Every {n} minutes', 4).format(n=4),
+                'Every {n} hour', 'Every {n} hours', 4).format(n=4),
             config.Config._6_HOURS: ngettext(
-                'Every {n} minute', 'Every {n} minutes', 6).format(n=6),
+                'Every {n} hour', 'Every {n} hours', 6).format(n=6),
             config.Config._12_HOURS: ngettext(
-                'Every {n} minute', 'Every {n} minutes', 12).format(n=12),
+                'Every {n} hour', 'Every {n} hours', 12).format(n=12),
             config.Config.CUSTOM_HOUR: _('Custom hours'),
             config.Config.DAY: _('Every day'),
             config.Config.REPEATEDLY: _('Repeatedly (anacron)'),


### PR DESCRIPTION
The "Schedule" dropdown menu in the SettingsDialog used "minutes" where it should be "hours".
![image](https://github.com/bit-team/backintime/assets/11861496/b8ce01b7-2e39-4c5f-bc88-d593bfa2fc2f)

The bug was introduced by me from the very first beginning in 7th August 0a6e615d41c939e73850d32787449dcff0835142 and released with version 1.4.0 and 1.4.1.

