### PR TITLE
Build: Pylint improvement & Travis using PyQt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-# env:
-#     # TravisCI support said this could prevent errors from "make".
-#     PYTHONUNBUFFERED=1
+env:
+    # TravisCI support said this could prevent errors from "make".
+    PYTHONUNBUFFERED=1
 
 python:
   - "3.8"
@@ -31,7 +31,7 @@ before_install:
   - sudo rm -f /etc/apt/sources.list.d/mongodb.list
   - sudo apt-get -qq update
   # install screen, and util-linux (provides flock) for test_sshtools
-  - sudo apt-get install -y sshfs screen util-linux
+  - sudo apt-get install -y sshfs screen util-linux python3-pyqt5
 
 jobs:
   exclude:
@@ -43,7 +43,7 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs pyqt5
+  - pip install pylint coveralls pyfakefs
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ arch :
 # ensures that we have UUID filesystem mounts for proper testing
 dist: focal
 
-addons:
-  # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
-  ssh_known_hosts: localhost
-
 env:
     # TravisCI support said this could prevent errors from "make".
     PYTHONUNBUFFERED=1
+
+addons:
+  # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
+  ssh_known_hosts: localhost
 
 python:
   - "3.8"
@@ -25,6 +25,12 @@ python:
   - "3.11"
   - "3.12"
 
+virtualenv:
+  # Packages installed via "apt" are available to Pythons virtenv.
+  # Necessary because PyQt is installed via "apt". Install via "pip" is
+  # not possible because PyPi do not offer a build for "ppc64le" architecture.
+  system_site_packages: true
+  
 before_install:
   # disable mongodb as we don't need it and it sometimes temporary fails
   # https://github.com/travis-ci/travis-ci/issues/4937#issuecomment-149289729

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 # TravisCI (https://travis-ci.org) configuration file
 # https://docs.travis-ci.com/user/languages/python
 
+# Note about PyQt related unit tests:
+# They are not executed on architecture "ppc64le". For this architecture
+# PyQt is not available from PyPi and not installable via pip.
+# The alternative to use "system-site-packages" option and installing PyQt5
+# from Ubuntu repository via "apt" is not working as expected. TravisCI
+# allow "system-site-packages" only for those Python interpreteres that are
+# offered by Ubuntu itself; Python 3.8 in case of Ubuntu Focal. Other Python
+# versions are installed from other sources into a virtual environment and
+# not allowed to use packages installed via "apt".
+
 language: python
 os: linux
 arch :
@@ -50,6 +60,7 @@ jobs:
 
 install:
   - pip install pylint coveralls pyfakefs
+  # PyQt5 is not available for "ppc64le" architecture on PyPi
   - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt5; fi
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
@@ -58,8 +69,6 @@ install:
   - eval `ssh-agent -s`
 
 script:
-  # Is a virtual environment active? Yes: if both variables are not equal.
-  # - python -c "import sys;print(f'{sys.prefix=} {sys.base_prefix=} In virtualenv={sys.prefix != sys.base_prefix}')"
   # - coverage debug sys
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
@@ -68,12 +77,10 @@ script:
   - ./configure  --python=python3
   - make unittest-v
   - cd ..
-  - echo $TRAVIS_PYTHON_VERSION
-  - echo $TRAVIS_ARCH
-  - python3 -c "import sys;print(f'{sys.executable=}')"
   - cd qt
-  - ./configure  --python=python3
+  - ./configure --python=python3
   - make
+  # PyQt5 is not installed on "ppc64le"
   - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@
 
 language: python
 
-# matrix:
-#   arch: [amd64, ppc64le]
-#   python: [3.8, 3.9, 3.10, 3.11]
-
 os: linux
  
 arch :
@@ -57,7 +53,10 @@ before_install:
   # install screen, and util-linux (provides flock) for test_sshtools
   - sudo apt-get install -y sshfs screen util-linux
 
-# jobs:
+jobs:
+  include:
+    - python: "3.8"
+      env: SYSTEM_SITE_PACKAGES=true
 #   exclude:
 #     - python: "3.9"
 #     - python: "3.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,16 @@
 # not allowed to use packages installed via "apt".
 
 language: python
+
+matrix:
+  python: [3.8, 3.9, 3.10, 3.11]
+  arch: [amd64, ppc64le]
+  os: linux
+ 
 os: linux
-arch :
- - amd64
- - ppc64le
+# arch :
+#  - amd64
+#  - ppc64le
 
 # ensures that we have UUID filesystem mounts for proper testing
 dist: focal
@@ -28,14 +34,16 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-python:
-  - "3.8"
-    virtualenv:
-        system_site_packages: true
-  - "3.9"
-  - "3.10"
-  - "3.11"
-  - "3.12"
+# python:
+#   - "3.8"
+#     virtualenv:
+#         system_site_packages: true
+#   - "3.9"
+#   - "3.10"
+#   - "3.11"
+# #   - "3.12"
+
+   
 
 # virtualenv:
 #   # Packages installed via "apt" are available to Pythons virtenv.
@@ -51,14 +59,14 @@ before_install:
   # install screen, and util-linux (provides flock) for test_sshtools
   - sudo apt-get install -y sshfs screen util-linux
 
-jobs:
-  exclude:
-    - python: "3.9"
-    - python: "3.10"
-    - python: "3.11"
-    # Excluding this temporarily because of an Issue on Travis. Support contact established.
-    - arch: ppc64le
-      python: "3.12"
+# jobs:
+#   exclude:
+#     - python: "3.9"
+#     - python: "3.10"
+#     - python: "3.11"
+#     # Excluding this temporarily because of an Issue on Travis. Support contact established.
+#     - arch: ppc64le
+#       python: "3.12"
 
 install:
   - pip install pylint coveralls pyfakefs

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,12 @@ script:
   - ./configure  --python=python3
   - make unittest-v
   - cd ..
+  - echo $TRAVIS_PYTHON_VERSION
+  - echo $TRAVIS_ARCH
   - cd qt
   - ./configure  --python=python3
   - make
-  - pytest
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ] ; then pytest; fi
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,24 @@ language: python
 
 os: linux
  
-arch :
+arch:
  - amd64
  - ppc64le
 
 # ensures that we have UUID filesystem mounts for proper testing
 dist: focal
 
-matrix:
+python:
+  - "3.8"
+  - "3.9"
+  - "3.10"
+  - "3.11"
+#   - "3.12"
+ 
+jobs:
   include:
     - python: 3.8
       env: SYSTEM_SITE_PACKAGES=true
-    - python: 3.9
-    - python: 3.10
-    - python: 3.11
 
 # env:
 #     # TravisCI support said this could prevent errors from "make".
@@ -40,13 +44,7 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-# python:
-#   - "3.8"
-#   - "3.9"
-#   - "3.10"
-#   - "3.11"
-# #   - "3.12"
-   
+  
 
 # virtualenv:
 #   # Packages installed via "apt" are available to Pythons virtenv.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ addons:
 
 python:
   - "3.8"
+    virtualenv:
+        system_site_packages: true
   - "3.9"
   - "3.10"
   - "3.11"
@@ -62,6 +64,7 @@ install:
   - pip install pylint coveralls pyfakefs
   # PyQt5 is not available for "ppc64le" architecture on PyPi
   - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt5; fi
+  - if [ "$TRAVIS_ARCH" == "ppc64le" ] ; then sudo apt install -y python3-pyqt5; fi
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
@@ -81,7 +84,8 @@ script:
   - ./configure --python=python3
   - make
   # PyQt5 is not installed on "ppc64le"
-  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
+  # - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
+  - pytest
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
+env:
+  # TravisCI support said this could prevent errors from "make".
+  PYTHONUNBUFFERED=1
   
 before_install:
   # disable mongodb as we don't need it and it sometimes temporary fails
@@ -75,7 +78,6 @@ script:
   - make
   # PyQt5 is not installed on "ppc64le"
   - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
-  - pytest
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ python:
   - "3.11"
   - "3.12"
 
-virtualenv:
-  # Packages installed via "apt" are available to Pythons virtenv.
-  # Necessary because PyQt is installed via "apt". Install via "pip" is
-  # not possible because PyPi do not offer a build for "ppc64le" architecture.
-  system_site_packages: true
+# virtualenv:
+#   # Packages installed via "apt" are available to Pythons virtenv.
+#   # Necessary because PyQt is installed via "apt". Install via "pip" is
+#   # not possible because PyPi do not offer a build for "ppc64le" architecture.
+#   system_site_packages: true
   
 before_install:
   # disable mongodb as we don't need it and it sometimes temporary fails
@@ -37,7 +37,7 @@ before_install:
   - sudo rm -f /etc/apt/sources.list.d/mongodb.list
   - sudo apt-get -qq update
   # install screen, and util-linux (provides flock) for test_sshtools
-  - sudo apt-get install -y sshfs screen util-linux python3-pyqt5
+  - sudo apt-get install -y sshfs screen util-linux
 
 jobs:
   exclude:
@@ -50,6 +50,7 @@ jobs:
 
 install:
   - pip install pylint coveralls pyfakefs
+  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt5; fi
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
@@ -69,10 +70,11 @@ script:
   - cd ..
   - echo $TRAVIS_PYTHON_VERSION
   - echo $TRAVIS_ARCH
+  - python3 -c "import sys;print(f'{sys.executable=}')"
   - cd qt
   - ./configure  --python=python3
   - make
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ] ; then pytest; fi
+  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,12 @@ arch :
 dist: focal
 
 matrix:
-  - python: [3.8, 3.9, 3.10, 3.11]
+  include:
+    - python: 3.8
+      env: SYSTEM_SITE_PACKAGES=true
+    - python: 3.9
+    - python: 3.10
+    - python: 3.11
 
 # env:
 #     # TravisCI support said this could prevent errors from "make".

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@
 language: python
 
 matrix:
-  python: [3.8, 3.9, 3.10, 3.11]
   arch: [amd64, ppc64le]
-  os: linux
+  python: [3.8, 3.9, 3.10, 3.11]
+
+os: linux
  
 os: linux
 # arch :

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
+env:
+    # TravisCI support said this could prevent errors from "make".
+    PYTHONUNBUFFERED=1
+
 python:
   - "3.8"
   - "3.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,47 +11,29 @@
 # versions are installed from other sources into a virtual environment and
 # not allowed to use packages installed via "apt".
 
-language: python
 
 os: linux
  
+# ensures that we have UUID filesystem mounts for proper testing
+dist: focal
+
+language: python
+
 arch:
  - amd64
  - ppc64le
 
-# ensures that we have UUID filesystem mounts for proper testing
-dist: focal
-
-# python:
-#   - "3.8"
-#   - "3.9"
-#   - "3.10"
-#   - "3.11"
-# #   - "3.12"
+python:
+  - "3.8"
+  - "3.9"
+  - "3.10"
+  - "3.11"
+  - "3.12"
  
-jobs:
-  include:
-    - python: 3.8
-      env: SYSTEM_SITE_PACKAGES=true
-    - python: [3.9, 3.10, 3.11]
-
-# env:
-#     # TravisCI support said this could prevent errors from "make".
-#     PYTHONUNBUFFERED=1
-#     - python: "3.8"
-#       env: SYSTEM_SITE_PACKAGES=true
-
 addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-  
-
-# virtualenv:
-#   # Packages installed via "apt" are available to Pythons virtenv.
-#   # Necessary because PyQt is installed via "apt". Install via "pip" is
-#   # not possible because PyPi do not offer a build for "ppc64le" architecture.
-#   system_site_packages: true
   
 before_install:
   # disable mongodb as we don't need it and it sometimes temporary fails
@@ -61,23 +43,19 @@ before_install:
   # install screen, and util-linux (provides flock) for test_sshtools
   - sudo apt-get install -y sshfs screen util-linux
 
-# jobs:
-#   include:
-#     - python: "3.8"
-#       env: SYSTEM_SITE_PACKAGES=true
-# #   exclude:
-# #     - python: "3.9"
-# #     - python: "3.10"
-# #     - python: "3.11"
-# #     # Excluding this temporarily because of an Issue on Travis. Support contact established.
-# #     - arch: ppc64le
-# #       python: "3.12"
+jobs:
+  exclude:
+    - python: "3.9"
+    - python: "3.10"
+    - python: "3.11"
+    # Excluding this temporarily because of an Issue on Travis. Support contact established.
+    - arch: ppc64le
+      python: "3.12"
 
 install:
   - pip install pylint coveralls pyfakefs
   # PyQt5 is not available for "ppc64le" architecture on PyPi
   - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt5; fi
-  - if [ "$TRAVIS_ARCH" == "ppc64le" ] ; then sudo apt install -y python3-pyqt5; fi
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
@@ -85,7 +63,6 @@ install:
   - eval `ssh-agent -s`
 
 script:
-  # - coverage debug sys
   # compile all files - ensure that syntax is correct
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs
+  - pip install pylint coveralls pyfakefs pyqt5
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,19 @@ dist: focal
 env:
     # TravisCI support said this could prevent errors from "make".
     PYTHONUNBUFFERED=1
+    - python: "3.8"
+      env: SYSTEM_SITE_PACKAGES=true
 
 addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-python:
-  - "3.8"
-  - "3.9"
-  - "3.10"
-  - "3.11"
-#   - "3.12"
-
+# python:
+#   - "3.8"
+#   - "3.9"
+#   - "3.10"
+#   - "3.11"
+# #   - "3.12"
    
 
 # virtualenv:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ addons:
 
 python:
   - "3.8"
-    env: SYSTEM_SITE_PACKAGES=true
   - "3.9"
   - "3.10"
   - "3.11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
   - ./configure --python=python3
   - make
   # PyQt5 is not installed on "ppc64le"
-  # - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
+  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
   - pytest
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-env:
-    # TravisCI support said this could prevent errors from "make".
-    PYTHONUNBUFFERED=1
+# env:
+#     # TravisCI support said this could prevent errors from "make".
+#     PYTHONUNBUFFERED=1
 
 python:
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,18 @@ arch:
 # ensures that we have UUID filesystem mounts for proper testing
 dist: focal
 
-python:
-  - "3.8"
-  - "3.9"
-  - "3.10"
-  - "3.11"
-#   - "3.12"
+# python:
+#   - "3.8"
+#   - "3.9"
+#   - "3.10"
+#   - "3.11"
+# #   - "3.12"
  
 jobs:
   include:
     - python: 3.8
       env: SYSTEM_SITE_PACKAGES=true
+    - python: [3.9, 3.10, 3.11]
 
 # env:
 #     # TravisCI support said this could prevent errors from "make".

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ jobs:
     - python: "3.9"
     - python: "3.10"
     - python: "3.11"
-    # Excluding this temporarily because of an Issue on Travis. Support contact established.
+    # Excluding temporarily because Pyhton 3.12 for ppc64le is not
+    # available yet on Travis.
     - arch: ppc64le
       python: "3.12"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs pyqt5
+  - pip install pylint coveralls pyfakefs
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,22 +22,25 @@ arch :
 # ensures that we have UUID filesystem mounts for proper testing
 dist: focal
 
-env:
-    # TravisCI support said this could prevent errors from "make".
-    PYTHONUNBUFFERED=1
-    - python: "3.8"
-      env: SYSTEM_SITE_PACKAGES=true
+matrix:
+  - python: [3.8, 3.9, 3.10, 3.11]
+
+# env:
+#     # TravisCI support said this could prevent errors from "make".
+#     PYTHONUNBUFFERED=1
+#     - python: "3.8"
+#       env: SYSTEM_SITE_PACKAGES=true
 
 addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-python:
-  - "3.8"
-  - "3.9"
-  - "3.10"
-  - "3.11"
-#   - "3.12"
+# python:
+#   - "3.8"
+#   - "3.9"
+#   - "3.10"
+#   - "3.11"
+# #   - "3.12"
    
 
 # virtualenv:
@@ -54,17 +57,17 @@ before_install:
   # install screen, and util-linux (provides flock) for test_sshtools
   - sudo apt-get install -y sshfs screen util-linux
 
-jobs:
-  include:
-    - python: "3.8"
-      env: SYSTEM_SITE_PACKAGES=true
-#   exclude:
-#     - python: "3.9"
-#     - python: "3.10"
-#     - python: "3.11"
-#     # Excluding this temporarily because of an Issue on Travis. Support contact established.
-#     - arch: ppc64le
-#       python: "3.12"
+# jobs:
+#   include:
+#     - python: "3.8"
+#       env: SYSTEM_SITE_PACKAGES=true
+# #   exclude:
+# #     - python: "3.9"
+# #     - python: "3.10"
+# #     - python: "3.11"
+# #     # Excluding this temporarily because of an Issue on Travis. Support contact established.
+# #     - arch: ppc64le
+# #       python: "3.12"
 
 install:
   - pip install pylint coveralls pyfakefs

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,16 +13,15 @@
 
 language: python
 
-matrix:
-  arch: [amd64, ppc64le]
-  python: [3.8, 3.9, 3.10, 3.11]
+# matrix:
+#   arch: [amd64, ppc64le]
+#   python: [3.8, 3.9, 3.10, 3.11]
 
 os: linux
  
-os: linux
-# arch :
-#  - amd64
-#  - ppc64le
+arch :
+ - amd64
+ - ppc64le
 
 # ensures that we have UUID filesystem mounts for proper testing
 dist: focal
@@ -35,14 +34,13 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-# python:
-#   - "3.8"
-#     virtualenv:
-#         system_site_packages: true
-#   - "3.9"
-#   - "3.10"
-#   - "3.11"
-# #   - "3.12"
+python:
+  - "3.8"
+    env: SYSTEM_SITE_PACKAGES=true
+  - "3.9"
+  - "3.10"
+  - "3.11"
+#   - "3.12"
 
    
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
   ssh_known_hosts: localhost
 
-# python:
-#   - "3.8"
-#   - "3.9"
-#   - "3.10"
-#   - "3.11"
-# #   - "3.12"
+python:
+  - "3.8"
+  - "3.9"
+  - "3.10"
+  - "3.11"
+#   - "3.12"
    
 
 # virtualenv:

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,9 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
-* Fix bug: Bash-completion symlink creation while installing & adding --diagnostics (#1615)
+* Build: Fix bash-completion symlink creation while installing & adding --diagnostics (#1615)
+* Build: Activate PyLint error E602 (undefined-variable)
+* Build: TravisCI use PyQt (except arch "ppc64le")
 
 Version 1.4.3 (2024-01-30)
 * Feature: Exclude 'SingletonLock' and 'SingletonCookie' (Discord) and 'lock' (Mozilla Firefox) files by default (part of #1555)

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -1,10 +1,7 @@
 import unittest
 import pathlib
 import subprocess
-from importlib import metadata
 from typing import Iterable
-
-# PACKAGE_NAME = 'buhtzology'
 
 
 class MirrorMirrorOnTheWall(unittest.TestCase):
@@ -16,24 +13,24 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         """All py-files related to that distribution package.
 
         Dev note (2023-11): Use package metadata after migration to
-        pyproject.toml. This will prevent the dirty folder-jumping-hack
-        currently done in this code.
+        pyproject.toml.
         """
-        p = pathlib.Path.cwd()
+        path = pathlib.Path.cwd()
 
         # Make sure we are inside the test folder
-        if p.name in ['qt', 'common']:  # happens e.g. on TravisCI
-            p = p / 'test'
+        if path.name in ['qt', 'common']:  # happens e.g. on TravisCI
+            path = path / 'test'
 
-        if not p.name.startswith('test'):
-            raise Exception('Something went wrong. The test should run inside'
-                            f' the test folder but current folder is {p}.')
+        if not path.name.startswith('test'):
+            raise RuntimeError('Something went wrong. The test should run '
+                               'inside the test folder but current folder '
+                               f'is {path}.')
 
         # Workaround
-        p = p.parent
+        path = path.parent
 
         # Find recursive all py-files.
-        return p.rglob('**/*.py')
+        return path.rglob('**/*.py')
 
     def test_with_pylint(self):
         """Use Pylint to check for specific error codes.
@@ -46,20 +43,35 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # Pylint base command
         cmd = [
             'pylint',
+            # Storing results in a pickle file is unnecessary
+            '--persistent=n',
+            # autodetec number of parallel jobs
+            '--jobs=0',
+            # Disable scoring  ("Your code has been rated at xx/10")
+            '--score=n',
+            # Deactivate all checks by default
+            '--disable=all',
             # prevent false-positive no-module-member errors
             '--extension-pkg-whitelist=PyQt5',
             # Because of globally installed GNU gettext functions
             '--additional-builtins=_,ngettext',
-            # Deactivate all checks by default
-            '--disable=all'
+            # PEP8 conform line length (see PyLint Issue #3078)
+            '--max-line-length=79',
+            # Whitelist variable names
+            '--good-names=idx,fp',
         ]
 
         # Explicit activate checks
         err_codes = [
+            'E0602',  # undefined-variable
             'E1101',  # no-member
             'W1401',  # anomalous-backslash-in-string (invalid escape sequence)
         ]
         cmd.append('--enable=' + ','.join(err_codes))
 
-        for fp in self._collect_py_files():
-            subprocess.run(cmd + [fp], check=True)
+        # Add py files
+        cmd.extend(self._collect_py_files())
+
+        # print(f'Execute {cmd=}')
+
+        subprocess.run(cmd, check=True)

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -1,10 +1,7 @@
 import unittest
 import pathlib
 import subprocess
-from importlib import metadata
 from typing import Iterable
-
-# PACKAGE_NAME = 'buhtzology'
 
 
 class MirrorMirrorOnTheWall(unittest.TestCase):
@@ -18,21 +15,22 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         Dev note (2023-11): Use package metadata after migration to
         pyproject.toml.
         """
-        p = pathlib.Path.cwd()
+        path = pathlib.Path.cwd()
 
         # Make sure we are inside the test folder
-        if p.name in ['qt', 'common']:  # happens e.g. on TravisCI
-            p = p / 'test'
+        if path.name in ['qt', 'common']:  # happens e.g. on TravisCI
+            path = path / 'test'
 
-        if not p.name.startswith('test'):
-            raise Exception('Something went wrong. The test should run inside'
-                            f' the test folder but current folder is {p}.')
+        if not path.name.startswith('test'):
+            raise RuntimeError('Something went wrong. The test should run '
+                               'inside the test folder but current folder '
+                               f'is {path}.')
 
         # Workaround
-        p = p.parent
+        path = path.parent
 
         # Find recursive all py-files.
-        return p.rglob('**/*.py')
+        return path.rglob('**/*.py')
 
     def test_with_pylint(self):
         """Use Pylint to check for specific error codes.
@@ -45,20 +43,35 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # Pylint base command
         cmd = [
             'pylint',
+            # Storing results in a pickle file is unnecessary
+            '--persistent=n',
+            # autodetec number of parallel jobs
+            '--jobs=0',
+            # Disable scoring  ("Your code has been rated at xx/10")
+            '--score=n',
+            # Deactivate all checks by default
+            '--disable=all',
             # prevent false-positive no-module-member errors
             '--extension-pkg-whitelist=PyQt5',
             # Because of globally installed GNU gettext functions
             '--additional-builtins=_,ngettext',
-            # Deactivate all checks by default
-            '--disable=all'
+            # PEP8 conform line length (see PyLint Issue #3078)
+            '--max-line-length=79',
+            # Whitelist variable names
+            '--good-names=idx,fp',
         ]
 
         # Explicit activate checks
         err_codes = [
+            'E0602',  # undefined-variable
             'E1101',  # no-member
             'W1401',  # anomalous-backslash-in-string (invalid escape sequence)
         ]
         cmd.append('--enable=' + ','.join(err_codes))
 
-        for fp in self._collect_py_files():
-            subprocess.run(cmd + [fp], check=True)
+        # Add py files
+        cmd.extend(self._collect_py_files())
+
+        # print(f'Execute {cmd=}')
+
+        subprocess.run(cmd, check=True)


### PR DESCRIPTION
- PyLint unit test does check all files before reporting errors (Fix #1626)
- Activate PyLint "undefined-variable" error (inspired by PR #1625)
- TravisCI now using PyQt and is prepared to run Qt related unit test except on "ppc64le" architecture.

## About PyQt on TravisCI
Spent to much hours into Travis config experiments. 😪 I added some comments into the travis config but also try to explain it here. The final solution is to install PyQt5 via pip only at architectures different from "ppc64le" and execute "pytest" for the qt module also only on none-ppce64le architectures.

PyQt is needed on TravisCI when we start using Qt tests. But it is also needed today because PyLint need to use it to determine variable-names. Without PyQt installed PyLint would throw "undefined-variable" errors on our qt code.
The primary problem is that PyQt on PyPi (installed via "pip") is not available for architecture "ppc64le". But Ubuntu support that architecture and offer such a package. But Ubuntu packages can not be used inside the Python virtual environment that is used by TravisCI. The option "system-site-packages" might be a workaround because it allow an isolated Python interpreter to access system wide Python packages (installed via "apt-get"). But TravisCI has the restriction that "system-site-packages" only works for the Python version shipped with the Ubuntu (3.8 in our case).
I also experimented about to use "system-site-packages" only for the "Python-3.8-ppce64le-job". But I was not able to make it work.
So many "But"'s...