### PR TITLE
Work around for rsync error 23 (part of #1587) + new "experimental" snapshot log filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ arch :
  - ppc64le
 
 # ensures that we have UUID filesystem mounts for proper testing
-sudo: true
 dist: focal
 
 addons:
@@ -29,6 +28,7 @@ before_install:
   - sudo apt-get -qq update
   # install screen, and util-linux (provides flock) for test_sshtools
   - sudo apt-get install -y sshfs screen util-linux
+
 jobs:
   exclude:
     - python: "3.9"
@@ -37,6 +37,7 @@ jobs:
     # Excluding this temporarily because of an Issue on Travis. Support contact established.
     - arch: ppc64le
       python: "3.12"
+
 install:
   - pip install pylint coveralls pyfakefs
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 
 script:
   # Is a virtual environment active? Yes: if both variables are not equal.
-  - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=}')"
+  - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=} In virtualenv={sys.prefix != sys.base_prefix')"
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
@@ -60,8 +60,8 @@ script:
   - cd ..
   - cd qt
   # - ./configure --python=python3
-  - ./configure
-  - make
+  # - ./configure
+  # - make
   - pytest
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ jobs:
     - python: "3.9"
     - python: "3.10"
     - python: "3.11"
-
+    # Excluding this temporarily because of an Issue on Travis. Support contact established.
+    - arch: ppc64le
+      python: "3.12"
 install:
   - pip install pylint coveralls pyfakefs
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
   # run unit tests - ensure that functionality is correct
   - cd common
   - ./configure
-  - make unittest-v
+  - make -d unittest-v
   - cd ..
   - cd qt
   - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ script:
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
+  - whereis python3
+  - ls -l /usr/bin/python3
   - cd common
   - ./configure
   - make unittest-v

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,11 +57,8 @@ script:
   - cat Makefile
   - make unittest-v
   - cd ..
-  - whereis pytest
-  - whereis py.test
-  - whereis py.test-3
-  - whereis pytest-3
-  - cd qt && py.test-3
+  - cd qt
+  - py.test
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ script:
   # - ./configure --python=python3
   - ./configure
   - cat Makefile
+  - coverage debug sys
   - make -d unittest-v
   - cd ..
   - cd qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,15 @@ install:
   - eval `ssh-agent -s`
 
 script:
+  # Is a virtual environment active? Yes: if both variables are not equal.
+  - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=}')"
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
   # - ./configure --python=python3
   - ./configure
+  - cat Makefile
   - make -v unittest-v
   - cd ..
   - cd qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,19 +48,17 @@ install:
 
 script:
   # Is a virtual environment active? Yes: if both variables are not equal.
-  - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=} In virtualenv={sys.prefix != sys.base_prefix}')"
+  # - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=} In virtualenv={sys.prefix != sys.base_prefix}')"
+  # - coverage debug sys
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
-  # - ./configure --python=python3
   - ./configure
   - cat Makefile
-  - coverage debug sys
-  - make -d unittest-v
+  - make unittest-v
   - cd ..
   - cd qt
-  # - ./configure --python=python3
   - ./configure
   - make
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,8 @@ script:
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
-  - cd common && ./configure && make unittest-v
+  - cd common
+  - ls -l && ./configure && make unittest-v
   - cd ..
   - cd qt && pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ script:
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
-  - ls -l && ./configure && make unittest-v
+  - ./configure
+  - make unittest-v
   - cd ..
   - cd qt && pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 
 script:
   # Is a virtual environment active? Yes: if both variables are not equal.
-  - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=} In virtualenv={sys.prefix != sys.base_prefix')"
+  - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=} In virtualenv={sys.prefix != sys.base_prefix}')"
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ script:
   # run unit tests - ensure that functionality is correct
   - cd common
   - ./configure
-  - cat Makefile
   - make unittest-v
   - cd ..
   - cd qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,11 @@ script:
   - cat Makefile
   - make unittest-v
   - cd ..
-  - cd qt && pytest
+  - whereis pytest
+  - whereis py.test
+  - whereis py.test-3
+  - whereis pytest-3
+  - cd qt && py.test-3
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,12 @@ script:
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
-  - ./configure --python=python3
+  # - ./configure --python=python3
+  - ./configure
   - whereis python3
   - ls -l /usr/bin/python3
   - cat Makefile
-  - make unittest-v
+  - make -v unittest-v
   - cd ..
   - cd qt
   - ./configure --python=python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs
+  - pip install pylint coveralls pyfakefs keyring packaging
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,12 @@ script:
   # - ./configure --python=python3
   - ./configure
   - cat Makefile
-  - make -v unittest-v
+  - make -d unittest-v
   - cd ..
   - cd qt
   # - ./configure --python=python3
-  # - ./configure
-  # - make
+  - ./configure
+  - make
   - pytest
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs keyring packaging
+  - pip install pylint coveralls pyfakefs
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
@@ -54,11 +54,11 @@ script:
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
-  - ./configure
-  - make -d unittest-v
+  - ./configure  --python=python3
+  - make unittest-v
   - cd ..
   - cd qt
-  - ./configure
+  - ./configure  --python=python3
   - make
   - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,11 @@ script:
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
-  - whereis python3
-  - ls -l /usr/bin/python3
   - cd common
   - ./configure
+  - whereis python3
+  - ls -l /usr/bin/python3
+  - cat Makefile
   - make unittest-v
   - cd ..
   - cd qt && pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,11 @@ script:
   - cd common
   # - ./configure --python=python3
   - ./configure
-  - whereis python3
-  - ls -l /usr/bin/python3
-  - cat Makefile
   - make -v unittest-v
   - cd ..
   - cd qt
-  - ./configure --python=python3
+  # - ./configure --python=python3
+  - ./configure
   - make
   - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,16 @@ script:
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
-  - ./configure
+  - ./configure --python=python3
   - whereis python3
   - ls -l /usr/bin/python3
   - cat Makefile
   - make unittest-v
   - cd ..
   - cd qt
-  - py.test
+  - ./configure --python=python3
+  - make
+  - pytest
 
 after_success:
   - coverage combine

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,12 @@
 Back In Time
 
 Version 1.4.2-dev (development of upcoming release)
-* Fix bug: `qt5_probing.py` hangs when BiT is run as root and no user is logged into a desktop environment (#1592 and #1580)
+* Feature: Exclude 'SingletonLock' and 'SingletonCookie' (Discord) and 'lock' (Mozilla Firefox) files by default (part of #1555)
+* Work around: Relax `rsync` exit code 23: Ignore instead of error now (part of #1587)
+* Feature (experimental): Add new snapshot log filter `rsync transfer failures (experimental)` to find them easier (they are normally not shown as "error").
+                          This feature is experimental because it is based on hard-coded error message strings in the rsync source code
+                          and may possibly not find all rsync messages or show false positives.
+* Fix bug: 'qt5_probing.py' hangs when BiT is run as root and no user is logged into a desktop environment (#1592 and #1580)
 * Fix bug: Launching BiT GUI (root) hangs on Wayland without showing the GUI (#836)
 * Improve: Launcher for BiT GUI (root) does not enforce Wayland anymore but uses same settings as for BiT GUI (userland) (#1350)
 * Fix bug: Disabling suspend during taking a backup ("inhibit suspend") hangs when BiT is run as root and no user is logged into a desktop environment (#1592)
@@ -77,7 +82,7 @@ Version 1.3.3 (2023-01-04)
 * Desktop integration: Update .desktop file to mark Back In Time as a single main window program (#1258)
 * Feature: Write all log output to stderr; do not pollute stdout with INFO and WARNING messages anymore (#1337)
 * Fix bug: RTE "reentrant call inside io.BufferedWriter" in logFile.flush() during backup (#1003)
-* Fix bug: Incompatibility with rsync 3.2.4 or later because of rsync's "new argument protection" (#1247). Deactivate "--old-args" rsync argument earlier recommaned to users as a workaround.
+* Fix bug: Incompatibility with rsync 3.2.4 or later because of rsync's "new argument protection" (#1247). Deactivate "--old-args" rsync argument earlier recommanded to users as a workaround.
 * Fix bug: DeprecationWarnings about invalid escape sequences.
 * Fix bug: AttributeError in "Diff Options" dialog (#898)
 * Fix bug: Settings GUI: "Save password to Keyring" was disabled due to "no appropriate keyring found" (#1321)

--- a/common/config.py
+++ b/common/config.py
@@ -116,6 +116,13 @@ class Config(configfile.ConfigFileWithProfiles):
         '/var/backups/*',
         '.Private',
         '/swapfile',
+        # Discord files
+        # See also: https://github.com/bit-team/backintime/issues/1555#issuecomment-1787230708
+        'SingletonLock',
+        'SingletonCookie',
+        # Mozilla files
+        # See also: https://github.com/bit-team/backintime/issues/1555#issuecomment-1787111063
+        'lock'
     ]
 
     DEFAULT_RUN_NICE_FROM_CRON = True

--- a/common/configure
+++ b/common/configure
@@ -283,7 +283,7 @@ done
 COVERAGE=$(which coverage 2>/dev/null)
 # Use "coverage run" only on travis-ci.org and if it is available
 # this will pass information to coveralls.io.
-# Otherwise use "python", "python3" or if available "py.test-3"
+# Otherwise use "python", "python3" or if available "py.test-3" 
 if onTravis && [ -n "${COVERAGE}" ]; then
     CMD="${PYTHON} -m coverage run -p"
 else

--- a/common/configure
+++ b/common/configure
@@ -283,9 +283,9 @@ done
 COVERAGE=$(which coverage 2>/dev/null)
 # Use "coverage run" only on travis-ci.org and if it is available
 # this will pass information to coveralls.io.
-# Otherwise use "python", "python3" or if available "py.test-3" 
+# Otherwise use "python", "python3" or if available "py.test-3"
 if onTravis && [ -n "${COVERAGE}" ]; then
-    CMD="${PYTHON} -m coverage run -p"
+    CMD="coverage run -p"
 else
     CMD="${PYTHON}"
 fi

--- a/common/configure
+++ b/common/configure
@@ -10,7 +10,7 @@ MAKEFILE="$(mktemp)"
 UNINSTALL_FILES="$(mktemp)"
 UNINSTALL_DIRS="$(mktemp)"
 
-#set default options
+# set default options
 PYTHON="/usr/bin/python3"
 
 USR_BIN_FILES="backintime backintime-askpass"
@@ -281,11 +281,11 @@ for i in "pytest" "py.test-3" "py.test-3.6" "py.test-3.5" "py.test-3.4"; do
     fi
 done
 COVERAGE=$(which coverage 2>/dev/null)
-#use "coverage run" only on travis-ci.org and if it is available
-#this will pass information to coveralls.io.
-#otherwise use "python", "python3" or if available "py.test-3"
+# Use "coverage run" only on travis-ci.org and if it is available
+# this will pass information to coveralls.io.
+# Otherwise use "python", "python3" or if available "py.test-3"
 if onTravis && [ -n "${COVERAGE}" ]; then
-    CMD="coverage run -p"
+    CMD="${PYTHON} -m coverage run -p"
 else
     CMD="${PYTHON}"
 fi

--- a/common/qt5_probing.py
+++ b/common/qt5_probing.py
@@ -5,7 +5,7 @@ import logger
 
 logger.openlog()
 
-from tools import isRoot
+# from tools import isRoot
 
 # This mini python script is used to determine if a Qt5 GUI application
 # can be created without an error.

--- a/common/qt5_probing.py
+++ b/common/qt5_probing.py
@@ -5,6 +5,8 @@ import logger
 
 logger.openlog()
 
+from tools import isRoot
+
 # This mini python script is used to determine if a Qt5 GUI application
 # can be created without an error.
 #
@@ -89,6 +91,15 @@ try:
     logger.debug(f"XDG_RUNTIME_DIR={os.environ.get('XDG_RUNTIME_DIR', '($XDG_RUNTIME_DIR is not set)')}")
     logger.debug(f"XAUTHORITY={os.environ.get('XAUTHORITY', '($XAUTHORITY is not set)')}")
     logger.debug(f"QT_QPA_PLATFORM={os.environ.get('QT_QPA_PLATFORM', '($QT_QPA_PLATFORM is not set)')}")
+
+    logger.debug(f"Current euid: {os.geteuid()}")
+    # Jan 25, 2024 Not enabled but just documented here since this "fix" is a hack (assumes hard-coded UID 1000 to be always correct). But it works in 99 % of installations
+    # if isRoot():
+    #     logger.debug("Changing euid from root to user as work-around for #1592 (qt5_probing hangs in root cron job)")
+    #     # Fix inspired by
+    #     # https://stackoverflow.com/questions/71425861/connecting-to-user-dbus-as-root
+    #     os.seteuid(1000)
+    #     logger.debug(f"New euid: {os.geteuid()}")
 
     from PyQt5 import QtCore
     from PyQt5.QtWidgets import QApplication

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -57,43 +57,50 @@ class LogFilter(object):
              INFORMATION:       re.compile(r'^(?:\[I\]|[^\[])'),
              ERROR_AND_CHANGES: re.compile(r'^(?:\[E\]|\[C\]|[^\[])'),
              RSYNC_TRANSFER_FAILURES: re.compile(
+                 # All links to rsync's source reference the commit 2f9b963 from Jun 27, 2023 (most-recent commit on "master" as at Jan 28, 2024)
                  r'.*(?:'
-                 r'Invalid cross-device link'
-                 r'|symlink has no referent'
-                 r'|readlink_stat\(.?\) failed'
-                 r'|link_stat .* failed'
-                 r'|receive_sums failed'
-                 r'|send_files failed to open'
-                 r'|fstat failed'
-                 r'|read errors mapping'
-                 r'|change_dir .* failed'
-                 r'|skipping overly long name'
-                 r'|skipping file with bogus \(zero\) st_mode'
-                 r'|skipping symlink with 0-length value'
-                 r'|cannot convert filename'
-                 r'|cannot convert symlink data for'
-                 r'|opendir .* failed'
-                 r'|filename overflows max-path len by'
-                 r'|cannot send file with empty name in'
-                 r'|readdir\(.*\)'
-                 r'|cannot add local filter rules in long-named directory'
-                 r'|failed to re-read xattr'
-                 r'|Skipping sender remove of destination file'
-                 r'|Skipping sender remove for changed file'
-                 r'|could not make way for'
-                 r'|system says the ACL I packed is invalid'
-                 r'|recv_acl_access: value out of range'
-                 r'|recv_acl_index: .* ACL index'
-                 r'|Create time value of .* truncated on receiver'
-                 r'|FATAL I/O ERROR: dying to avoid a \-\-delete'
-                 r'|IO error encountered'  # TODO reported in an issue but is this string really contained in the rsync source code?
-                 r'|some files/attrs were not transferred'  # TODO reported in an issue but is this string really contained in the rsync source code?
-                 r'|temporary filename too long'
-                 r'|No batched update for'
-                 r'|recv_files: .* is a directory'
-                 r'|no ftruncate for over-long pre-alloc'
-                 r'|daemon refused to receive'
-                 r'|get_xattr_data: lgetxattr'
+                 r'Invalid cross-device link'     # not directly contained in rsync's source code but may be catched and passed through as-is
+                 r'|symlink has no referent'      # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1281
+                 r'|readlink_stat\(.?\) failed'   # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1294
+                 r'|link_stat .* failed'          # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1810
+                 r'|receive_sums failed'          # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/sender.c#L347
+                 r'|send_files failed to open'    # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/sender.c#L361
+                 r'|fstat failed'                 # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/sender.c#L373
+                 r'|read errors mapping'          # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/sender.c#L435
+                 r'|change_dir .* failed'         # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/main.c#L749
+                                                  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/main.c#L807
+                                                  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/main.c#L827
+                                                  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/main.c#L1161
+                 r'|skipping overly long name'    # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1247
+                 r'|skipping file with bogus \(zero\) st_mode'  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1300
+                 r'|skipping symlink with 0-length value'       # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1569
+                 r'|cannot convert filename'      # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L748
+                                                  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1599
+                 r'|cannot convert symlink data for'  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1144
+                                                      # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1613
+                 r'|opendir .* failed'            # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1842
+                 r'|filename overflows max-path len by'   # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1868
+                 r'|cannot send file with empty name in'  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1876
+                 r'|readdir\(.*\)'                        # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L1888
+                 r'|cannot add local filter rules in long-named directory'  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/exclude.c#L817
+                 r'|failed to re-read xattr'                                # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/xattrs.c#L662
+                 r'|Skipping sender remove of destination file'     # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/sender.c#L152
+                 r'|Skipping sender remove for changed file'        # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/sender.c#L161
+                 r'|could not make way for'                         # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/delete.c#L220
+                 r'|system says the ACL I packed is invalid'        # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/acls.c#L435
+                 r'|recv_acl_access: value out of range'            # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/acls.c#L689
+                 r'|recv_acl_index: .* ACL index'                   # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/acls.c#L739
+                 r'|Create time value of .* truncated on receiver'  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L858
+                 r'|FATAL I/O ERROR: dying to avoid a \-\-delete'   # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/flist.c#L2005
+                 r'|IO error encountered'                           # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/generator.c#L295
+                 r'|some files/attrs were not transferred'  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/log.c#L97
+                 r'|temporary filename too long'            # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/receiver.c#L138
+                 r'|No batched update for'                  # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/receiver.c#L456
+                 r'|recv_files: .* is a directory'          # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/receiver.c#L805
+                 r'|no ftruncate for over-long pre-alloc'   # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/util1.c#L438
+                 r'|daemon refused to receive'              # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/generator.c#L1270
+                 r'|get_xattr_data: lgetxattr'              # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/xattrs.c#L199
+                                                            # https://github.com/WayneD/rsync/blob/2f9b963abaa52e44891180fe6c0d1c2219f6686d/xattrs.c#L215
                  # r').*'  # no need to match the remainder of the line
                  r')'
              )}

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -38,18 +38,65 @@ class LogFilter(object):
                                     :py:data:`ERROR_AND_CHANGES`
         decode (encfstools.Decode): instance used for decoding lines or ``None``
     """
+
+    # TODO Better use an enumeration
     NO_FILTER =         0
     ERROR =             1
     CHANGES =           2
     INFORMATION =       3
     ERROR_AND_CHANGES = 4
+    RSYNC_TRANSFER_FAILURES = 5
 
+    # Regular expressions used for filtering log file lines.
+    # RegExp syntax see: https://docs.python.org/3.10/library/re.html#regular-expression-syntax
+    # (?:...) = the matched substring cannot be retrieved in a group (non-capturing)
     REGEX = {None:              None,
              NO_FILTER:         None,
              ERROR:             re.compile(r'^(?:\[E\]|[^\[])'),
              CHANGES:           re.compile(r'^(?:\[C\]|[^\[])'),
              INFORMATION:       re.compile(r'^(?:\[I\]|[^\[])'),
-             ERROR_AND_CHANGES: re.compile(r'^(?:\[E\]|\[C\]|[^\[])')}
+             ERROR_AND_CHANGES: re.compile(r'^(?:\[E\]|\[C\]|[^\[])'),
+             RSYNC_TRANSFER_FAILURES: re.compile(
+                 r'.*(?:'
+                 r'Invalid cross-device link'
+                 r'|symlink has no referent'
+                 r'|readlink_stat\(.?\) failed'
+                 r'|link_stat .* failed'
+                 r'|receive_sums failed'
+                 r'|send_files failed to open'
+                 r'|fstat failed'
+                 r'|read errors mapping'
+                 r'|change_dir .* failed'
+                 r'|skipping overly long name'
+                 r'|skipping file with bogus \(zero\) st_mode'
+                 r'|skipping symlink with 0-length value'
+                 r'|cannot convert filename'
+                 r'|cannot convert symlink data for'
+                 r'|opendir .* failed'
+                 r'|filename overflows max-path len by'
+                 r'|cannot send file with empty name in'
+                 r'|readdir\(.*\)'
+                 r'|cannot add local filter rules in long-named directory'
+                 r'|failed to re-read xattr'
+                 r'|Skipping sender remove of destination file'
+                 r'|Skipping sender remove for changed file'
+                 r'|could not make way for'
+                 r'|system says the ACL I packed is invalid'
+                 r'|recv_acl_access: value out of range'
+                 r'|recv_acl_index: .* ACL index'
+                 r'|Create time value of .* truncated on receiver'
+                 r'|FATAL I/O ERROR: dying to avoid a \-\-delete'
+                 r'|IO error encountered'  # TODO reported in an issue but is this string really contained in the rsync source code?
+                 r'|some files/attrs were not transferred'  # TODO reported in an issue but is this string really contained in the rsync source code?
+                 r'|temporary filename too long'
+                 r'|No batched update for'
+                 r'|recv_files: .* is a directory'
+                 r'|no ftruncate for over-long pre-alloc'
+                 r'|daemon refused to receive'
+                 r'|get_xattr_data: lgetxattr'
+                 # r').*'  # no need to match the remainder of the line
+                 r')'
+             )}
 
     def __init__(self, mode = 0, decode = None):
         self.regex = self.REGEX[mode]

--- a/common/test/test_snapshotlog.py
+++ b/common/test/test_snapshotlog.py
@@ -73,6 +73,22 @@ class TestLogFilter(generic.TestCase):
         for line in (self.i,):
             self.assertIsNone(logFilter.filter(line))
 
+        # New filter (#1587): rsync transfer failures (experimental)
+        logFilter = snapshotlog.LogFilter(mode=snapshotlog.LogFilter.RSYNC_TRANSFER_FAILURES)
+        log_lines = (
+            '[I] Take snapshot (rsync: symlink has no referent: "/home/user/Documents/dead-link")',
+            '[E] Error: rsync: [sender] send_files failed to open "/home/user/Documents/root_only_file.txt": Permission denied (13)',
+            '[I] Schnappschuss erstellen (rsync: IO error encountered -- skipping file deletion)',
+            '[I] Schnappschuss erstellen (rsync: rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1333) [sender=3.2.3])',
+            '[I] Take snapshot (rsync: rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1333) [sender=3.2.3])',
+        )
+        for line in log_lines:
+            self.assertEqual(line, logFilter.filter(line))
+        for line in (self.e, self.c, self.i, self.h):
+            self.assertIsNone(logFilter.filter(line))
+        for line in (self.n):
+            self.assertEqual(line, logFilter.filter(line))  # empty line stays empty line
+
 class TestSnapshotLog(generic.SnapshotsTestCase):
     def setUp(self):
         super(TestSnapshotLog, self).setUp()

--- a/qt/app.py
+++ b/qt/app.py
@@ -1165,7 +1165,7 @@ class MainWindow(QMainWindow):
 
     def btnLastLogViewClicked (self):
         with self.suspendMouseButtonNavigation():
-            logviewdialog.LogViewDialog(self).show()
+            logviewdialog.LogViewDialog(self).show()  # no SID argument in constructor means "show last log"
 
     def btnSnapshotLogViewClicked (self):
         item = self.timeLine.currentItem()

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -30,6 +30,15 @@ import messagebox
 
 class LogViewDialog(QDialog):
     def __init__(self, parent, sid = None, systray = False):
+        """
+        Instantiate a snapshot log file viewer
+
+        Args:
+            parent:
+            sid (:py:class:`SID`): snapshot ID whose log file shall be shown
+                                   (``None`` = show last log)
+            systray (bool): TODO Show log from systray icon or from App (boolean)
+        """
         if systray:
             super(LogViewDialog, self).__init__()
         else:
@@ -88,17 +97,18 @@ class LogViewDialog(QDialog):
         layout.addWidget(self.comboFilter, 1)
         self.comboFilter.currentIndexChanged.connect(self.comboFilterChanged)
 
-        self.comboFilter.addItem(_('All'), 0)
+        self.comboFilter.addItem(_('All'), snapshotlog.LogFilter.NO_FILTER)
 
         # Note about ngettext plural forms: n=102 means "Other" in Arabic and
         # "Few" in Polish.
         # Research in translation community indicate this as the best fit to
         # the meaning of "all".
-        self.comboFilter.addItem(' + '.join((_('Errors'), _('Changes'))), 4)
+        self.comboFilter.addItem(' + '.join((_('Errors'), _('Changes'))), snapshotlog.LogFilter.ERROR_AND_CHANGES)
         self.comboFilter.setCurrentIndex(self.comboFilter.count() - 1)
-        self.comboFilter.addItem(_('Errors'), 1)
-        self.comboFilter.addItem(_('Changes'), 2)
-        self.comboFilter.addItem(_('Information'), 3)
+        self.comboFilter.addItem(_('Errors'), snapshotlog.LogFilter.ERROR)
+        self.comboFilter.addItem(_('Changes'), snapshotlog.LogFilter.CHANGES)
+        self.comboFilter.addItem(_('Information'), snapshotlog.LogFilter.INFORMATION)
+        self.comboFilter.addItem(_('rsync transfer failures (experimental)'), snapshotlog.LogFilter.RSYNC_TRANSFER_FAILURES)
 
         # text view
         self.txtLogView = QPlainTextEdit(self)
@@ -130,7 +140,7 @@ class LogViewDialog(QDialog):
             # only watch if we show the last log
             log = self.config.takeSnapshotLogFile(self.comboProfiles.currentProfileID())
             self.watcher.addPath(log)
-        self.watcher.fileChanged.connect(self.updateLog)
+        self.watcher.fileChanged.connect(self.updateLog)  # passes the path to the changed file to updateLog()
 
         self.txtLogView.setContextMenuPolicy(Qt.CustomContextMenu)
         self.txtLogView.customContextMenuRequested.connect(self.contextMenuClicked)
@@ -252,11 +262,24 @@ class LogViewDialog(QDialog):
                 self.cbDecode.setChecked(False)
 
     def updateLog(self, watchPath = None):
+        """
+        Show the log file of the current snapshot in the GUI
+
+        Args:
+            watchPath: FQN to a log file (as string) whose changes are watched
+                       via ``QFileSystemWatcher``. In case of changes
+                       this function is called with the log file
+                       and only the new lines in the log file are appended
+                       to the log file widget in the GUI
+                       Use ``None`` if a complete log file shall be shown
+                       at once.
+        """
         if not self.enableUpdate:
             return
 
         mode = self.comboFilter.itemData(self.comboFilter.currentIndex())
 
+        # TODO This expressions is hard to understand (watchPath is not a boolean!)
         if watchPath and self.sid is None:
             # remove path from watch to prevent multiple updates at the same time
             self.watcher.removePath(watchPath)


### PR DESCRIPTION


* Work around: Relax `rsync` exit code 23: Ignore instead of error now (part of #1587)

* Feature: Exclude 'SingletonLock' and 'SingletonCookie' (Discord) and 'lock' (Mozilla Firefox) files by default (part of #1555)

* Feature (experimental): Add new snapshot log filter `rsync transfer failures (experimental)` to find them easier (they are normally not shown as "error").

  This feature is experimental because it is based on hard-coded error message strings in the `rsync` source code and may possibly not find all rsync messages or show false positives.

  The filter is meant only to support humans, **not** to automatically recognize errors when taking a snapshot!

  ![image](https://github.com/bit-team/backintime/assets/11374410/a412c911-4ed7-439a-9413-d38641037afd)

  The filter recognizes snapshot log entries that would otherwise require intensive human search in long logs
  because they are hidden in `[I]`nfo log entries, eg.:

  ```
  [I] Take snapshot (rsync: symlink has no referent: "/home/user/Documents/dead-link
  [I] Schnappschuss erstellen (rsync: IO error encountered -- skipping file deletion)
  [I] Schnappschuss erstellen (rsync: rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1333) [sender=3.2.3])
  [I] Take snapshot (rsync: rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1333) [sender=3.2.3])
  ```

Changelog is updated too...
