### PR TITLE
Install dbus configuration file to /usr/share not /etc

### DIFF
--- a/debian/backintime-qt.maintscript
+++ b/debian/backintime-qt.maintscript
@@ -1,0 +1,2 @@
+# Moved to /usr/share in 1.4.2; remove old copy in /etc if not modified
+rm_conffile /etc/dbus-1/system.d/net.launchpad.backintime.serviceHelper.conf 1.4.2~~

--- a/qt/configure
+++ b/qt/configure
@@ -162,10 +162,10 @@ addUninstallDir                                     "/share/dbus-1"
 addNewline
 
 addComment "dbus conf"
-addInstallDir                                    "/../etc/dbus-1/system.d"
-addInstallFiles "net.launchpad.backintime*.conf" "/../etc/dbus-1/system.d"
-addUninstallDir                                  "/../etc/dbus-1"
-addUninstallDir                                  "/../etc"
+addInstallDir                                    "/share/dbus-1/system.d"
+addInstallFiles "net.launchpad.backintime*.conf" "/share/dbus-1/system.d"
+addUninstallDir                                  "/share/dbus-1"
+addUninstallDir                                  "/share"
 addNewline
 
 addComment "polkit action"

--- a/qt/configure
+++ b/qt/configure
@@ -134,6 +134,13 @@ printf "\trm -f man/C/*.gz\n\n" >> ${MAKEFILE}
 
 #create install and uninstall target
 printf "install:\n" >> ${MAKEFILE}
+
+# Migration
+printf "\t#clean-up installed old files that were renamed or moved in later BiT versions\n" >> ${MAKEFILE}
+printf "\trm -f /etc/dbus-1/system.d/net.launchpad.backintime.serviceHelper.conf\n" >> ${MAKEFILE}
+printf "\trm -f $(DEST)/share/backintime/plugins/qt4plugin.py\n" >> ${MAKEFILE}
+addNewline
+
 addComment "python"
 addUninstallDir          "/share/backintime/qt/__pycache__"
 addUninstallFile "*.pyc" "/share/backintime/qt/__pycache__"


### PR DESCRIPTION
This was done in Debian packages in version 1.4.1-1

From https://dbus.freedesktop.org/doc/dbus-daemon.1.html:

> The standard system bus normally reads additional XML files from /usr/share/dbus-1/system.d. Third-party packages should install the default policies necessary for correct operation into that directory, which has been supported since dbus 1.10 (released in 2015).
> The standard system bus normally also reads XML files from /etc/dbus-1/system.d, which should be used by system administrators if they wish to override default policies.
> **Third-party packages would historically install XML files into /etc/dbus-1/system.d, but this practice is now considered to be deprecated: that directory should be treated as reserved for the system administrator.**