### PR TITLE
build: Move manpage-creation-script to root folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
   - ./configure --python=python3
   - make
   # PyQt5 is not installed on "ppc64le"
-  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest ; else echo "On ppc64le no Qt testing because PyQt is impossible to install." ; fi
+  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest ; else echo -e "\033[1;35mOn ppc64le no Qt testing because PyQt is impossible to install.\033[0m" ; fi
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,8 @@ script:
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
-  - ./configure  --python=python3
+  # - ./configure  --python=python3
+  - ./configure
   - make unittest-v
   - cd ..
   - cd qt

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
   - ./configure --python=python3
   - make
   # PyQt5 is not installed on "ppc64le"
-  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; fi
+  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; else echo "On ppc64le no Qt testing because PyQt is impossible to install." fi
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
   - ./configure --python=python3
   - make
   # PyQt5 is not installed on "ppc64le"
-  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest; else echo "On ppc64le no Qt testing because PyQt is impossible to install." fi
+  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pytest ; else echo "On ppc64le no Qt testing because PyQt is impossible to install." ; fi
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,7 @@ script:
   - python -m compileall common common/test common/plugins qt qt/test qt/plugins
   # run unit tests - ensure that functionality is correct
   - cd common
-  # - ./configure  --python=python3
-  - ./configure
+  - ./configure  --python=python3
   - make unittest-v
   - cd ..
   - cd qt

--- a/create-manpage-backintime-config.py
+++ b/create-manpage-backintime-config.py
@@ -52,7 +52,7 @@ import os
 import sys
 from time import strftime, gmtime
 
-PATH = os.path.join(os.getcwd(), os.path.dirname(sys.argv[0]))
+PATH = os.path.join(os.getcwd(), 'common')
 
 CONFIG = os.path.join(PATH, 'config.py')
 MAN = os.path.join(PATH, 'man/C/backintime-config.1')


### PR DESCRIPTION
The helper script creating "backintime-config.1" man page just moves one folder up.

The reason is that the script is contained in release tarballs and deb-files of BIT. But it is not necessary.

The CI is failing because of the [known PyLint problem](https://github.com/bit-team/backintime/pull/1625#issuecomment-1952208460) fixed in upcoming PR #1632. The "ppc64le" machine is not failing because Qt-tests are not executed on that architecture.

I "improved" the CI script to be more "verbose" about the special situation with Qt tests on ppc64le architecture.
![image](https://github.com/bit-team/backintime/assets/11861496/6e0f7921-4f70-46bf-8142-a77fe5be40ff)
