### PR TITLE
fix: Debug output with version, name, run-as-root and OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs keyring
+  - pip install pylint coveralls pyfakefs keyring dbus-python
   # PyQt is not available for "ppc64le" architecture on PyPi
   - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt6; fi
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs
+  - pip install pylint coveralls pyfakefs keyring
   # PyQt is not available for "ppc64le" architecture on PyPi
   - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt6; fi
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,9 @@ jobs:
       python: "3.12"
 
 install:
-  - pip install pylint coveralls pyfakefs keyring dbus-python
+  - pip install pylint coveralls pyfakefs keyring
   # PyQt is not available for "ppc64le" architecture on PyPi
-  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt6; fi
+  - if [ "$TRAVIS_ARCH" != "ppc64le" ] ; then pip install pyqt6 dbus-python; fi
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""
   - cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,8 @@ replaced with PyPi packages.
   - `python3-dbus.mainloop.pyqt6`
   - `libnotify-bin`
   - `policykit-1`
-  - `qttranslations5-l10n`
-  - `qtwayland5` (if Wayland is used as display server instead of X11)
+  - `qttranslations6-l10n`
+  - `qtwayland6` (if Wayland is used as display server instead of X11)
   - Recommended
       - For SSH key storage **one** of these packages
         - `python3-secretstorage`
@@ -151,4 +151,4 @@ Keep in mind as you contribute, that code, docs and other material submitted
 to the project are considered licensed under the same terms (see
 [LICENSE](LICENSE)) as the rest of the work.
 
-<sub>Sept 2023</sub>
+<sub>March 2024</sub>

--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ with `rsync >= 3.2.4`
 
 If you use `rsync >= 3.2.4` and `backintime <= 1.3.2` there is a
 workaround. Add `--old-args` in
-[_Expert Options_ / _Additional options to rsync_]
-(https://backintime.readthedocs.io/en/latest/settings.html#expert-options).
+[_Expert Options_ / _Additional options to rsync_](https://backintime.readthedocs.io/en/latest/settings.html#expert-options).
 Note that some GNU/Linux distributions (e.g. Manjaro) using a workaround with
 environment variable `RSYNC_OLD_ARGS` in their distro-specific packages for
 _Back In Time_. In that case you may not see any problems.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In the latest stable release:
 - [`qt5_probing.py` may hang with high CPU usage when running BiT as `root` via `cron`](#qt5_probingpy-may-hang-with-high-cpu-usage-when-running-bit-as-root-via-cron)
 
 In older releases:
-- RTE "module 'qttools' has no attribute 'initate_translator'" with encFS when prompting the user for a password (#1553)
+- RTE "module 'qttools' has no attribute 'initate_translator'" with encFS when prompting the user for a password ([#1553](https://github.com/bit-team/backintime/issues/#1553))
 - [Tray icon or other icons not shown correctly](#tray-icon-or-other-icons-not-shown-correctly)
 - [Non-working password safe and BiT forgets passwords (keyring backend issues)](#non-working-password-safe-and-bit-forgets-passwords-keyring-backend-issues)
 - [Incompatibility with rsync >= 3.2.4](#incompatibility-with-rsync-324-or-newer)

--- a/README.md
+++ b/README.md
@@ -7,20 +7,14 @@
 <sub>Copyright (C) 2008-2024 Oprea Dan, Bart de Koning, Richard Bailey,
 Germar Reitze, Taylor Raack, Christian Buhtz, Michael Büker, Jürgen Altfeld<sub>
  
-_Back In Time_ is an easy-to-use backup tool for files and folders.
+_Back In Time_ is an easy-to-use tool to backup files and folders.
 It runs on GNU Linux (not on Windows or OS X/macOS) and provides a command line tool `backintime` and a
 GUI `backintime-qt` both written in Python3. It uses 
 [`rsync`](https://rsync.samba.org/) to take manual or scheduled snapshots and
 stores them locally or remotely through SSH. Each snapshot is in its own folder
 with copies of the original files, but unchanged files are hard-linked between
-snapshots to save space.
+snapshots to save storage space.
 It was inspired by [FlyBack](https://en.wikipedia.org/wiki/FlyBack).
-
-You only need to specify 3 things:
-
-* What folders to back up.
-* Where to save snapshots.
-* The backup frequency (manual, every hour, every day, every month).
 
 ## Maintenance status
 
@@ -77,11 +71,11 @@ installation options provided and maintained by third parties.
 
 In the latest stable release:
 - [File permissions handling and therefore possible non-differential backups](#file-permissions-handling-and-therefore-possible-non-differential-backups)
-- RTE "module 'qttools' has no attribute 'initate_translator'" with encFS when prompting the user for a password (#1553)
 - [Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).](#warning-apt-key-is-deprecated-manage-keyring-files-in-trustedgpgd-instead-see-apt-key8)
 - [`qt5_probing.py` may hang with high CPU usage when running BiT as `root` via `cron`](#qt5_probingpy-may-hang-with-high-cpu-usage-when-running-bit-as-root-via-cron)
 
 In older releases:
+- RTE "module 'qttools' has no attribute 'initate_translator'" with encFS when prompting the user for a password (#1553)
 - [Tray icon or other icons not shown correctly](#tray-icon-or-other-icons-not-shown-correctly)
 - [Non-working password safe and BiT forgets passwords (keyring backend issues)](#non-working-password-safe-and-bit-forgets-passwords-keyring-backend-issues)
 - [Incompatibility with rsync >= 3.2.4](#incompatibility-with-rsync-324-or-newer)
@@ -120,7 +114,7 @@ This issue is tracked in [#1338](https://github.com/bit-team/backintime/issues/1
 
 #### `qt5_probing.py` may hang with high CPU usage when running BiT as `root` via `cron`
 
-See the related issue #1592
+See the related issue [#1592](https://github.com/bit-team/backintime/issues/1592).
 
 The only reliable work-around is to delete (or move into another folder)
 the file `/usr/share/backintime/common/qt5_probing.py`:
@@ -184,15 +178,26 @@ See also issue [#1321](https://github.com/bit-team/backintime/issues/1321)
 
 #### Incompatibility with rsync 3.2.4 or newer
 
-The release (`1.3.2`) and earlier versions of _Back In Time_ are incompatible with `rsync >= 3.2.4` ([#1247](https://github.com/bit-team/backintime/issues/1247)). The problem is [fixed](https://github.com/bit-team/backintime/pull/1351) in the current master branch of that repo and will be released with the next release (`1.3.3`) of _Back In Time_.
+**Status: Fixed in v1.3.3**
 
-If you use `rsync >= 3.2.4` and `backintime <= 1.3.2` there is a workaround. Add `--old-args` in [_Expert Options_ / _Additional options to rsync_](https://backintime.readthedocs.io/en/latest/settings.html#expert-options). Note that some GNU/Linux distributions (e.g. Manjaro) using a workaround with environment variable `RSYNC_OLD_ARGS` in their distro-specific packages for _Back In Time_. In that case you may not see any problems.
+The release (`1.3.2`) and earlier versions of _Back In Time_ are incompatible
+with `rsync >= 3.2.4`
+([#1247](https://github.com/bit-team/backintime/issues/1247)).
+
+If you use `rsync >= 3.2.4` and `backintime <= 1.3.2` there is a
+workaround. Add `--old-args` in
+[_Expert Options_ / _Additional options to rsync_]
+(https://backintime.readthedocs.io/en/latest/settings.html#expert-options).
+Note that some GNU/Linux distributions (e.g. Manjaro) using a workaround with
+environment variable `RSYNC_OLD_ARGS` in their distro-specific packages for
+_Back In Time_. In that case you may not see any problems.
 
 #### Python 3.10 compatibility and Ubuntu version
 
 _Back In Time_ versions older than 1.3.2 do not start with Python >= 3.10.
 Ubuntu 22.04 LTS ships with Python 3.10 and backintime 1.2.1, but has applied
 [a patch](https://bugs.launchpad.net/ubuntu/+source/backintime/+bug/1976164/+attachment/5593556/+files/backintime_1.2.1-3_1.2.1-3ubuntu0.1.diff)
-to make it work. If you want to update to backintime 1.3.2 in Ubuntu, you may use the PPA: see under [`INSTALL/Ubuntu PPA`](#Ubuntu-PPA).
+to make it work. If you want to update _Back In Time_, you may use one of the
+[alternative options for installation](#alternative-installation-options).
 
-<sub>Jan 2024</sub>
+<sub>March 2024</sub>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ instead of implementing new
 If you are interested in the development, please
 see [CONTRIBUTING](CONTRIBUTING.md) and have a look on
 [open issues](https://github.com/bit-team/backintime/issues) especially
-those labeled as [good first](https://github.com/bit-team/backintime/labels/GOOD%20FIRST%20ISSUE)
+those labeled as [good first issue](https://github.com/bit-team/backintime/labels/GOOD%20FIRST%20ISSUE)
 and [help wanted](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%3Aopen+label%3AHELP-WANTED).
 
 ## Index
@@ -43,14 +43,15 @@ and [help wanted](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%
 
 ## Documentation, FAQs, Support
 
- * [End user documentation](https://backintime.readthedocs.org/) (not totally up-to-date)
  * [FAQ - Frequently Asked Questions](FAQ.md)
- * [Source code documentation for developers](https://backintime-dev.readthedocs.org)
- * Use [Issues](https://github.com/bit-team/backintime/issues) to ask questions and report bugs.
+ * [End user documentation](https://backintime.readthedocs.org/) (not totally up-to-date)
  * [Mailing list
    _bit-dev_](https://mail.python.org/mailman3/lists/bit-dev.python.org/) for
    **every topic**, question and idea about _Back In Time_. Despite its name
    it is not restricted to development topics only.
+ * Use [Issues](https://github.com/bit-team/backintime/issues) to ask
+   questions and report bugs.
+ * [Source code documentation for developers](https://backintime-dev.readthedocs.org)
 
 ## Installation
 

--- a/common/config.py
+++ b/common/config.py
@@ -176,13 +176,12 @@ class Config(configfile.ConfigFileWithProfiles):
         tools.makeDirs(self._LOCAL_MOUNT_ROOT)
 
         self._DEFAULT_CONFIG_PATH = os.path.join(self._LOCAL_CONFIG_FOLDER, 'config')
+
         if config_path is None:
-            print(f'config_path is None :: {self._DEFAULT_CONFIG_PATH=}')  # DEBUG
             self._LOCAL_CONFIG_PATH = self._DEFAULT_CONFIG_PATH
         else:
             self._LOCAL_CONFIG_PATH = os.path.abspath(config_path)
             self._LOCAL_CONFIG_FOLDER = os.path.dirname(self._LOCAL_CONFIG_PATH)
-            print(f'config_path NOT None :: {self._LOCAL_CONFIG_PATH=} {self._LOCAL_CONFIG_FOLDER=}')  # DEBUG
 
         # (buhtz) Introduced in 2009 via commit 5b26575be4.
         # Ready to remove after 15 years.

--- a/common/config.py
+++ b/common/config.py
@@ -177,10 +177,12 @@ class Config(configfile.ConfigFileWithProfiles):
 
         self._DEFAULT_CONFIG_PATH = os.path.join(self._LOCAL_CONFIG_FOLDER, 'config')
         if config_path is None:
+            print(f'config_path is None :: {self._DEFAULT_CONFIG_PATH=}')  # DEBUG
             self._LOCAL_CONFIG_PATH = self._DEFAULT_CONFIG_PATH
         else:
             self._LOCAL_CONFIG_PATH = os.path.abspath(config_path)
             self._LOCAL_CONFIG_FOLDER = os.path.dirname(self._LOCAL_CONFIG_PATH)
+            print(f'config_path NOT None :: {self._LOCAL_CONFIG_PATH=} {self._LOCAL_CONFIG_FOLDER=}')  # DEBUG
 
         # (buhtz) Introduced in 2009 via commit 5b26575be4.
         # Ready to remove after 15 years.

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -48,7 +48,6 @@ def collect_diagnostics():
     """
     result = collect_minimal_diagnostics()
 
-
     # === BACK IN TIME ===
 
     # work-around: Instantiate to get the user-callback folder
@@ -83,7 +82,7 @@ def collect_diagnostics():
         # Kernel & Architecture
         'platform': platform.platform(),
         # OS Version (and maybe name)
-        'system': '{} {}'.format(platform.system(), platform.version()),
+        'system': f'{platform.system()} {platform.version()}'
     })
 
     # Display system (X11 or Wayland)
@@ -111,20 +110,21 @@ def collect_diagnostics():
         result['host-setup'][var] = os.environ.get(var, '(not set)')
 
     # === PYTHON setup ===
-    python = '{} {} {} {}'.format(
+    python = ' '.join((
         platform.python_version(),
         ' '.join(platform.python_build()),
         platform.python_implementation(),
         platform.python_compiler()
-    )
+    ))
 
     # Python branch and revision if available
     branch = platform.python_branch()
     if branch:
-        python = '{} branch: {}'.format(python, branch)
+        python = f'{python} branch: {branch}'
+
     rev = platform.python_revision()
     if rev:
-        python = '{} rev: {}'.format(python, rev)
+        python = f'{python} rev: {rev}'
 
     python_executable = Path(sys.executable)
 
@@ -214,6 +214,7 @@ def _get_qt_information():
     If environment variable ``DISPLAY`` is set a temporary QApplication
     instances is created.
     """
+    # pylint: disable=import-outside-toplevel
     try:
         import PyQt6.QtCore
         import PyQt6.QtGui
@@ -235,8 +236,8 @@ def _get_qt_information():
         qapp.quit()
 
     return {
-        'Version': 'PyQt {} / Qt {}'.format(PyQt6.QtCore.PYQT_VERSION_STR,
-                                            PyQt6.QtCore.QT_VERSION_STR),
+        'Version': f'PyQt {PyQt6.QtCore.PYQT_VERSION_STR} '
+                   f'/ Qt {PyQt6.QtCore.QT_VERSION_STR}',
         **theme_info
     }
 

--- a/common/plugins/usercallbackplugin.py
+++ b/common/plugins/usercallbackplugin.py
@@ -68,7 +68,7 @@ class UserCallbackPlugin(pluginmanager.Plugin):
         return os.path.exists(self.script)
 
     # TODO 09/28/2022: This method should be private (_callback)
-    def callback(self, *args, profileID = None):
+    def callback(self, *args, profileID=None):
         if profileID is None:
             profileID = self.config.currentProfile()
 

--- a/common/qt_probing.py
+++ b/common/qt_probing.py
@@ -101,9 +101,8 @@ try:
     #     os.seteuid(1000)
     #     logger.debug(f"New euid: {os.geteuid()}")
 
-    # Disable pylint "import-error" because of TravisCI ppc64le architecture
-    from PyQt6 import QtCore  # pylint: disable=import-error
-    from PyQt6.QtWidgets import QApplication  # pylint: disable=import-error
+    from PyQt6 import QtCore
+    from PyQt6.QtWidgets import QApplication
 
     app = QApplication([''])
 
@@ -118,7 +117,7 @@ try:
     # ("GUI") is active at all (e.g. in headless installations it isn't).
     # See: https://forum.qt.io/topic/3852/issystemtrayavailable-always-crashes-segfault-on-ubuntu-10-10-desktop/6
 
-    from PyQt6.QtWidgets import QSystemTrayIcon # pylint: disable=import-error
+    from PyQt6.QtWidgets import QSystemTrayIcon
     is_sys_tray_available = QSystemTrayIcon.isSystemTrayAvailable()
 
     if is_sys_tray_available:

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -236,6 +236,7 @@ under certain conditions; type `backintime --license' for details.
                                  "/tmp/test",
                                  "/tmp/restored"])
 
+    @unittest.skip('temporary')
     def test_diagnostics_arg(self):
         # "output" from stdout may currently be polluted with logging output
         # lines from INFO and DEBUG log output.

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -236,7 +236,6 @@ under certain conditions; type `backintime --license' for details.
                                  "/tmp/test",
                                  "/tmp/restored"])
 
-    @unittest.skip('temporary')
     def test_diagnostics_arg(self):
         # "output" from stdout may currently be polluted with logging output
         # lines from INFO and DEBUG log output.

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -31,7 +31,6 @@ class Diagnostics(unittest.TestCase):
         """Some containted elements"""
         result = diagnostics.collect_diagnostics()
 
-        print(f'\n{result=}')  # DEBUG
         # 1st level keys
         self.assertCountEqual(
             result.keys(),

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -1,3 +1,4 @@
+"""Test related to diagnostics.py"""
 import sys
 import pathlib
 import unittest
@@ -8,15 +9,32 @@ import diagnostics  # testing target
 
 
 class Diagnostics(unittest.TestCase):
+    """Test about collecting diagnostic infos."""
 
-    def test_minimal(self):
+    def test_content_minimal(self):
         """Minimal set of elements."""
 
-        result = diagnostics.collect_diagnostics()
+        sut = diagnostics.collect_minimal_diagnostics()
 
         # 1st level keys
-        self.assertEqual(
-            sorted(result.keys()),
+        self.assertCountEqual(sut.keys(), ['backintime', 'host-setup'])
+
+        # 2nd level "backintime"
+        self.assertCountEqual(
+            sut['backintime'].keys(),
+            ['name', 'version', 'running-as-root'])
+
+        # 2nd level "host-setup"
+        self.assertCountEqual(sut['host-setup'].keys(), ['OS'])
+
+    def test_some_content(self):
+        """Some containted elements"""
+        result = diagnostics.collect_diagnostics()
+
+        print(f'\n{result=}')  # DEBUG
+        # 1st level keys
+        self.assertCountEqual(
+            result.keys(),
             ['backintime', 'external-programs', 'host-setup', 'python-setup']
         )
 
@@ -59,8 +77,7 @@ class Diagnostics(unittest.TestCase):
                 diagnostics.collect_diagnostics()
 
     def test_no_extern_version(self):
-        """Get version from not existing tool.
-        """
+        """Get version from not existing tool."""
         self.assertEqual(
             diagnostics._get_extern_versions(['fooXbar']),
             '(no fooXbar)'
@@ -68,7 +85,6 @@ class Diagnostics(unittest.TestCase):
 
     def test_replace_user_path(self):
         """Replace users path."""
-
         d = {
             'foo': '/home/rsync',
             'bar': '~/rsync'
@@ -86,5 +102,3 @@ class Diagnostics(unittest.TestCase):
             diagnostics._replace_username_paths(d, 'user'),
             d
         )
-
-

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -93,7 +93,6 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # Add py files
         cmd.extend(self._collect_py_files())
 
-        # subprocess.run(cmd, check=True)
         r = subprocess.run(
             cmd,
             check=False,

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -12,6 +12,7 @@ PYLINT_REASON = ('Using PyLint is mandatory on TravisCI, on other systems'
 ON_TRAVIS_PPC64LE = os.environ.get('TRAVIS_ARCH', '') == 'ppc64le'
 
 
+@unittest.skip('temp')
 class MirrorMirrorOnTheWall(unittest.TestCase):
     """Check all py-files in the package (incl. test files) for lints and
     potential bugs and if they are compliant to the coding styles (e.g. PEP8).

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -86,6 +86,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         if ON_TRAVIS_PPC64LE:
             # Because of missing PyQt6 on ppc64le architecture
             err_codes.remove('I0021')
+            err_codes.remove('E0401')
 
         cmd.append('--enable=' + ','.join(err_codes))
 

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -105,4 +105,4 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
                                   r.stdout.splitlines())))
         print(r.stdout)
 
-        self.assertEqual(0, r.returncode, f'PyLint found {error_n} problems.')
+        self.assertEqual(0, error_n, f'PyLint found {error_n} problems.')

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -12,7 +12,6 @@ PYLINT_REASON = ('Using PyLint is mandatory on TravisCI, on other systems'
 ON_TRAVIS_PPC64LE = os.environ.get('TRAVIS_ARCH', '') == 'ppc64le'
 
 
-@unittest.skip('temp')
 class MirrorMirrorOnTheWall(unittest.TestCase):
     """Check all py-files in the package (incl. test files) for lints and
     potential bugs and if they are compliant to the coding styles (e.g. PEP8).
@@ -53,8 +52,10 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # Pylint base command
         cmd = [
             'pylint',
-            # Make sure BIT modules can be improted (to detect "no-member")
-            '--init-hook=import sys;sys.path.insert(0, "./../qt");',
+            # Make sure BIT modules can be imported (to detect "no-member")
+            '--init-hook=import sys;'
+            'sys.path.insert(0, "./../qt");'
+            'sys.path.insert(0, "./../common");',
             # Storing results in a pickle file is unnecessary
             '--persistent=n',
             # autodetec number of parallel jobs

--- a/common/test/test_plugin_usercallback.py
+++ b/common/test/test_plugin_usercallback.py
@@ -172,9 +172,6 @@ class SystemTest(unittest.TestCase):
         if isinstance(output, str):
             output = output.splitlines()
 
-        # for ooo in output:
-        #     print(f'_extract_callback_response() :: {ooo=}')  # DEBUG
-
         # only log lines related to user-callback
         response_lines = filter(
             lambda line: 'user-callback returned' in line, output)
@@ -182,9 +179,7 @@ class SystemTest(unittest.TestCase):
         callback_responses = []
 
         for line in response_lines:
-            # print(f'extract_usercallback_responses() :: {line=}')  # DEBUG
             to_eval = line[line.index("'")+1:line.rindex("'")]
-            # print(f'extract_usercallback_responses() :: {to_eval=}')  # DEBUG
 
             callback_responses.append(
                 eval(line[line.index("'")+1:line.rindex("'")])
@@ -251,7 +246,6 @@ class SystemTest(unittest.TestCase):
     def setUp(self):
         """Setup a local snapshot profile including a user-callback"""
         # cleanup() happens automatically
-        logger.DEBUG = True
         self._temp_dir = tempfile.TemporaryDirectory(prefix='bit.')
         # Workaround: tempfile and pathlib not compatible yet
         self.temp_path = Path(self._temp_dir.name)
@@ -260,16 +254,17 @@ class SystemTest(unittest.TestCase):
         self.config_fp = self._create_config_file(self.temp_path)
         self._create_user_callback_file(self.config_fp.parent)
 
+        # Reset this instance because it is not isolated between tests.
+        Config.PLUGIN_MANAGER = pluginmanager.PluginManager()
+
     def test_local_snapshot(self):
         """User-callback response while doing a local snapshot"""
 
-        Config.PLUGIN_MANAGER = pluginmanager.PluginManager()
         config = Config(
             config_path=str(self.config_fp),
             data_path=str(self.temp_path / '.local' / 'share')
         )
 
-        # print(f'{config.takeSnapshotUserCallback()=}')  # DEBUG
         full_snapshot_path = config.snapshotsFullPath()
         Path(full_snapshot_path).mkdir(parents=True)
 
@@ -290,7 +285,6 @@ class SystemTest(unittest.TestCase):
 
         responses = self._extract_callback_responses(stderr.getvalue())
 
-        # print(f'\n{responses=}')  # DEBUG
         # Number of responses
         self.assertEqual(5, len(responses))
 

--- a/common/test/test_plugin_usercallback.py
+++ b/common/test/test_plugin_usercallback.py
@@ -172,6 +172,7 @@ class SystemTest(unittest.TestCase):
         if isinstance(output, str):
             output = output.splitlines()
 
+        print(f'{output=}')  # DEBUG
         # only log lines related to user-callback
         response_lines = filter(
             lambda line: 'user-callback returned' in line, output)

--- a/common/test/test_plugin_usercallback.py
+++ b/common/test/test_plugin_usercallback.py
@@ -260,6 +260,7 @@ class SystemTest(unittest.TestCase):
             data_path=str(self.temp_path / '.local' / 'share')
         )
 
+        print(list(self.temp_path.rglob('**/*')))
         full_snapshot_path = config.snapshotsFullPath()
         Path(full_snapshot_path).mkdir(parents=True)
 
@@ -278,8 +279,10 @@ class SystemTest(unittest.TestCase):
         # Empty STDOUT output
         self.assertFalse(stdout.getvalue())
 
+        print(f'\n{stderr.getvalue()=}')  # DEBUG
         responses = self._extract_callback_responses(stderr.getvalue())
 
+        print(f'\n{responses=}')  # DEBUG
         # Number of responses
         self.assertEqual(5, len(responses))
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -53,9 +53,9 @@ try:
     #       because the latter is still not available here in the global
     #       module code.
     if os.getenv('BIT_USE_KEYRING', 'true') == 'true' and os.geteuid() != 0:
-        import keyring  # pylint: disable=import-error
-        from keyring import backend  # pylint: disable=import-error
-        import keyring.util.platform_  # pylint: disable=import-error
+        import keyring
+        from keyring import backend
+        import keyring.util.platform_
         is_keyring_available = True
 except Exception as e:
     is_keyring_available = False

--- a/qt/aboutdlg.py
+++ b/qt/aboutdlg.py
@@ -29,7 +29,7 @@ import messagebox
 import backintime
 
 
-class AboutDlg(QDialog):  # pylint: disable=too-few-public-methods
+class AboutDlg(QDialog):
     """The about dialog accessible from the Help menu in the main window."""
 
     def __init__(self, parent=None):

--- a/qt/languagedialog.py
+++ b/qt/languagedialog.py
@@ -169,7 +169,6 @@ class LanguageDialog(QDialog):
         btn = self.sender()
 
         if btn.isChecked():
-            # pylint: disable-next=attribute-defined-outside-init
             self.language_code = btn.lang_code
 
 
@@ -268,7 +267,7 @@ class ApproachTranslatorDialog(QDialog):
         if self.height() < best.height():
             self.resize(best)
 
-    def resizeEvent(self, event):  # pylint: disable=invalid-name
+    def resizeEvent(self, event):
         """See `_fixSize()`  for details."""
         super().resizeEvent(event)
 

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -31,7 +31,6 @@ import messagebox
 class LogViewDialog(QDialog):
     # Workaround because of *-imports of Qt elements.
     # Remove as soon as possible.
-    # pylint: disable=undefined-variable
     def __init__(self, parent, sid = None, systray = False):
         """
         Instantiate a snapshot log file viewer

--- a/qt/serviceHelper.py
+++ b/qt/serviceHelper.py
@@ -74,7 +74,9 @@ except ImportError:
 import dbus
 import dbus.service
 import dbus.mainloop
-import dbus.mainloop.pyqt6  # pylint: disable=import-error,useless-suppression
+# pylint: disable-next=import-error,useless-suppression
+import dbus.mainloop.pyqt6
+# pylint: disable-next=import-error,useless-suppression
 from dbus.mainloop.pyqt6 import DBusQtMainLoop
 from PyQt6.QtCore import QCoreApplication
 

--- a/qt/serviceHelper.py
+++ b/qt/serviceHelper.py
@@ -71,11 +71,11 @@ except ImportError:
 
 # "dbus-python" not available for ppc64le architecture
 # "dbus.mainloop.pyqt6" not available via PyPi for any architecture
-import dbus  # pylint: disable=import-error
-import dbus.service  # pylint: disable=import-error
-import dbus.mainloop  # pylint: disable=import-error
-import dbus.mainloop.pyqt6  # pylint: disable=import-error
-from dbus.mainloop.pyqt6 import DBusQtMainLoop  # pylint: disable=import-error
+import dbus
+import dbus.service
+import dbus.mainloop
+import dbus.mainloop.pyqt6
+from dbus.mainloop.pyqt6 import DBusQtMainLoop
 from PyQt6.QtCore import QCoreApplication
 
 UDEV_RULES_PATH = '/etc/udev/rules.d/99-backintime-%s.rules'

--- a/qt/serviceHelper.py
+++ b/qt/serviceHelper.py
@@ -74,7 +74,7 @@ except ImportError:
 import dbus
 import dbus.service
 import dbus.mainloop
-import dbus.mainloop.pyqt6
+import dbus.mainloop.pyqt6  # pylint: disable=import-error,useless-suppression
 from dbus.mainloop.pyqt6 import DBusQtMainLoop
 from PyQt6.QtCore import QCoreApplication
 

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -93,7 +93,6 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # Add py files
         cmd.extend(self._collect_py_files())
 
-        # subprocess.run(cmd, check=True)
         r = subprocess.run(
             cmd,
             check=False,

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -52,8 +52,10 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # Pylint base command
         cmd = [
             'pylint',
-            # Workaround
-            '--init-hook=import sys;sys.path.insert(0, "./../common");',
+            # Make sure BIT modules can be imported (to detect "no-member")
+            '--init-hook=import sys;'
+            'sys.path.insert(0, "./../qt");'
+            'sys.path.insert(0, "./../common");',
             # Storing results in a pickle file is unnecessary
             '--persistent=n',
             # autodetec number of parallel jobs

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -86,6 +86,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         if ON_TRAVIS_PPC64LE:
             # Because of missing PyQt6 on ppc64le architecture
             err_codes.remove('I0021')
+            err_codes.remove('E0401')
 
         cmd.append('--enable=' + ','.join(err_codes))
 

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -105,4 +105,4 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
                                   r.stdout.splitlines())))
         print(r.stdout)
 
-        self.assertEqual(0, r.returncode, f'PyLint found {error_n} problems.')
+        self.assertEqual(0, error_n, f'PyLint found {error_n} problems.')


### PR DESCRIPTION
This is one of the "tiny" PRs becoming a "big mess". Sorry, it wasn't planed that way.

- Separated some code from `collect_diagnostics()` into `collect_minimal_diagnostics()` which is then called in `common/backintime.py::startApp()` to build a debug message.
- I fixed an akward problem with the user-callback unit tests introduced in #1658. **REMEMBER**: There are some module/class objects around in BIT that are not isolated in a test but live the whole test suit runs. Cost me some hours to realize this. 🤣 
- Minor refactoring and minor mods in README.md and CONTRIBUTING.md.

Fix #1664
Improve PR #1658

Result debug output
```
$ ./backintime --debug
DEBUG: [common/backintime.py:608 argParse] Used argument(s): {'debug': True, 'quiet': False}
DEBUG: [common/backintime.py:609 argParse] Unknown argument(s): []
DEBUG: [common/backintime.py:511 startApp] {'name': 'Back In Time', 'version': '1.4.4-dev', 'running-as-root': False} ['Debian GNU/Linux 12 (bookworm)', '12.5\n']

Back In Time
Version: 1.4.4-dev

Back In Time comes with ABSOLUTELY NO WARRANTY.
This is free software, and you are welcome to redistribute it
under certain conditions; type `backintime --license' for details.

DEBUG: [common/configfile.py:591 Config.setCurrentProfile] Change current profile: 1=Hauptprofil
DEBUG: [common/tools.py:225 initiate_translation] Language code "en".
DEBUG: [common/backintime.py:691 getConfig] config file: /home/user/.config/backintime/config
DEBUG: [common/backintime.py:692 getConfig] share path: /home/user/.local/share/backintime
DEBUG: [common/backintime.py:693 getConfig] profiles: 1=Main profile, 3=playwithme
```