### PR TITLE
test/feat: Include F2FS root fs in test script

### DIFF
--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -432,7 +432,7 @@ class TestTools(generic.TestCase):
         self.assertRegex(tools.filesystem('/sys'), r'sys.*')
         self.assertRegex(
             tools.filesystem('/nonExistingFolder/foo/bar').lower(),
-            r'(:?ext[2-4]|xfs|zfs|jfs|raiserfs|btrfs|tmpfs|overlay|shiftfs)')
+            r'(:?ext[2-4]|xfs|zfs|jfs|raiserfs|btrfs|f2fs|tmpfs|overlay|shiftfs)')
 
     # tools.uuidFromDev() get called from tools.uuidFromPath because the
     # latter is a synonym/surrogate for too.suuidFromDev()


### PR DESCRIPTION
I am using F2FS on my Pinebook Pro as the root fs; backintime-cli will not build properly under these circumstances, since the test_tools.py script does not expect a F2FS root. This commit fixes this.
