### PR TITLE
Add developer documentation for usage of lock, flock and other files in BiT ( related to #1573)

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -131,7 +131,7 @@ schedules.
 
 ## Known Errors and Warnings
 ### WARNING: A backup is already running
-_Back In Time_ uses signal files like `worker.lock` to avoid starting the same backup twice.
+_Back In Time_ uses signal files like `worker<PID>.lock` to avoid starting the same backup twice.
 Normally it is deleted as soon as the backup finishes. In some case something went wrong
 so that _Back In Time_ was forcefully stopped without having the chance to delete
 this signal file.
@@ -147,12 +147,16 @@ ps aux | grep -i backintime
 If the output shows a running instance of _Back In Time_ it must be waited until it finishes
 or killed via `kill <process id>`.
 
+For more details see the developer documentation: [Usage of control files (locks, flocks, logs and others)](common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md)
+
 ### The application is already running! (pid: 1234567)
 This message occurs when _Back In Time_ did not finish regularly and wasn't able
 to delete its application lock file. Before deleting that file make sure
 no backintime process is running via `ps aux | grep -i backintime`. Otherwise
 kill the process. After that look into the folder
-`~/.local/share/backintime` for the file `app.loc.pid` and delete it.
+`~/.local/share/backintime` for the file `app.lock.pid` and delete it.
+
+For more details see the developer documentation: [Usage of control files (locks, flocks, logs and others)](common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md)
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ installation options provided and maintained by third parties.
 
 - A Personal Package Archive ([PPA](https://launchpad.net/ubuntu/+ppas)) offering [`ppa:bit-team/stable`](https://launchpad.net/~bit-team/+archive/ubuntu/stable) as stable and [`ppa:bit-team/testing`](https://launchpad.net/~bit-team/+archive/ubuntu/testing) as testing PPA. Hosted at Launchpad and provided by [@Germar](https://github.com/germar).
 - A PPA distributing [_Back In Time_ for the latest stable Ubuntu release](https://git.sdxlive.com/PPA/about). See [PPA requirements](https://git.sdxlive.com/PPA/about/#requirements) and [install instructions](https://git.sdxlive.com/PPA/about/#installing). The PPA is self-hosted and provided by [@jean-christophe-manciot](https://github.com/jean-christophe-manciot).
-- The Arch User Repository ([AUR](https://aur.archlinux.org/)) do offer [some packages](https://aur.archlinux.org/packages?K=backintime).
+- The Arch User Repository ([AUR](https://aur.archlinux.org/)) does offer [some packages](https://aur.archlinux.org/packages?K=backintime).
 
 ## Known Problems and Workarounds
 

--- a/common/applicationinstance.py
+++ b/common/applicationinstance.py
@@ -26,6 +26,10 @@ import logger
 import tools
 
 
+# TODO This class name is a misnomer (there may be more than
+#      one app instance eg. if a restore is running and another
+#      backup starts).
+#      Rename it to eg. LockFileManager
 class ApplicationInstance:
     """
     Class used to handle one application instance mechanism.
@@ -54,12 +58,13 @@ class ApplicationInstance:
     def __del__(self):
         self.flockUnlock()
 
+    # TODO Rename to is_single_instance() to make the purpose more obvious
     def check(self, autoExit=False):
         """
         Check if the current application is already running
 
         Args:
-            autoExit (bool): automatically call sys.exit if there is an other
+            autoExit (bool): automatically call sys.exit if there is another
                              instance running
 
         Returns:
@@ -71,7 +76,7 @@ class ApplicationInstance:
 
         self.pid, self.procname = self.readPidFile()
 
-        # check if the process with specified by pid exists
+        # check if the process (PID) that created the pid file still exists
         if 0 == self.pid:
             return True
 
@@ -119,6 +124,9 @@ class ApplicationInstance:
                 'Failed to write PID file %s: [%s] %s'
                 % (e.filename, e.errno, e.strerror))
 
+        # The flock is removed here because it shall only ensure serialized access to the "pidFile" (lock file):
+        # Without setting flock in __init__ another process could also check for the existences of the "pidFile"
+        # in parallel and also create a new one (overwriting the one created here).
         self.flockUnlock()
 
     def exitApplication(self):
@@ -132,15 +140,52 @@ class ApplicationInstance:
 
     def flockExclusiv(self):
         """
-        Create an exclusive lock to block a second instance while
-        the first instance is starting.
+        Create an exclusive advisory file lock named <PID file>.flock
+        to block the creation of a second instance while the first instance
+        is still in the process of starting (but has not yet completely
+        started).
 
-        Dev note (buhtz: 2023-09)
+        The purpose is to make
+        1. the check if the PID lock file already exists
+        2. and the subsequent creation of the PID lock file
+        an atomic operation by using a blocking "flock" file lock
+        on a second file to avoid that two or more processes check for
+        an existing PID lock file, find none and create a new one
+        (so that only the last creator wins).
+
+        Dev notes:
+        ---------
+        buhtz (2023-09):
         Not sure but just log an ERROR without doing anything else is
         IMHO not enough.
+        aryoda (2023-12):
+        It seems the purpose of this additional lock file using an exclusive lock
+        is to block the other process to continue until this exclusive lock
+        is released (= serialize execution).
+        Therefor advisory locks are used via fcntl.flock (see: man 2 fcntl)
         """
+
+        flock_file_URI = self.pidFile + '.flock'
+        logger.debug(f"Trying to put an advisory lock on the flock file {flock_file_URI}")
+
         try:
-            self.flock = open(self.pidFile + '.flock', 'w')
+            self.flock = open(flock_file_URI, 'w')
+            # This opens an advisory lock which which is considered only
+            # if other processes cooperate by explicitly acquiring locks
+            # (which BiT does IMHO).
+            # TODO Does this lock request really block if another processes
+            #      already holds a lock (until the lock is released)?
+            #      = Is the execution serialized?
+            # Provisional answer:
+            #      Yes, fcntl.flock seems to wait until the lock is removed
+            #      from the file.
+            #      Tested by starting one process in the console via
+            #         python3 applicationinstance.py
+            #      and then (while the first process is still running)
+            #      the same command in a 2nd terminal.
+            #      The ApplicationInstance constructor call needs
+            #      to be changed for this by adding "False, True"
+            #      to trigger an exclusive lock.
             fcntl.flock(self.flock, fcntl.LOCK_EX)
 
         except OSError as e:
@@ -153,6 +198,7 @@ class ApplicationInstance:
         but should find it self to be obsolete.
         """
         if self.flock:
+            logger.debug(f"Trying to remove the advisory lock from the flock file {self.flock.name}")
             fcntl.fcntl(self.flock, fcntl.LOCK_UN)
             self.flock.close()
 

--- a/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
+++ b/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
@@ -18,7 +18,7 @@ Table of contents:
    + [`save_to_continue` flag file in new snapshots](#save_to_continue-flag-file-in-new-snapshots)
    + [Restore lock file (`restore<Profile ID>.lock`)](#restore-lock-file-restoreprofile-idlock)
 * [See also](#see-also)
-   + [_Back in Time_ FAQ](#_back-in-time_-faq)
+   + [_Back in Time_ FAQ](#back-in-time-faq)
    + [Linux advisory locks](#linux-advisory-locks)
 
 Notes:

--- a/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
+++ b/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
@@ -2,8 +2,8 @@
 
 Table of contents:
 
-* [TLDR ;-)](#tldr-)
-* [_Back In Time_ commands that use lock files](#_back-in-time_-commands-that-use-lock-files)
+* [TLDR ;-)](#tldr--)
+* [_Back In Time_ commands that use lock files](#back-in-time-commands-that-use-lock-files)
    + [`backup`](#backup)
    + [`restore`](#restore)
    + [`shutdown`](#shutdown)

--- a/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
+++ b/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
@@ -56,12 +56,9 @@ of _Back In Time_.
 _Back In Time_ does only start a new backup job (for the same profile)
 if the control file does not exist.
 
-Lock files are stored by default in the folder
-
-`~/.local/share/backintime`
-
-and contain the process id (also known as PID - see `man ps`) and process name
-of the running backup process.
+Lock files are stored by default in the folder `~/.local/share/backintime` and
+contain the process id (also known as PID - see `man ps`) and process name of
+the running backup process.
 
 The PID is used [to check if the process that created the
 lock file is still running](https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/applicationinstance.py#L78-L79) and delete or overwrite the lock file

--- a/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
+++ b/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
@@ -1,5 +1,26 @@
 # Usage of lock files in _Back In Time_ (developer documentation?
 
+Table of contents:
+
+* [TLDR ;-)](#tldr-)
+* [_Back In Time_ commands that use lock files](#_back-in-time_-commands-that-use-lock-files)
+   + [`backup()`](#backup)
+   + [`restore()`](#restore)
+   + [`shutdown()`](#shutdown)
+* [List of known control files](#list-of-known-control-files)
+   + [GUI (application) lock files (`app.lock.pid`)](#gui-application-lock-files-applockpid)
+   + [Global flock file `/tmp/backintime.lock`](#global-flock-file-tmpbackintimelock)
+   + [Backup lock files (`worker<Profile ID>.lock.flock`)](#backup-lock-files-workerprofile-idlockflock)
+   + [Backup progress file (`worker<PID>.progress`)](#backup-progress-file-workerpidprogress)
+   + [`takesnapshot_<profile ID>.log`](#takesnapshot_profile-idlog)
+   + [`restore_<profile ID>.log`](#restore_profile-idlog)
+   + [Raise file (`app.lock.raise`)](#raise-file-applockraise)
+   + [`save_to_continue` flag file in new snapshots](#save_to_continue-flag-file-in-new-snapshots)
+   + [Restore lock file (`restore<Profile ID>.lock`)](#restore-lock-file-restoreprofile-idlock)
+* [See also](#see-also)
+   + [_Back in Time_ FAQ](#_back-in-time_-faq)
+   + [Linux advisory locking](#linux-advisory-locking)
+
 Notes:
 
 - The logic is based on the the source code of
@@ -168,7 +189,7 @@ https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d
 
 
 
-### Backup progress file (`worker<PID>.progress')
+### Backup progress file (`worker<PID>.progress`)
 
 _Back In Time_ starts `rsync` as separate process.
 To read the progress, errors and results of `rsync` a `worker<PID>.progress' file

--- a/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
+++ b/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
@@ -1,12 +1,12 @@
-# Usage of lock files in _Back In Time_ (developer documentation?
+# Usage of control files in _Back In Time_ (developer documentation)
 
 Table of contents:
 
 * [TLDR ;-)](#tldr-)
 * [_Back In Time_ commands that use lock files](#_back-in-time_-commands-that-use-lock-files)
-   + [`backup()`](#backup)
-   + [`restore()`](#restore)
-   + [`shutdown()`](#shutdown)
+   + [`backup`](#backup)
+   + [`restore`](#restore)
+   + [`shutdown`](#shutdown)
 * [List of known control files](#list-of-known-control-files)
    + [GUI (application) lock files (`app.lock.pid`)](#gui-application-lock-files-applockpid)
    + [Global flock file `/tmp/backintime.lock`](#global-flock-file-tmpbackintimelock)
@@ -19,7 +19,7 @@ Table of contents:
    + [Restore lock file (`restore<Profile ID>.lock`)](#restore-lock-file-restoreprofile-idlock)
 * [See also](#see-also)
    + [_Back in Time_ FAQ](#_back-in-time_-faq)
-   + [Linux advisory locking](#linux-advisory-locking)
+   + [Linux advisory locks](#linux-advisory-locks)
 
 Notes:
 
@@ -71,7 +71,7 @@ with a new instance.
 
 ## _Back In Time_ commands that use lock files
 
-### `backup()`
+### `backup`
 
 Takes a snapshot after checking that no other snapshot or restore is running at the same time:
 
@@ -104,7 +104,7 @@ This table shows the control file focused execution sequence of the [`snapshots.
 
 
 
-### `restore()`
+### `restore`
 
 Before restoring one or more files from a snapshot _Back In Time_ checks
 if a restore is already running (using the restore lock file `restore<Profile ID>.lock`)
@@ -124,7 +124,7 @@ This table shows the control file focused execution sequence of the [`snapshots.
 
 
 
-### `shutdown()`
+### `shutdown`
 
 This command shuts down the computer after the current snapshot has finished.
 It polls the worker lock file to recognize running backups.
@@ -264,7 +264,7 @@ for some problems caused by lock files.
 
 
 
-### Linux advisory locking
+### Linux advisory locks
 
 See `man 2 fcntl` and https://linuxhandbook.com/file-locking/
 

--- a/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
+++ b/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md
@@ -1,0 +1,256 @@
+# Usage of lock files in _Back In Time_ (developer documentation?
+
+Notes:
+
+- The logic is based on the the source code of
+  [_Back In Time_ v1.4.1](https://github.com/bit-team/backintime/releases/tag/v1.4.1)
+  and all source code references point to v1.4.1.
+  The code may look differently and even the logic may have been changed
+  in later versions.
+
+- Tables in this markdown file are generated using https://www.tablesgenerator.com/markdown_tables
+  with `Line breaks as "br"` enabled.
+
+- Whenever `<Profile ID>` is mentioned it means the profile number of the configuration.
+  **For the profile ID 1 no number is used but an empty string**
+  (why this confusing exception is made is unclear).
+
+
+
+## TLDR ;-)
+
+_Back In Time_ uses control files to prevent that multiple instances
+work in parallel and conflicts may occur (eg. taking a snapshot for the same
+profile in two different processes).
+
+The most important control file is `worker<Profile ID>.lock` which is used
+to avoid starting the same backup twice in parallel.
+
+The `<Profile ID>` is empty for the default profile (1).
+
+It also uses another exclusively locked file named `worker<Profile ID>.lock.flock`
+to serialize the access of checking for another running backup
+of _Back In Time_.
+
+_Back In Time_ does only start a new backup job (for the same profile)
+if the control file does not exist.
+
+Lock files are stored by default in the folder
+
+`~/.local/share/backintime`
+
+and contain the process id (also known as PID - see `man ps`) and process name
+of the running backup process.
+
+The PID is used [to check if the process that created the
+lock file is still running](https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/applicationinstance.py#L78-L79) and delete or overwrite the lock file
+with a new instance.
+
+
+
+## _Back In Time_ commands that use lock files
+
+### `backup()`
+
+Takes a snapshot after checking that no other snapshot or restore is running at the same time:
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/snapshots.py#L713-L729
+
+If a snapshot or restore is running a warning (not an error!) is issued and
+**no** new snapshot is taken!
+
+Another control file named `worker<Profile ID>.lock.flock` is used to serialize access to the `worker*.lock` file
+**before** a new one is created (via a “flock” = blocking advisory lock on the file).
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/applicationinstance.py#L47-L48
+
+This table shows the control file focused execution sequence of the [`snapshots.py#backup()` function](https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/snapshots.py#L680):
+
+| Step | worker<Profile ID>.lock.flock                                                                                    | worker<Profile ID>.lock                                   | restore<Profile ID>.lock.flock                                                                                    | restore<profile ID>.lock                                   | /tmp/backintime.lock                                                                                                               | Other actions                            | Relevant code snippets                                                                                                                                                                                                                                                                                                                                                                           |
+|------|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|      | Control file to serialize access to the `worker*.lock` file (via a “flock” = blocking advisory lock on the file) | Control file to indicate a running backup                 | Control file to serialize access to the `restore*.lock` file (via a “flock” = blocking advisory lock on the file) | Control file to indicate a running restore                 | Global control file to prevent running backups or restores on multiple snapshots from different profiles or users at the same time | Executed logic not related to lock files | Taken from the source code of BiT v1.4.1                                                                                                                                                                                                                                                                                                                                                         |
+| 1    | Create file and set flock                                                                                        |                                                           |                                                                                                                   |                                                            |                                                                                                                                    |                                          | instance = ApplicationInstance(self.config.takeSnapshotInstanceFile(), False, flock = True)                                                                                                                                                                                                                                                                                                      |
+| 2    |                                                                                                                  |                                                           |                                                                                                                   |                                                            |                                                                                                                                    |                                          | restore_instance = ApplicationInstance(self.config.restoreInstanceFile(), False)                                                                                                                                                                                                                                                                                                                 |
+| 3    |                                                                                                                  | Check if exists:<br>→ Yes: Exit without taking a snapshot |                                                                                                                   |                                                            |                                                                                                                                    |                                          | instance.check() == not True?                                                                                                                                                                                                                                                                                                                                                                    |
+| 4    |                                                                                                                  |                                                           |                                                                                                                   | Check if exists:<br>-> Yes: Exit without taking a snapshot |                                                                                                                                    |                                          | restore_instance.check() == not True?                                                                                                                                                                                                                                                                                                                                                            |
+| 5    |                                                                                                                  | Create file                                               |                                                                                                                   |                                                            |                                                                                                                                    |                                          | instance.startApplication()                                                                                                                                                                                                                                                                                                                                                                      |
+| 6    | Release flock and delete file                                                                                    |                                                           |                                                                                                                   |                                                            |                                                                                                                                    |                                          | self.flockUnlock()  # within startApplication()                                                                                                                                                                                                                                                                                                                                                  |
+| 7    |                                                                                                                  |                                                           |                                                                                                                   |                                                            | Create file and set flock                                                                                                          |                                          | self.flockExclusive()  # global flock to block backups from other profiles or users (and run them serialized)                                                                                                                                                                                                                                                                                    |
+| 8    |                                                                                                                  |                                                           |                                                                                                                   |                                                            |                                                                                                                                    | Take the snapshot using rsync            | self.takeSnapshot(sid, now, include_folders)                                                                                                                                                                                                                                                                                                                                                     |
+| 9    |                                                                                                                  |                                                           |                                                                                                                   |                                                            |                                                                                                                                    | Perform user-callback calls              | In case of errors call eg.<br>self.config.PLUGIN_MANAGER.error(5, msg)  # no snapshot and errors<br>self.config.PLUGIN_MANAGER.error(6, sid.displayID) # snapshot with errors<br>If a new snapshot was taken (complete or incomplete due to errors):<br>self.config.PLUGIN_MANAGER.newSnapshot(sid, sid.path()) #new snapshot  (if taken)<br>Finally:<br>self.config.PLUGIN_MANAGER.processEnd() |
+| 10   |                                                                                                                  | Delete file                                               |                                                                                                                   |                                                            |                                                                                                                                    |                                          | instance.exitApplication()                                                                                                                                                                                                                                                                                                                                                                       |
+| 11   |                                                                                                                  |                                                           |                                                                                                                   |                                                            | Release flock and delete file                                                                                                      |                                          | self.flockRelease()                                                                                                                                                                                                                                                                                                                                                                              |
+
+
+
+### `restore()`
+
+Before restoring one or more files from a snapshot _Back In Time_ checks
+if a restore is already running (using the restore lock file `restore<Profile ID>.lock`)
+and exits with a warning (**not an error!**).
+
+This table shows the control file focused execution sequence of the [`snapshots.py#restore()` function](https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/snapshots.py#L416:
+
+| Step | worker<Profile ID>.lock.flock                                                                                    | worker<Profile ID>.lock                   | restore<Profile ID>.lock.flock                                                                                    | restore<profile ID>.lock                                       | /tmp/backintime.lock                                                                                                               | Other actions                            | Relevant code snippets                                                                                |
+|------|------------------------------------------------------------------------------------------------------------------|-------------------------------------------|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|-------------------------------------------------------------------------------------------------------|
+|      | Control file to serialize access to the `worker*.lock` file (via a “flock” = blocking advisory lock on the file) | Control file to indicate a running backup | Control file to serialize access to the `restore*.lock` file (via a “flock” = blocking advisory lock on the file) | Control file to indicate a running restore                     | Global control file to prevent running backups or restores on multiple snapshots from different profiles or users at the same time | Executed logic not related to lock files | Taken from the source code of BiT v1.4.1                                                              |
+| 1    |                                                                                                                  |                                           | Create file and set flock                                                                                         |                                                                |                                                                                                                                    |                                          | instance = ApplicationInstance(pidFile=self.config.restoreInstanceFile(), autoExit=False, flock=True) |
+| 2    |                                                                                                                  |                                           |                                                                                                                   | Check if exists:<br>→ Yes: Exit without restoring the snapshot |                                                                                                                                    |                                          | instance.check() == not True?                                                                         |
+| 3    |                                                                                                                  |                                           |                                                                                                                   | Create file                                                    |                                                                                                                                    |                                          | instance.startApplication()                                                                           |
+| 4    |                                                                                                                  |                                           | Release flock and delete file                                                                                     |                                                                |                                                                                                                                    |                                          | self.flockUnlock()  # within startApplication()                                                       |
+| 5    |                                                                                                                  |                                           |                                                                                                                   |                                                                |                                                                                                                                    | Restore the snapshot using rsync         | proc = tools.Execute(cmd […]                                                                          |
+| 6    |                                                                                                                  |                                           |                                                                                                                   | Delete file                                                    |                                                                                                                                    |                                          | instance.exitApplication()                                                                            |
+
+
+
+### `shutdown()`
+
+This command shuts down the computer after the current snapshot has finished.
+It polls the worker lock file to recognize running backups.
+
+It is implemented in the function `backintime.py#shutdown()`:
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/backintime.py#L805-L819
+
+This table shows the control file focused execution sequence of the function:
+
+| Step | worker<Profile ID>.lock.flock                                                                                    | worker<Profile ID>.lock                                   | restore<Profile ID>.lock.flock                                                                                    | restore<profile ID>.lock                   | /tmp/backintime.lock                                                                                                               | Other actions                                           | Relevant code snippets                                                                              |
+|------|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+|      | Control file to serialize access to the `worker*.lock` file (via a “flock” = blocking advisory lock on the file) | Control file to indicate a running backup                 | Control file to serialize access to the `restore*.lock` file (via a “flock” = blocking advisory lock on the file) | Control file to indicate a running restore | Global control file to prevent running backups or restores on multiple snapshots from different profiles or users at the same time | Executed logic not related to lock files                | Taken from the source code of BiT v1.4.1                                                            |
+| 1    |                                                                                                                  |                                                           |                                                                                                                   |                                            |                                                                                                                                    | Prepare lock file checking (without using a flock file) | instance = ApplicationInstance(cfg.takeSnapshotInstanceFile()                                       |
+| 2    |                                                                                                                  | Check if exists:<br>→ No: Exit (no active snapshot)       |                                                                                                                   |                                            |                                                                                                                                    |                                                         | if not instance.busy():    logger.info('There is no active snapshot for profile %s. Skip shutdown.' |
+| 3    |                                                                                                                  | Check if exists:<br>→ Yes: Wait 5 seconds and check again |                                                                                                                   |                                            |                                                                                                                                    |                                                         | while instance.busy():    logger.debug('Snapshot is still active. Wait for shutdown.')    sleep(5)  |
+| 4    |                                                                                                                  |                                                           |                                                                                                                   |                                            |                                                                                                                                    | shutdown computer                                       | sd.shutdown()                                                                                       |
+
+
+
+## List of known control files
+
+### GUI (application) lock files (`app.lock.pid`)
+
+An **application lock file** named `app.lock.pid` is used for the _Back In Time_ application (GUI) 
+to avoid starting more than one instance of the application (GUI) for the same user.
+
+The name and path of the application lock file  is defined in two locations
+(which should be refactored into one single place).
+
+Path and base file name in `config.py#appInstanceFile()`:
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/config.py#L1369-L1370
+
+The file extension `.pid` is added in `guiapplicationinstance.py#__init__()`:
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/guiapplicationinstance.py#L35
+
+
+
+### Global flock file `/tmp/backintime.lock`
+
+To prevent multiple snapshots from different profiles or users to be
+run at the same time a global flock file  ("flock") `/tmp/backintime.lock` is created
+(with and advisory lock to serialize access):
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/config.py#L1356-L1358
+
+
+
+### Backup lock files (`worker<Profile ID>.lock.flock`)
+
+The name and path of the worker process lock file for running snapshots is defined in
+`config.py#takeSnapshotInstanceFile()`:
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/config.py#L1388-L1391
+
+Only for the default profile ID (1) no number is used resulting in `worker.lock`
+(why this confusing exception is made is unclear):
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/config.py#L1372-L1377
+
+
+
+### Backup progress file (`worker<PID>.progress')
+
+_Back In Time_ starts `rsync` as separate process.
+To read the progress, errors and results of `rsync` a `worker<PID>.progress' file
+is used (written by `rsync` and read + filtered by _Back In Time_):
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/snapshots.py#L858
+
+
+
+### `takesnapshot_<profile ID>.log`
+
+TODO
+
+
+
+### `restore_<profile ID>.log`
+
+TODO
+
+
+
+### Raise file (`app.lock.raise`)
+
+TODO (what is the purpose of this?)
+
+Defined:
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/guiapplicationinstance.py#L32-L33
+
+Called via timer:
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/qt/app.py#L389-L393
+
+RaiseCMD passed in the main() entry point:
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/qt/app.py#L1979
+
+
+
+### `save_to_continue` flag file in new snapshots
+
+This flag file is set for new snapshots initially.
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/snapshots.py#L2749-L2763
+
+In `snapshots.py#takeSnapshot()` it is then decided if the existing snapshot can be used to "continue"
+taking a snapshot or to delete the contained files and restart taking the snapshot:
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/snapshots.py#L1140-L1166
+
+TODO How exactly does this work? Could we use this to implement a "retry" feature for failed snapshots?
+
+
+
+### Restore lock file (`restore<Profile ID>.lock`)
+
+The name and path of the restore process lock file `restore<Profile ID>.lock`
+for running restores is defined in
+
+`config.py#restoreInstanceFile()`:
+
+https://github.com/bit-team/backintime/blob/25c2115b42904ec4a4aee5ba1d73bd97cb5d8b31/common/config.py#L1444-L1447
+
+The flock file to serialize write access to the lock file (via a blocking advisory lock on the file)
+is different from the backup flock file: `restore<Profile ID>.lock.flock`
+
+
+
+## See also
+
+### _Back in Time_ FAQ
+
+The [FAQ](https://github.com/bit-team/backintime/blob/dev/FAQ.md) gives answers
+for some problems caused by lock files.
+
+
+
+### Linux advisory locking
+
+See `man 2 fcntl` and https://linuxhandbook.com/file-locking/
+
+> 1.  Advisory Locking
+>
+> The advisory locking system will not force the forces and will only work if both processes are participating in locking.
+> For example, process A acquires the lock and starts given tasks with a file.
+> And if process B starts without acquiring a lock, it can interrupt the ongoing task with process A.
+> So the condition for making an advisory lock is to ensure each process participates in locking.
+> the flock command which allows users to handle tasks related to advisory locking

--- a/common/doc-dev/README.md
+++ b/common/doc-dev/README.md
@@ -4,7 +4,8 @@
 - [Using Sphinx to write and build documentation](1_doc_maintenance_howto.md)
 - [Localization and translation using Weblate](2_localization.md)
 - [How to setup openssh for unit tests](3_How_to_set_up_openssh_server_for_ssh_unit_tests.md)
+- [Usage of control files (locks, flocks, logs and others)](4_Control_files_usage_(locks_flocks_logs_and_others).md)
 - [How to prepare and publish a new BiT release](BiT_release_process.md)
 <!-- TOC end -->
 
-<sub>Nov 2023</sub>
+<sub>Dec 2023</sub>

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -442,7 +442,7 @@ class Snapshots:
                                         snapshot
             backup (bool):              create backup files (``*.backup.YYYYMMDD``)
                                         before changing or deleting local files.
-            only_new (bool):            Only restore files which does not exist
+            only_new (bool):            Only restore files which do not exist
                                         or are newer than those in destination.
                                         Using ``rsync --update`` option.
         """
@@ -677,6 +677,10 @@ class Snapshots:
 
             return True
 
+    # TODO Refactor: This functions is extremely difficult to understand:
+    #  - Nested "if"s
+    #  - Fuzzy names of classes, attributes and methods
+    # - unclear variable names (at least for the return values)
     def backup(self, force = False):
         """
         Wrapper for :py:func:`takeSnapshot` which will prepare and clean up
@@ -725,7 +729,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
                     logger.warning('Backups disabled on battery but power status is not available', self)
 
                 instance.startApplication()
-                self.flockExclusive()
+                self.flockExclusive()  # global flock to block backups from other profiles or users (and run them serialized)
                 logger.info('Lock', self)
 
                 now = datetime.datetime.today()
@@ -2012,6 +2016,7 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
             logger.error('Failed to create symlink %s: %s' %(symlink, str(e)), self)
             return False
 
+    # TODO Rename to make the purpose obvious, eg: Serialize_[backup|execution]_via_exclusive_global_flock()
     def flockExclusive(self):
         """
         Block :py:func:`backup` from other profiles or users
@@ -2020,8 +2025,8 @@ restore is done. The pid of the already running restore is in %s.  Maybe delete 
         if self.config.globalFlock():
             logger.debug('Set flock %s' %self.GLOBAL_FLOCK, self)
             self.flock = open(self.GLOBAL_FLOCK, 'w')
-            fcntl.flock(self.flock, fcntl.LOCK_EX)
-            #make it rw by all if that's not already done.
+            fcntl.flock(self.flock, fcntl.LOCK_EX)  # blocks (waits) until an existing flock is released
+            # make it rw by all if that's not already done.
             perms = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | \
                     stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
             s = os.fstat(self.flock.fileno())


### PR DESCRIPTION
Mainly contributes a new dev doc file:

https://github.com/aryoda/backintime/blob/issue/1573_retry_backup/common/doc-dev/4_Control_files_usage_(locks_flocks_logs_and_others).md

This documentation is part of #1573 


