### PR TITLE
Fix #1630 (make install tries to remove old file using absolute path)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
 * TODO
+* Fix bug: `make install` ignored $(DEST) in file migration part (#1630)
 
 Version 1.4.3 (2024-01-30)
 * Feature: Exclude 'SingletonLock' and 'SingletonCookie' (Discord) and 'lock' (Mozilla Firefox) files by default (part of #1555)

--- a/qt/configure
+++ b/qt/configure
@@ -149,7 +149,7 @@ printf "install:\n" >> ${MAKEFILE}
 
 # Migration
 printf "\t#clean-up installed old files that were renamed or moved in later BiT versions\n" >> ${MAKEFILE}
-printf "\trm -f /etc/dbus-1/system.d/net.launchpad.backintime.serviceHelper.conf\n" >> ${MAKEFILE}
+printf "\trm -f \$(DEST)/etc/dbus-1/system.d/net.launchpad.backintime.serviceHelper.conf\n" >> ${MAKEFILE}
 printf "\trm -f \$(DEST)/share/backintime/plugins/qt4plugin.py\n" >> ${MAKEFILE}
 addNewline
 


### PR DESCRIPTION
Fixes #1630

Tested with `make DESTDIR="/home/user/temp/bit" install` before and after the fix