### PR TITLE
fix(build): Use addInstallDir to create metainfo folder

### DIFF
--- a/qt/configure
+++ b/qt/configure
@@ -176,9 +176,8 @@ addComment "application"
 addInstallDir                           "/bin"
 addInstallFile "backintime-qt"         "/bin" "755"
 addInstallFile "backintime-qt_polkit"  "/bin" "755"
-printf "\tinstall -d /usr/share/metainfo\n" >> ${MAKEFILE}
+addInstallDir "/share/metainfo"
 addInstallFile "io.github.bit_team.back_in_time.gui.metainfo.xml" "/share/metainfo"
-# printf "\tinstall --mode=644 io.github.bit_team.back_in_time.gui.metainfo.xml /usr/share/metainfo\n"  >> ${MAKEFILE}
 addNewline
 
 addComment "dbus service"


### PR DESCRIPTION
Fix #1654 

@willemw12 Can you test this on your AUR before merging?