### PR TITLE
Allow manual specification of python executable during build

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Version 1.4.2-dev (development of upcoming release)
 * Build: Use PyLint in unit testing to catch E1101 (no-member) errors.
 * Build: Activate PyLint warning W1401 (anomalous-backslash-in-string).
 * Build: Add codespell config.
+* Build: Allow manual specification of python executable (--python=PYTHON_PATH) in common/configure and qt/configure
 * Translation: Minor modifications in source strings and updating language files.
 * Improved: qtsystrayicon.py, qt5_probing.py, usercallbackplugin.py and all parts of app.py
             do now also use "backintime" as logging namespace in the syslog to ensure complete log output with `journalctl | grep -i backintime`

--- a/common/configure
+++ b/common/configure
@@ -133,9 +133,12 @@ if [ -n "$unknown_args" ]; then
     echo "Unknown Arguments: $unknown_args"
 fi
 
-sed -e "s#^python3 #${PYTHON} #g" \
-    -e "s#^ssh-agent python3 #ssh-agent ${PYTHON} #g" \
-    -i $USR_BIN_FILES
+if [ -n "$(sed -e "s#^python3\? #${PYTHON} #gw /dev/stdout" -i $USR_BIN_FILES)" ]
+then
+    echo "Replacement of python path with \"${PYTHON}\" successful."
+else
+    echo "WARNING: Replacement of python path with \"${PYTHON}\" FAILED. Maybe you ran configure more than once?"
+fi
 
 #check languages
 mos=""

--- a/common/configure
+++ b/common/configure
@@ -17,12 +17,14 @@ USR_BIN_FILES="backintime backintime-askpass"
 
 usage () {
     echo "Usage:"
-    echo "$0 [--python | --python3]"
+    echo "$0 [--python | --python3 | --python=PYTHON_BINARY]"
     echo ""
     echo "--python"
     echo "\tuse 'python' to start Python3"
     echo "--python3"
     echo "\tuse 'python3' to start Python3"
+    echo "--python=PYTHON_BINARY"
+    echo "\tuse PYTHON_BINARY to start Python3"
 }
 
 addInstallFiles () {
@@ -113,7 +115,15 @@ onTravis () {
 unknown_args=""
 for arg in $*; do
     case $arg in
-        --python | --python3) PYTHON=$arg;;
+        --python=*)
+            PYTHON=$(echo $arg | cut -f2 -d'=')
+            ;;
+        --python3)
+            PYTHON="/usr/bin/python3"
+            ;;
+        --python)
+            PYTHON="/usr/bin/python"
+            ;;
         --help | -h) usage; exit 0;;
         *) unknown_args="$unknown_args $arg";;
     esac
@@ -123,14 +133,8 @@ if [ -n "$unknown_args" ]; then
     echo "Unknown Arguments: $unknown_args"
 fi
 
-#patch python command
-#use 'python' or 'python3' to start Python Version 3.x
-case $PYTHON in
-    --python)   PYVERSION="" ;;
-    --python3)  PYVERSION="3";;
-esac
-sed -e "s/^python3\? /python${PYVERSION} /g" \
-    -e "s/^ssh-agent python3\? /ssh-agent python${PYVERSION} /g" \
+sed -e "s/^python3\? /${PYTHON} /g" \
+    -e "s/^ssh-agent python3\? /ssh-agent ${PYTHON} /g" \
     -i $USR_BIN_FILES
 
 #check languages
@@ -276,7 +280,7 @@ COVERAGE=$(which coverage 2>/dev/null)
 if onTravis && [ -n "${COVERAGE}" ]; then
     CMD="coverage run -p"
 else
-    CMD="python${PYVERSION}"
+    CMD="${PYTHON}"
 fi
 
 printf "test:\tunittest\n\n" >> ${MAKEFILE}
@@ -324,7 +328,7 @@ done
 
 # check python version
 PYTHON_VERSION_REQUIRED="3.8"
-PYTHON_VERSION_CURRENT=$(python${PYVERSION} --version | tr --delete 'Python ')
+PYTHON_VERSION_CURRENT=$(${PYTHON} --version | tr --delete 'Python ')
 
 # Credits: https://unix.stackexchange.com/a/285928/136851
 if [ "$(printf '%s\n' "$PYTHON_VERSION_REQUIRED" "$PYTHON_VERSION_CURRENT" | sort -V | head -n1)" != "$PYTHON_VERSION_REQUIRED" ]; then

--- a/common/configure
+++ b/common/configure
@@ -133,8 +133,8 @@ if [ -n "$unknown_args" ]; then
     echo "Unknown Arguments: $unknown_args"
 fi
 
-sed -e "s/^python3\? /${PYTHON} /g" \
-    -e "s/^ssh-agent python3\? /ssh-agent ${PYTHON} /g" \
+sed -e "s#^python3 #${PYTHON} #g" \
+    -e "s#^ssh-agent python3 #ssh-agent ${PYTHON} #g" \
     -i $USR_BIN_FILES
 
 #check languages

--- a/common/configure
+++ b/common/configure
@@ -11,7 +11,7 @@ UNINSTALL_FILES="$(mktemp)"
 UNINSTALL_DIRS="$(mktemp)"
 
 #set default options
-PYTHON="--python3"
+PYTHON="python3"
 
 USR_BIN_FILES="backintime backintime-askpass"
 

--- a/qt/configure
+++ b/qt/configure
@@ -18,12 +18,14 @@ DBUS_SERVICE_FILES="net.launchpad.backintime.serviceHelper.service"
 
 usage () {
     echo "Usage:"
-    echo "$0 [--python | --python3]"
+    echo "$0 [--python | --python3 | --python=PYTHON_BINARY]"
     echo ""
     echo "--python"
     echo "\tuse 'python' to start Python3"
     echo "--python3"
     echo "\tuse 'python3' to start Python3"
+    echo "--python=PYTHON_BINARY"
+    echo "\tuse PYTHON_BINARY to start Python3"
 }
 
 addInstallFiles () {
@@ -98,9 +100,17 @@ addNewline () {
 unknown_args=""
 for arg in $*; do
 	case $arg in
-		--python | --python3) PYTHON=$arg;;
-		--help | -h) usage; exit 0;;
-		*) unknown_args="$unknown_args $arg";;
+        --python=*)
+            PYTHON=$(echo $arg | cut -f2 -d'=')
+            ;;
+        --python3)
+            PYTHON="/usr/bin/python3"
+            ;;
+        --python)
+            PYTHON="/usr/bin/python"
+            ;;
+        --help | -h) usage; exit 0;;
+        *) unknown_args="$unknown_args $arg";;
 	esac
 done
 
@@ -110,14 +120,10 @@ fi
 
 #patch python command
 #use 'python' or 'python3' to start Python Version 3.x
-case $PYTHON in
-	--python)   PYVERSION="" ;;
-	--python3)  PYVERSION="3";;
-esac
-sed -e "s#^python3\? #python${PYVERSION} #g" \
-    -e "s#^ssh-agent python3\? #ssh-agent python${PYVERSION} #g" \
+sed -e "s#^python3\? #${PYTHON} #g" \
+    -e "s#^ssh-agent python3\? #ssh-agent ${PYTHON} #g" \
     -i $USR_BIN_FILES
-sed -e "s#^Exec=/usr/bin/python3\? #Exec=/usr/bin/python${PYVERSION} #g" \
+sed -e "s#^Exec=/usr/bin/python3\? #Exec=${PYTHON} #g" \
     -i $DBUS_SERVICE_FILES
 
 #start Makefile
@@ -233,7 +239,7 @@ done
 
 # check python version
 PYTHON_VERSION_REQUIRED="3.8"
-PYTHON_VERSION_CURRENT=$(python${PYVERSION} --version | tr --delete 'Python ')
+PYTHON_VERSION_CURRENT=$(${PYTHON} --version | tr --delete 'Python ')
 
 # Credits: https://unix.stackexchange.com/a/285928/136851
 if [ "$(printf '%s\n' "$PYTHON_VERSION_REQUIRED" "$PYTHON_VERSION_CURRENT" | sort -V | head -n1)" != "$PYTHON_VERSION_REQUIRED" ]; then

--- a/qt/configure
+++ b/qt/configure
@@ -11,7 +11,7 @@ UNINSTALL_FILES="$(mktemp)"
 UNINSTALL_DIRS="$(mktemp)"
 
 #set default options
-PYTHON="--python3"
+PYTHON="python3"
 
 USR_BIN_FILES="backintime-qt backintime-qt_polkit"
 DBUS_SERVICE_FILES="net.launchpad.backintime.serviceHelper.service"

--- a/qt/configure
+++ b/qt/configure
@@ -120,11 +120,13 @@ fi
 
 #patch python command
 #use 'python' or 'python3' to start Python Version 3.x
-sed -e "s#^python3\? #${PYTHON} #g" \
-    -e "s#^ssh-agent python3\? #ssh-agent ${PYTHON} #g" \
-    -i $USR_BIN_FILES
-sed -e "s#^Exec=/usr/bin/python3\? #Exec=${PYTHON} #g" \
-    -i $DBUS_SERVICE_FILES
+if [ -n "$(sed -e "s#^python3\? #${PYTHON} #gw /dev/stdout" -i $USR_BIN_FILES)" ] \
+    && [ -n "$(sed -e "s#^Exec=/usr/bin/python3\? #Exec=${PYTHON} #gw /dev/stdout" -i $DBUS_SERVICE_FILES)" ]
+then
+    echo "Replacement of python path with \"${PYTHON}\" successful."
+else
+    echo "WARNING: Replacement of python path with \"${PYTHON}\" FAILED. Maybe you ran configure more than once?"
+fi
 
 #start Makefile
 printf "PREFIX=/usr\n" >> ${MAKEFILE}


### PR DESCRIPTION
common/configure and qt/configure now support `--python=PYTHON_PATH` option to manually specify the python executable. A full, absolute path is preferred but any valid path should work.

Previous --python and --python3 options also should still work, representing /usr/bin/python and /usr/bin/python3 respectively.

Tests pass on openSUSE Leap 15.5 and Tumbleweed.

This is the quick fix for #1574 .