### PR TITLE
Fixes #1592, #1580, #836, #1350: "qt5_probing.py" hangs; Cannot launch … BiT (root) on Wayland

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,8 @@ Back In Time
 
 Version 1.4.2-dev (development of upcoming release)
 * Fix bug: `qt5_probing.py` hangs when BiT is run as root and no user is logged into a desktop environment (#1592 and #1580)
+* Fix bug: Launching BiT GUI (root) hangs on Wayland without showing the GUI (#836)
+* Improve: Launcher for BiT GUI (root) does not enforce Wayland anymore but uses same settings as for BiT GUI (userland) (#1350)
 * Fix bug: Disabling suspend during taking a backup ("inhibit suspend") hangs when BiT is run as root and no user is logged into a desktop environment (#1592)
 * Change of semantics: BiT running as root never disables suspend during taking a backup ("inhibit suspend") even though this may have worked before in BiT <= v1.4.1 sometimes (required to fix #1592)
 * Fix bug: RTE: module 'qttools' has no attribute 'initate_translator' with encFS when prompting the user for a password (#1553).
@@ -10,8 +12,8 @@ Version 1.4.2-dev (development of upcoming release)
 * Build: Activate PyLint warning W1401 (anomalous-backslash-in-string).
 * Build: Add codespell config.
 * Translation: Minor modifications in source strings and updating language files.
-* Improved: Logging of qtsystrayicon.py, qt5_probing.py, usercallbackplugin.py and all parts of app.py
-            do now use the "backintime" app id in the syslog too to ensure complete log output with journalctl + grep
+* Improved: qtsystrayicon.py, qt5_probing.py, usercallbackplugin.py and all parts of app.py
+            do now also use "backintime" as logging namespace in the syslog to ensure complete log output with `journalctl | grep -i backintime`
 
 Version 1.4.1 (2023-10-01)
 * Dependency: Add "qt translations" to GUI runtime dependencies (#1538).

--- a/CHANGES
+++ b/CHANGES
@@ -1,12 +1,17 @@
 Back In Time
 
 Version 1.4.2-dev (development of upcoming release)
+* Fix bug: `qt5_probing.py` hangs when BiT is run as root and no user is logged into a desktop environment (#1592 and #1580)
+* Fix bug: Disabling suspend during taking a backup ("inhibit suspend") hangs when BiT is run as root and no user is logged into a desktop environment (#1592)
+* Change of semantics: BiT running as root never disables suspend during taking a backup ("inhibit suspend") even though this may have worked before in BiT <= v1.4.1 sometimes (required to fix #1592)
 * Fix bug: RTE: module 'qttools' has no attribute 'initate_translator' with encFS when prompting the user for a password (#1553).
 * Fix bug: Schedule dropdown menu used "minutes" instead of "hours".
 * Build: Use PyLint in unit testing to catch E1101 (no-member) errors.
 * Build: Activate PyLint warning W1401 (anomalous-backslash-in-string).
 * Build: Add codespell config.
 * Translation: Minor modifications in source strings and updating language files.
+* Improved: Logging of qtsystrayicon.py, qt5_probing.py, usercallbackplugin.py and all parts of app.py
+            do now use the "backintime" app id in the syslog too to ensure complete log output with journalctl + grep
 
 Version 1.4.1 (2023-10-01)
 * Dependency: Add "qt translations" to GUI runtime dependencies (#1538).

--- a/common/backintime
+++ b/common/backintime
@@ -17,11 +17,21 @@
 #    with this program; if not, write to the Free Software Foundation, Inc.,
 #    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# Location of this script
 CUR_PATH="$(dirname $(readlink -m $0))"
+
+# Was this script started in the source code folder (normally during development)?
 if [ -f "${CUR_PATH}/backintime.py" ]; then
 	APP_PATH=$CUR_PATH
 else
+  # CUR_PATH must be /usr/bin (the default installation path of this script)
+  # or another sibling folder of "share" (in case of an alternative installation
+  # folder like "/var/bin" where BiT must be installed into /var/share/backintime then)
 	APP_PATH=$(readlink -m "${CUR_PATH}/../share/backintime/common")
 fi
 
+# -E ignores env vars like PYTHONPATH and PYTHONHOME that may modify
+#    the behaviour of the interpreter
+# -s Don't add user site directory to sys.path
+# TODO Should we use "$APP_PATH" (quoted) to prevent globbing and word splitting?
 python3 -Es $APP_PATH/backintime.py "$@"

--- a/common/logger.py
+++ b/common/logger.py
@@ -38,12 +38,11 @@ _level_names = {
 
 def openlog():
     """
-    Initializes the logger
+    Initialize the BiT logger system (which uses syslog)
 
-    Esp. sets the app name for the log output so that the system log
-    can be queried with with grep.
+    Esp. sets the app name as identifier for the log entries in the syslog.
 
-    Don't forget to call it in each sub process that uses logging.
+    Attention: Call it in each sub process that uses logging.
     """
     syslog.openlog(SYSLOG_IDENTIFIER)
     atexit.register(closelog)

--- a/common/logger.py
+++ b/common/logger.py
@@ -37,6 +37,14 @@ _level_names = {
 
 
 def openlog():
+    """
+    Initializes the logger
+
+    Esp. sets the app name for the log output so that the system log
+    can be queried with with grep.
+
+    Don't forget to call it in each sub process that uses logging.
+    """
     syslog.openlog(SYSLOG_IDENTIFIER)
     atexit.register(closelog)
 

--- a/common/pluginmanager.py
+++ b/common/pluginmanager.py
@@ -246,6 +246,7 @@ class PluginManager:
                 tools.registerBackintimePath(path)
                 for f in os.listdir(fullPath):
                     if f not in loadedPlugins and f.endswith('.py') and not f.startswith('__'):
+                        logger.debug('Probing plugin %s' % f, self)
                         try:
                             module = __import__(f[: -3])
                             module_dict = module.__dict__
@@ -265,7 +266,6 @@ class PluginManager:
                                                 self.plugins.insert(0, plugin)
                                             else:
                                                 self.plugins.append(plugin)
-                                # TODO 09/28/2022 Ignored files in plugin folders should be logged
                             loadedPlugins.append(f)
                         except BaseException as e:
                             logger.error('Failed to load plugin %s: %s' %(f, str(e)), self)

--- a/common/plugins/usercallbackplugin.py
+++ b/common/plugins/usercallbackplugin.py
@@ -61,6 +61,7 @@ class UserCallbackPlugin(pluginmanager.Plugin):
         in the first line of the script file.
     """
     def __init__(self):
+        logger.openlog()
         return
 
     def init(self, snapshots):

--- a/common/qt5_probing.py
+++ b/common/qt5_probing.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import resource
 import logger
@@ -84,6 +85,10 @@ try:
         logger.DEBUG = True
 
     logger.debug(f"{__file__} started... Call args: {str(sys.argv)}")
+    logger.debug(f"Display system: {os.environ.get('XDG_SESSION_TYPE', '($XDG_SESSION_TYPE is not set)')}")
+    logger.debug(f"XDG_RUNTIME_DIR={os.environ.get('XDG_RUNTIME_DIR', '($XDG_RUNTIME_DIR is not set)')}")
+    logger.debug(f"XAUTHORITY={os.environ.get('XAUTHORITY', '($XAUTHORITY is not set)')}")
+    logger.debug(f"QT_QPA_PLATFORM={os.environ.get('QT_QPA_PLATFORM', '($QT_QPA_PLATFORM is not set)')}")
 
     from PyQt5 import QtCore
     from PyQt5.QtWidgets import QApplication

--- a/common/qt5_probing.py
+++ b/common/qt5_probing.py
@@ -2,6 +2,8 @@ import sys
 import resource
 import logger
 
+logger.openlog()
+
 # This mini python script is used to determine if a Qt5 GUI application
 # can be created without an error.
 #
@@ -77,6 +79,9 @@ resource.setrlimit(resource.RLIMIT_CORE, (0, old_limits[1]))
 exit_code = 0
 
 try:
+
+    if "--debug" in sys.argv:  # HACK: Minimal arg parsing to enable debug-level logging
+        logger.DEBUG = True
 
     logger.debug(f"{__file__} started... Call args: {str(sys.argv)}")
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -2006,7 +2006,7 @@ if __name__ == '__main__':
         mainWindow.show()
         qapp.exec_()
 
-    logger.closelog()
-
     cfg.PLUGIN_MANAGER.appExit()
     appInstance.exitApplication()
+
+    logger.closelog()  # must be last line (log until BiT "dies" ;-)

--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -1,8 +1,11 @@
 #!/bin/sh
 
 if [ "x$XDG_SESSION_TYPE" = "xwayland" ]; then
-    PREFIX="env QT_QPA_PLATFORM=wayland-egl XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+    # PREFIX="env QT_QPA_PLATFORM=wayland-egl XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+    # Empty prefix to use the default Qt5 platform plugin (normally xcb) to fix #836 and #1350
+    PREFIX=""
 else
+    # X11
     PREFIX=""
 fi
 

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -48,6 +48,7 @@ from PyQt5.QtGui import QIcon, QRegion
 
 class QtSysTrayIcon:
     def __init__(self):
+
         self.snapshots = snapshots.Snapshots()
         self.config = self.snapshots.config
         self.decode = None
@@ -239,6 +240,8 @@ class QtSysTrayIcon:
         self.snapshots.setTakeSnapshotMessage(0, 'Snapshot terminated')
 
 if __name__ == '__main__':
+
+    logger.openlog()
 
     if "--debug" in sys.argv:  # HACK: Minimal arg parsing to enable debug-level logging
         logger.DEBUG = True


### PR DESCRIPTION
- "qt5_probing.py" hangs when BiT is run as root and no user is logged into a desktop environment
- BiT (root) starter script does not set Qt5 wayland-egl plugin anymore but uses the default (like BiT userland)
- Improve logging (all sub processes do now use the log context "backintime" too for easy journalctl grepping
- Different Wayland Qt plugin was used in BiT (root) vs. BiT user-space: Now no wayland is enforced anymore

CHANGELOG was updated
