### PR TITLE
Fix: "Highly recommended" exclusion patterns show missing patterns only

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Fix: Show only unused patterns in "Highly recommended" label in "Exclude" tab of the settings dialog (#1620)
 * Build: Activate PyLint error E0401 (import-error)
 * Fix: Respect dark mode using color roles (#1601)
 * Dependency: Migration to PyQt6

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
-* Fix: Show only unused patterns in "Highly recommended" label in "Exclude" tab of the settings dialog (#1620)
+* Fix: "Highly recommended" exclusion pattern in "Manage Profile" dialog's "Exclude" tab show missings only (#1620)
 * Build: Activate PyLint error E0401 (import-error)
 * Fix: Respect dark mode using color roles (#1601)
 * Dependency: Migration to PyQt6

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -570,6 +570,8 @@ class SettingsDialog(QDialog):
         label.setWordWrap(True)
         layout.addWidget(label)
 
+        print(f'\n{self.config.DEFAULT_EXCLUDE=}')  # DEBUG
+
         buttonsLayout = QHBoxLayout()
         layout.addLayout(buttonsLayout)
 
@@ -1793,8 +1795,8 @@ class SettingsDialog(QDialog):
         item.setText(0, pattern)
         item.setData(0, Qt.ItemDataRole.UserRole, pattern)
         self.listExcludeCount += 1
-        item.setText(1, str(self.listExcludeCount).zfill(6))
-        item.setData(1, Qt.ItemDataRole.UserRole, self.listExcludeCount)
+        # item.setText(1, str(self.listExcludeCount).zfill(6))
+        # item.setData(1, Qt.ItemDataRole.UserRole, self.listExcludeCount)
         self.formatExcludeItem(item)
         self.listExclude.addTopLevelItem(item)
 
@@ -1845,13 +1847,13 @@ class SettingsDialog(QDialog):
             self.listExclude.setCurrentItem(self.listExclude.topLevelItem(0))
 
     def addExclude_(self, pattern):
+        """WTF is this compared to addExclude() !?"""
         if not pattern:
             return
 
-        for index in range(self.listExclude.topLevelItemCount()):
-            item = self.listExclude.topLevelItem(index)
-            if pattern == item.text(0):
-                return
+        # Is pattern still in the list widget?
+        if self.listExclude.findItems(pattern, Qt.MatchFlag.MatchFixedString):
+            return
 
         self.addExclude(pattern)
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1862,7 +1862,7 @@ class SettingsDialog(QDialog):
     def addExclude(self, pattern):
         """Initiate adding a new exclude pattern to the list widget.
 
-        See `_add_exlcude_pattern()` also.
+        See `_add_exclude_pattern()` also.
         """
         if not pattern:
             return
@@ -2112,25 +2112,25 @@ class SettingsDialog(QDialog):
     def _formatExcludeItem(self, item):
         """Modify visual appearance of an item in the exclude list widget.
         """
-        no_encr_wildcard \
-            = tools.patternHasNotEncryptableWildcard(item.text(0))
-
         # Invalid item (because of encfs restrictions)
-        if self.mode == 'ssh_encfs' and no_encr_wildcard:
+        if (self.mode == 'ssh_encfs'
+                and tools.patternHasNotEncryptableWildcard(item.text(0))):
+
             item.setIcon(0, self.icon.INVALID_EXCLUDE)
             item.setBackground(0, QPalette().brush(QPalette.ColorGroup.Active,
                                                    QPalette.ColorRole.Link))
             return
 
-        # A default exclude item
+        # default background color
+        item.setBackground(0, QBrush())
+
+        # Icon: default exclude item
         if item.text(0) in self.config.DEFAULT_EXCLUDE:
             item.setIcon(0, self.icon.DEFAULT_EXCLUDE)
-            item.setBackground(0, QBrush())
             return
 
-        # User definied
+        # Icon: user definied
         item.setIcon(0, self.icon.EXCLUDE)
-        item.setBackground(0, QBrush())
 
 
     def customSortOrder(self, header, loop, newColumn, newOrder):

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -562,14 +562,9 @@ class SettingsDialog(QDialog):
 
         layout.addWidget(self.listExclude)
 
-        label = QLabel(_('Highly recommended') + ':', self)
-        qttools.setFontBold(label)
-        layout.addWidget(label)
-        label = QLabel(', '.join(sorted(self.config.DEFAULT_EXCLUDE)), self)
-        label.setWordWrap(True)
-        layout.addWidget(label)
-
-        print(f'\n{self.config.DEFAULT_EXCLUDE=}')  # DEBUG
+        self._label_exclude_recommend = QLabel('', self)
+        self._label_exclude_recommend.setWordWrap(True)
+        layout.addWidget(self._label_exclude_recommend)
 
         buttonsLayout = QHBoxLayout()
         layout.addLayout(buttonsLayout)
@@ -1262,6 +1257,26 @@ class SettingsDialog(QDialog):
 
         self.disableProfileChanged = False
 
+    def _update_exclude_recommend_label(self):
+        """Update the label about recommended exclude patterns."""
+
+        # Default patterns that are not still in the list widget
+        recommend = list(filter(
+            lambda val: not self.listExclude.findItems(
+                val, Qt.MatchFlag.MatchFixedString),
+            self.config.DEFAULT_EXCLUDE
+        ))
+
+        if not recommend:
+            recommend = [_('(All recommendations already included.)')]
+
+        self._label_exclude_recommend.setText(
+            '<strong>{}</strong>: {}'.format(
+                _('Highly recommended'),
+                ', '.join(sorted(recommend))
+            )
+        )
+
     def updateProfile(self):
         if self.config.currentProfile() == '1':
             self.btnEditProfile.setEnabled(False)
@@ -1364,6 +1379,7 @@ class SettingsDialog(QDialog):
                                         Qt.SortOrder.AscendingOrder)
         )
         self.listExclude.sortItems(excludeSortColumn, excludeSortOrder)
+        self._update_exclude_recommend_label()
 
         # TAB: Auto-remove
 
@@ -1841,6 +1857,8 @@ class SettingsDialog(QDialog):
         if self.listExclude.topLevelItemCount() > 0:
             self.listExclude.setCurrentItem(self.listExclude.topLevelItem(0))
 
+        self._update_exclude_recommend_label(self)
+
     def addExclude(self, pattern):
         """Initiate adding a new exclude pattern to the list widget.
 
@@ -1858,6 +1876,8 @@ class SettingsDialog(QDialog):
 
         # Select/highlight that entry.
         self.listExclude.setCurrentItem(item)
+
+        self._update_exclude_recommend_label()
 
     def btnExcludeAddClicked(self):
         dlg = QInputDialog(self)

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -561,7 +561,7 @@ class SettingsDialog(QDialog):
             .connect(self.excludeCustomSortOrder)
 
         layout.addWidget(self.listExclude)
-        self.listExcludeCount = 0
+        # self.listExcludeCount = 0
 
         label = QLabel(_('Highly recommended') + ':', self)
         qttools.setFontBold(label)
@@ -1794,7 +1794,7 @@ class SettingsDialog(QDialog):
         item = QTreeWidgetItem()
         item.setText(0, pattern)
         item.setData(0, Qt.ItemDataRole.UserRole, pattern)
-        self.listExcludeCount += 1
+        # self.listExcludeCount += 1
         # item.setText(1, str(self.listExcludeCount).zfill(6))
         # item.setData(1, Qt.ItemDataRole.UserRole, self.listExcludeCount)
         self.formatExcludeItem(item)

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1857,7 +1857,7 @@ class SettingsDialog(QDialog):
         if self.listExclude.topLevelItemCount() > 0:
             self.listExclude.setCurrentItem(self.listExclude.topLevelItem(0))
 
-        self._update_exclude_recommend_label(self)
+        self._update_exclude_recommend_label()
 
     def addExclude(self, pattern):
         """Initiate adding a new exclude pattern to the list widget.


### PR DESCRIPTION
- I joined the two used labels and now use Qt's Rich Text feature to realize the bold font.
- I removed a second invisible column from the list widget. I was not able to find out why it is used. Maybe it was old code from a previous "solution"?

The result looks like this:
![image](https://github.com/bit-team/backintime/assets/11861496/995deff3-8ba6-41a0-927b-322a21008111)

Or when all recommendations full filled:
![image](https://github.com/bit-team/backintime/assets/11861496/76113a26-98f2-4fae-9ca0-f9f21af361f1)

Fix #1620
Close incomplete PR #1629