### PR TITLE
Use absolute path to the python executable now by default (closes #1574)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Version 1.4.2-dev (development of upcoming release)
 * Build: Activate PyLint warning W1401 (anomalous-backslash-in-string).
 * Build: Add codespell config.
 * Build: Allow manual specification of python executable (--python=PYTHON_PATH) in common/configure and qt/configure
+* Build: All starter scripts do use an absolute path to the python executable by default now via common/configure and qt/configure (#1574)
 * Build: Install dbus configuration file to /usr/share not /etc (#1596)
 * Build: `configure` does delete old installed files (`qt4plugin.py` and `net.launchpad.backintime.serviceHelper.conf`) that were renamed or moved in a previous release (#1596)
 * Translation: Minor modifications in source strings and updating language files.

--- a/common/backintime
+++ b/common/backintime
@@ -34,4 +34,4 @@ fi
 #    the behaviour of the interpreter
 # -s Don't add user site directory to sys.path
 # TODO Should we use "$APP_PATH" (quoted) to prevent globbing and word splitting?
-python3 -Es $APP_PATH/backintime.py "$@"
+/usr/bin/python3 -Es $APP_PATH/backintime.py "$@"

--- a/common/backintime-askpass
+++ b/common/backintime-askpass
@@ -28,4 +28,4 @@ else
 	APP_PATH=$(readlink -m "${CUR_PATH}/../share/backintime/common")
 fi
 
-python3 -Es $APP_PATH/askpass.py "$@"
+/usr/bin/python3 -Es $APP_PATH/askpass.py "$@"

--- a/common/configure
+++ b/common/configure
@@ -11,7 +11,7 @@ UNINSTALL_FILES="$(mktemp)"
 UNINSTALL_DIRS="$(mktemp)"
 
 #set default options
-PYTHON="python3"
+PYTHON="/usr/bin/python3"
 
 USR_BIN_FILES="backintime backintime-askpass"
 
@@ -133,7 +133,11 @@ if [ -n "$unknown_args" ]; then
     echo "Unknown Arguments: $unknown_args"
 fi
 
-if [ -n "$(sed -e "s#^python3\? #${PYTHON} #gw /dev/stdout" -i $USR_BIN_FILES)" ]
+if [ ! -f "$PYTHON" ]; then
+    echo "Warning: \"${PYTHON}\" not found on this computer"
+fi
+
+if [ -n "$(sed -e "s#^/usr/bin/python3\? #${PYTHON} #gw /dev/stdout" -i $USR_BIN_FILES)" ]
 then
     echo "Replacement of python path with \"${PYTHON}\" successful."
 else

--- a/qt/backintime-qt
+++ b/qt/backintime-qt
@@ -28,4 +28,4 @@ else
 	APP_PATH=$(readlink -m "${CUR_PATH}/../share/backintime/qt")
 fi
 
-python3 -Es ${APP_PATH}/app.py "$@"
+/usr/bin/python3 -Es ${APP_PATH}/app.py "$@"

--- a/qt/configure
+++ b/qt/configure
@@ -11,7 +11,7 @@ UNINSTALL_FILES="$(mktemp)"
 UNINSTALL_DIRS="$(mktemp)"
 
 #set default options
-PYTHON="python3"
+PYTHON="/usr/bin/python3"
 
 USR_BIN_FILES="backintime-qt backintime-qt_polkit"
 DBUS_SERVICE_FILES="net.launchpad.backintime.serviceHelper.service"
@@ -118,9 +118,13 @@ if [ -n "$unknown_args" ]; then
 	echo "Unknown Arguments: $unknown_args"
 fi
 
+if [ ! -f "$PYTHON" ]; then
+    echo "Warning: \"${PYTHON}\" not found on this computer"
+fi
+
 #patch python command
 #use 'python' or 'python3' to start Python Version 3.x
-if [ -n "$(sed -e "s#^python3\? #${PYTHON} #gw /dev/stdout" -i $USR_BIN_FILES)" ] \
+if [ -n "$(sed -e "s#^/usr/bin/python3\? #${PYTHON} #gw /dev/stdout" -i $USR_BIN_FILES)" ] \
     && [ -n "$(sed -e "s#^Exec=/usr/bin/python3\? #Exec=${PYTHON} #gw /dev/stdout" -i $DBUS_SERVICE_FILES)" ]
 then
     echo "Replacement of python path with \"${PYTHON}\" successful."


### PR DESCRIPTION
All starter scripts do use an absolute path to the python executable by default now via common/configure and qt/configure (see #1574)

