### PR TITLE
fix: Full os-release path in --diagnostics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ python:
   - "3.9"
   - "3.10"
   - "3.11"
+  - "3.12"
 
 before_install:
   # disable mongodb as we don't need it and it sometimes temporary fails
@@ -32,6 +33,7 @@ jobs:
   exclude:
     - python: "3.9"
     - python: "3.10"
+    - python: "3.11"
 
 install:
   - pip install pylint coveralls pyfakefs

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -382,20 +382,20 @@ def _get_os_release():
                            ))
 
     # "os-release" is standard and should be on top of the list
-    fp = etc_path / 'os-release'
+    fp_osrelease = etc_path / 'os-release'
     try:
-        os_files.remove(fp)
+        os_files.remove(fp_osrelease)
     except ValueError:
         pass
     else:
-        os_files = [fp] + os_files
+        os_files = [fp_osrelease] + os_files
 
     # each release/version file found
     osrelease = {str(fp): _get_pretty_name_or_content(fp) for fp in os_files}
 
     # No alternative release files found
     if len(osrelease) == 1:
-        return osrelease['os-release']
+        return osrelease[str(fp_osrelease)]
 
     return osrelease
 


### PR DESCRIPTION
This fix a minor bug (discovered in #1580) in context of diagnostic output handling os-release file.

IMHO no need for a changelog entry because it is very minor.