### PR TITLE
Implement SSH Proxy Host

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Feature: Support SSH proxy (jump) host (#1688) (@cgrinham, Christie Grinham)
 * Refactor: Replace Config.user() with getpass.getuser() (#1694)
 * Fix: Validation of diff command settings in compare snapshots dialog (#1662) (@stcksmsh Kosta Vukicevic)
 * Fix bug: Open symlinked folders in file view (#1476)

--- a/common/config.py
+++ b/common/config.py
@@ -735,16 +735,16 @@ class Config(configfile.ConfigFileWithProfiles):
         return args
 
     def sshCommand(self,
-                   cmd = None,
-                   custom_args = None,
-                   port = True,
-                   cipher = True,
-                   user_host = True,
-                   ionice = True,
-                   nice = True,
-                   quote = False,
-                   prefix = True,
-                   profile_id = None):
+                   cmd=None,
+                   custom_args=None,
+                   port=True,
+                   cipher=True,
+                   user_host=True,
+                   ionice=True,
+                   nice=True,
+                   quote=False,
+                   prefix=True,
+                   profile_id=None):
         """
         Return SSH command with all arguments.
 
@@ -763,27 +763,35 @@ class Config(configfile.ConfigFileWithProfiles):
         Returns:
             list:               ssh command with chosen arguments
         """
+        # Refactor: Use of assert is discouraged in productive code.
+        # Raise Exceptions instead.
         assert cmd is None or isinstance(cmd, list), "cmd '{}' is not list instance".format(cmd)
         assert custom_args is None or isinstance(custom_args, list), "custom_args '{}' is not list instance".format(custom_args)
-        ssh  = ['ssh']
+
+        ssh = ['ssh']
         ssh += self.sshDefaultArgs(profile_id)
 
+        # Proxy (aka Jump host)
         if self.sshProxyHost(profile_id):
             ssh += ['-J', '{}@{}:{}'.format(
                 self.sshProxyUser(profile_id),
                 self.sshProxyHost(profile_id),
                 self.sshProxyPort(profile_id)
             )]
+
         # remote port
         if port:
             ssh += ['-p', str(self.sshPort(profile_id))]
+
         # cipher used to transfer data
         c = self.sshCipher(profile_id)
         if cipher and c != 'default':
-            ssh += ['-o', 'Ciphers={}'.format(c)]
+            ssh += ['-o', f'Ciphers={c}']
+
         # custom arguments
         if custom_args:
             ssh += custom_args
+
         # user@host
         if user_host:
             ssh.append('{}@{}'.format(self.sshUser(profile_id),
@@ -791,27 +799,32 @@ class Config(configfile.ConfigFileWithProfiles):
         # quote the command running on remote host
         if quote and cmd:
             ssh.append("'")
+
         # run 'ionice' on remote host
         if ionice and self.ioniceOnRemote(profile_id) and cmd:
             ssh += ['ionice', '-c2', '-n7']
+
         # run 'nice' on remote host
         if nice and self.niceOnRemote(profile_id) and cmd:
             ssh += ['nice', '-n19']
+
         # run prefix on remote host
         if prefix and cmd and self.sshPrefixEnabled(profile_id):
-            ssh += self.sshPrefixCmd(profile_id, cmd_type = list)
+            ssh += self.sshPrefixCmd(profile_id, cmd_type=type(cmd))
+
         # add the command
         if cmd:
             ssh += cmd
+
         # close quote
         if quote and cmd:
             ssh.append("'")
 
-        logger.debug('SSH command: %s' % ' '.join(ssh), self)
+        logger.debug(f'SSH command: {ssh}', self)
 
         return ssh
 
-    #ENCFS
+    # EncFS
     def localEncfsPath(self, profile_id = None):
         #?Where to save snapshots in mode 'local_encfs'.;absolute path
         return self.profileStrValue('snapshots.local_encfs.path', '', profile_id)
@@ -1357,17 +1370,25 @@ class Config(configfile.ConfigFileWithProfiles):
         self.setProfileBoolValue('snapshots.ssh.prefix.enabled', enabled, profile_id)
         self.setProfileStrValue('snapshots.ssh.prefix.value', value, profile_id)
 
-    def sshPrefixCmd(self, profile_id = None, cmd_type = str):
+    def sshPrefixCmd(self, profile_id=None, cmd_type=str):
+        """Return the config value of sshPrefix if enabled.
+
+        Dev note by buhtz (2024-04): Good opportunity to refactor. To much
+        implicit behavior in it.
+        """
         if cmd_type == list:
             if self.sshPrefixEnabled(profile_id):
                 return shlex.split(self.sshPrefix(profile_id))
-            else:
-                return []
+
+            return []
+
         if cmd_type == str:
             if self.sshPrefixEnabled(profile_id):
                 return self.sshPrefix(profile_id).strip() + ' '
-            else:
-                return ''
+
+            return ''
+
+        raise TypeError(f'Unable to handle type {cmd_type}.')
 
     def continueOnErrors(self, profile_id = None):
         #?Continue on errors. This will keep incomplete snapshots rather than

--- a/common/config.py
+++ b/common/config.py
@@ -668,6 +668,27 @@ class Config(configfile.ConfigFileWithProfiles):
     def setSshPrivateKeyFile(self, value, profile_id = None):
         self.setProfileStrValue('snapshots.ssh.private_key_file', value, profile_id)
 
+    def sshProxyHost(self, profile_id = None):
+        #?Proxy host used to connect to remote host.;;IP or domain address
+        return self.profileStrValue('snapshots.ssh.proxy_host', '', profile_id)
+
+    def setSshProxyHost(self, value, profile_id = None):
+        self.setProfileStrValue('snapshots.ssh.proxy_host', value, profile_id)
+
+    def sshProxyPort(self, profile_id = None):
+        #?Proxy host port used to connect to remote host.;0-65535
+        return self.profileIntValue('snapshots.ssh.proxy_host_port', 22, profile_id)
+
+    def setSshProxyPort(self, value, profile_id = None):
+        self.setProfileIntValue('snapshots.ssh.proxy_host_port', value, profile_id)
+
+    def sshProxyUser(self, profile_id = None):
+        #?Remote SSH user;;local users name
+        return self.profileStrValue('snapshots.ssh.proxy_user', self.user(), profile_id)
+
+    def setSshProxyUser(self, value, profile_id = None):
+        self.setProfileStrValue('snapshots.ssh.proxy_user', value, profile_id)
+
     def sshMaxArgLength(self, profile_id = None):
         #?Maximum command length of commands run on remote host. This can be tested
         #?for all ssh profiles in the configuration
@@ -745,6 +766,13 @@ class Config(configfile.ConfigFileWithProfiles):
         assert custom_args is None or isinstance(custom_args, list), "custom_args '{}' is not list instance".format(custom_args)
         ssh  = ['ssh']
         ssh += self.sshDefaultArgs(profile_id)
+
+        if self.sshProxyHost(profile_id):
+            ssh += ['-J', '{}@{}:{}'.format(
+                self.sshProxyUser(profile_id),
+                self.sshProxyHost(profile_id),
+                self.sshProxyPort(profile_id)
+            )]
         # remote port
         if port:
             ssh += ['-p', str(self.sshPort(profile_id))]
@@ -777,6 +805,8 @@ class Config(configfile.ConfigFileWithProfiles):
         # close quote
         if quote and cmd:
             ssh.append("'")
+
+        logger.debug('SSH command: %s' % ' '.join(ssh), self)
 
         return ssh
 

--- a/common/config.py
+++ b/common/config.py
@@ -666,11 +666,13 @@ class Config(configfile.ConfigFileWithProfiles):
             'snapshots.ssh.proxy_host_port', '22', profile_id)
 
     def setSshProxyPort(self, value, profile_id = None):
-        self.setProfileIntValue('snapshots.ssh.proxy_host_port', value, profile_id)
+        self.setProfileIntValue(
+            'snapshots.ssh.proxy_host_port', value, profile_id)
 
     def sshProxyUser(self, profile_id=None):
         #?Remote SSH user;;local users name
-        return self.profileStrValue('snapshots.ssh.proxy_user', self.user(), profile_id)
+        return self.profileStrValue(
+            'snapshots.ssh.proxy_user', getpass.getuser(), profile_id)
 
     def setSshProxyUser(self, value, profile_id=None):
         self.setProfileStrValue('snapshots.ssh.proxy_user', value, profile_id)

--- a/common/config.py
+++ b/common/config.py
@@ -668,25 +668,26 @@ class Config(configfile.ConfigFileWithProfiles):
     def setSshPrivateKeyFile(self, value, profile_id = None):
         self.setProfileStrValue('snapshots.ssh.private_key_file', value, profile_id)
 
-    def sshProxyHost(self, profile_id = None):
+    def sshProxyHost(self, profile_id=None):
         #?Proxy host used to connect to remote host.;;IP or domain address
         return self.profileStrValue('snapshots.ssh.proxy_host', '', profile_id)
 
-    def setSshProxyHost(self, value, profile_id = None):
+    def setSshProxyHost(self, value, profile_id=None):
         self.setProfileStrValue('snapshots.ssh.proxy_host', value, profile_id)
 
-    def sshProxyPort(self, profile_id = None):
+    def sshProxyPort(self, profile_id=None):
         #?Proxy host port used to connect to remote host.;0-65535
-        return self.profileIntValue('snapshots.ssh.proxy_host_port', 22, profile_id)
+        return self.profileIntValue(
+            'snapshots.ssh.proxy_host_port', '22', profile_id)
 
     def setSshProxyPort(self, value, profile_id = None):
         self.setProfileIntValue('snapshots.ssh.proxy_host_port', value, profile_id)
 
-    def sshProxyUser(self, profile_id = None):
+    def sshProxyUser(self, profile_id=None):
         #?Remote SSH user;;local users name
         return self.profileStrValue('snapshots.ssh.proxy_user', self.user(), profile_id)
 
-    def setSshProxyUser(self, value, profile_id = None):
+    def setSshProxyUser(self, value, profile_id=None):
         self.setProfileStrValue('snapshots.ssh.proxy_user', value, profile_id)
 
     def sshMaxArgLength(self, profile_id = None):

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -732,8 +732,9 @@ class Snapshots:
             self.config.PLUGIN_MANAGER.error(1)
 
         elif (not force
-                  and self.config.noSnapshotOnBattery()
-                  and tools.onBattery()):
+              and self.config.noSnapshotOnBattery()
+              and tools.onBattery()):
+
             self.setTakeSnapshotMessage(
                 0, _('Deferring backup while on battery'))
             logger.info('Deferring backup while on battery', self)
@@ -761,7 +762,7 @@ class Snapshots:
                 logger.warning(
                     'A backup is already running. The pid of the already '
                     f'running backup is in file {instance.pidFile}. Maybe '
-                    'delete it.', self )
+                    'delete it.', self)
 
                 # a backup is already running
                 self.config.PLUGIN_MANAGER.error(2)
@@ -773,7 +774,7 @@ class Snapshots:
                     f'{restore_instance.pidFile}. Maybe delete it.', self)
 
             else:
-                if (self.config.noSnapshotOnBattery ()
+                if (self.config.noSnapshotOnBattery()
                         and not tools.powerStatusAvailable()):
                     logger.warning('Backups disabled on battery but power '
                                    'status is not available', self)
@@ -793,7 +794,7 @@ class Snapshots:
 
                 # mount
                 try:
-                    hash_id = mount.Mount(cfg = self.config).mount()
+                    hash_id = mount.Mount(cfg=self.config).mount()
 
                 except MountException as ex:
                     logger.error(str(ex), self)
@@ -948,9 +949,6 @@ class Snapshots:
 
                 if not ret_error:
                     self.clearTakeSnapshotMessage()
-
-                # QUESTION - unmounting at the end of backup breaks snapshot list,
-                # why is this happening?
 
                 # unmount
                 try:

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -3034,8 +3034,7 @@ class RootSnapshot(GenericNonSnapshot):
 
 def iterSnapshots(cfg, includeNewSnapshot = False):
     """
-    Iterate over snapshots in current snapshot path. Use this in a 'for' loop
-    for faster processing than list object
+    A generator to iterate over snapshots in current snapshot path.
 
     Args:
         cfg (config.Config):        current config
@@ -3046,21 +3045,33 @@ def iterSnapshots(cfg, includeNewSnapshot = False):
         SID:                        snapshot IDs
     """
     path = cfg.snapshotsFullPath()
+
     if not os.path.exists(path):
         return None
+
     for item in os.listdir(path):
+
         if item == NewSnapshot.NEWSNAPSHOT:
             newSid = NewSnapshot(cfg)
+
             if newSid.exists() and includeNewSnapshot:
                 yield newSid
+
             continue
+
         try:
             sid = SID(item, cfg)
+
             if sid.exists():
                 yield sid
+
+        # REFACTOR!
+        # LastSnapshotSymlink is an exception instance and could be catched
+        # explicit. But not sure about its purpose.
         except Exception as e:
             if not isinstance(e, LastSnapshotSymlink):
-                logger.debug("'{}' is not a snapshot ID: {}".format(item, str(e)))
+                logger.debug(
+                    "'{}' is not a snapshot ID: {}".format(item, str(e)))
 
 
 def listSnapshots(cfg, includeNewSnapshot = False, reverse = True):

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -950,6 +950,9 @@ class Snapshots:
                 if not ret_error:
                     self.clearTakeSnapshotMessage()
 
+                # QUESTION - unmounting at the end of backup breaks snapshot list,
+                # why is this happening?
+
                 # unmount
                 try:
                     mount.Mount(cfg = self.config).umount(self.config.current_hash_id)

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -23,6 +23,7 @@ import socket
 import re
 import atexit
 import signal
+from pathlib import Path
 from time import sleep
 import logger
 import tools
@@ -1067,7 +1068,7 @@ def sshCopyIdCommand(
     port='22',
     proxy_user=None,
     proxy_host=None,
-    proxy_port=None,
+    proxy_port='22',
     cipher=None
 ):
     """
@@ -1087,7 +1088,7 @@ def sshCopyIdCommand(
     Returns:
         list: The ssh-copy-id command as a list.
     """
-    if not os.path.exists(pubkey):
+    if not Path(pubkey).exists():
         logger.warning(f'SSH public key "{pubkey}" does not exist. '
                        'Skip copy to remote host')
 

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+import random
 import subprocess
 import stat
 import shutil
@@ -399,43 +400,60 @@ class TestStartSshAgent(generic.SSHTestCase):
             self.ssh.startSshAgent()
 
 
-class SSHCopyIDTestCase(unittest.TestCase):
-
-    def test_ssh_copy_id_command_default_port(self):
+class SSHCopyID(unittest.TestCase):
+    def test_complete_command(self):
+        """Complete generated command"""
         command = sshtools.sshCopyIdCommand(
             generic.PRIV_KEY_FILE,
             'user',
             'non_existing_host',
-        )
-        self.assertEqual(
-            command,
-            ['ssh-copy-id', '-i', generic.PRIV_KEY_FILE, '-p', '22', 'user@non_existing_host']
-        )
-
-    def test_ssh_copy_id_command_custom_port(self):
-        command = sshtools.sshCopyIdCommand(
-            generic.PRIV_KEY_FILE,
-            'user',
-            'non_existing_host',
-            port='23'
-        )
-        self.assertEqual(
-            command,
-            ['ssh-copy-id', '-i', generic.PRIV_KEY_FILE, '-p', '23', 'user@non_existing_host']
-        )
-
-    def test_ssh_copy_id_command_with_proxy(self):
-        command = sshtools.sshCopyIdCommand(
-            generic.PRIV_KEY_FILE,
-            'user',
-            'non_existing_host',
-            proxy_user='non_existing_proxy_user',
-            proxy_host='non_existing_proxy_host',
-            proxy_port='24',
         )
         self.assertEqual(
             command,
             [
-                'ssh-copy-id', '-i', generic.PRIV_KEY_FILE, '-p', '22', '-o',
-                'ProxyJump=non_existing_proxy_user@non_existing_proxy_host:24', 'user@non_existing_host']
+                'ssh-copy-id',
+                '-i',
+                generic.PRIV_KEY_FILE,
+                '-p',
+                '22',
+                'user@non_existing_host'
+            ]
+        )
+
+    def test_default_port(self):
+        """Default port used"""
+        command = sshtools.sshCopyIdCommand(
+            generic.PRIV_KEY_FILE,
+            'user',
+            'non_existing_host',
+        )
+        self.assertEqual(command[4], '22')
+
+    def test_custom_port(self):
+        """Custom (random) port"""
+        custom_port = str(random.randint(23, 128))
+
+        sut = sshtools.sshCopyIdCommand(
+            generic.PRIV_KEY_FILE,
+            'user',
+            'non_existing_host',
+            port=custom_port
+        )
+        self.assertEqual(sut[4], custom_port)
+
+    def test_ssh_copy_id_command_with_proxy(self):
+        """Used proxy"""
+        proxy_user = 'non_existing_proxy_user'
+        proxy_host = 'non_existing_proxy_host'
+
+        sut = sshtools.sshCopyIdCommand(
+            generic.PRIV_KEY_FILE,
+            'user',
+            'non_existing_host',
+            proxy_user=proxy_user,
+            proxy_host=proxy_host
+        )
+
+        self.assertTrue(sut[6].startswith(
+            'ProxyJump=non_existing_proxy_user@non_existing_proxy_host')
         )

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -415,20 +415,22 @@ class SSHCopyID(unittest.TestCase):
                 'ssh-copy-id',
                 '-i',
                 generic.PRIV_KEY_FILE,
+                '-p',
+                '22',
                 'user@non_existing_host'
             ]
         )
 
     def test_default_port(self):
-        """Default port decided by ssh itself"""
+        """Default port"""
         sut = sshtools.sshCopyIdCommand(
             generic.PRIV_KEY_FILE,
             'user',
             'non_existing_host',
         )
-        self.assertEqual(len(sut), 4)
+        self.assertEqual(len(sut), 6, sut)
         # no port explicit specified
-        self.assertNotIn('-p', sut)
+        self.assertEqual(sut[4], '22')
 
     def test_custom_port(self):
         """Custom (random) port"""
@@ -457,7 +459,7 @@ class SSHCopyID(unittest.TestCase):
         )
 
         self.assertIn(
-            'ProxyJump=non_existing_proxy_user@non_existing_proxy_host',
+            'ProxyJump=non_existing_proxy_user@non_existing_proxy_host:22',
             sut)
 
     def test_proxy_with_custom_port(self):

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -34,6 +34,7 @@ import sshtools
 import tools
 from exceptions import MountException
 
+
 @unittest.skipIf(not generic.LOCAL_SSH, 'Skip as this test requires a local ssh server, public and private keys installed')
 class TestSSH(generic.SSHTestCase):
     # running this test requires that user has public / private key pair created and ssh server running
@@ -396,3 +397,45 @@ class TestStartSshAgent(generic.SSHTestCase):
         mockWhich.return_value = ''
         with self.assertRaises(MountException):
             self.ssh.startSshAgent()
+
+
+class SSHCopyIDTestCase(unittest.TestCase):
+
+    def test_ssh_copy_id_command_default_port(self):
+        command = sshtools.sshCopyIdCommand(
+            generic.PRIV_KEY_FILE,
+            'user',
+            'non_existing_host',
+        )
+        self.assertEqual(
+            command,
+            ['ssh-copy-id', '-i', generic.PRIV_KEY_FILE, '-p', '22', 'user@non_existing_host']
+        )
+
+    def test_ssh_copy_id_command_custom_port(self):
+        command = sshtools.sshCopyIdCommand(
+            generic.PRIV_KEY_FILE,
+            'user',
+            'non_existing_host',
+            port='23'
+        )
+        self.assertEqual(
+            command,
+            ['ssh-copy-id', '-i', generic.PRIV_KEY_FILE, '-p', '23', 'user@non_existing_host']
+        )
+
+    def test_ssh_copy_id_command_with_proxy(self):
+        command = sshtools.sshCopyIdCommand(
+            generic.PRIV_KEY_FILE,
+            'user',
+            'non_existing_host',
+            proxy_user='non_existing_proxy_user',
+            proxy_host='non_existing_proxy_host',
+            proxy_port='24',
+        )
+        self.assertEqual(
+            command,
+            [
+                'ssh-copy-id', '-i', generic.PRIV_KEY_FILE, '-p', '22', '-o',
+                'ProxyJump=non_existing_proxy_user@non_existing_proxy_host:24', 'user@non_existing_host']
+        )

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -480,4 +480,4 @@ class SSHCopyID(unittest.TestCase):
         self.assertIn(
             'ProxyJump=non_existing_proxy_user@non_existing_proxy_host'
             f':{proxy_port}',
-            sut,)
+            sut)

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -441,7 +441,7 @@ class SSHCopyID(unittest.TestCase):
         )
         self.assertEqual(sut[4], custom_port)
 
-    def test_ssh_copy_id_command_with_proxy(self):
+    def test_proxy(self):
         """Used proxy"""
         proxy_user = 'non_existing_proxy_user'
         proxy_host = 'non_existing_proxy_host'

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -30,14 +30,29 @@
 """
 import os
 import sys
-
+import textwrap
+from typing import Union, Iterable
 from PyQt6.QtGui import (QAction, QFont, QPalette, QIcon)
-from PyQt6.QtCore import (QDir, Qt, pyqtSlot, pyqtSignal, QModelIndex,
-                          QTranslator, QLocale, QLibraryInfo,
+from PyQt6.QtCore import (QDir,
+                          Qt,
+                          pyqtSlot,
+                          pyqtSignal,
+                          QModelIndex,
+                          QTranslator,
+                          QLocale,
+                          QLibraryInfo,
                           QT_VERSION_STR)
-from PyQt6.QtWidgets import (QFileDialog, QAbstractItemView, QListView,
-                             QTreeView, QDialog, QApplication, QStyleFactory,
-                             QTreeWidget, QTreeWidgetItem, QComboBox,
+from PyQt6.QtWidgets import (QWidget,
+                             QFileDialog,
+                             QAbstractItemView,
+                             QListView,
+                             QTreeView,
+                             QDialog,
+                             QApplication,
+                             QStyleFactory,
+                             QTreeWidget,
+                             QTreeWidgetItem,
+                             QComboBox,
                              QSystemTrayIcon)
 from datetime import (datetime, date, timedelta)
 from calendar import monthrange
@@ -92,6 +107,34 @@ def can_render(string, widget):
             return False
 
     return True
+
+
+# |--------------------------------|
+# | Widget modification & creation |
+# |--------------------------------|
+
+def set_wrapped_tooltip(widget: QWidget,
+                        tooltip: Union[str, Iterable[str]],
+                        wrap_length: int=72):
+    """Add a tooltip to the widget but insert line breaks when appropriated.
+
+    If a list of strings is provided, each string is wrapped individually and
+    then joined with a line break.
+
+    Args:
+        widget: The widget to which a tooltip should be added.
+        tooltip: The tooltip as string or iterable of strings.
+        wrap_length: Every line is at most this lengths.
+    """
+    # Always use tuple or list
+    if isinstance(tooltip, str):
+        tooltip = (tooltip, )
+
+    result = []
+    for paragraph in tooltip:
+        result.append('\n'.join(textwrap.wrap(paragraph, wrap_length)))
+
+    widget.setToolTip('\n'.join(result))
 
 
 # |---------------------|

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -119,9 +119,9 @@ class SshProxyWidget(QWidget):
     def _slot_checkbox_changed(self, state):
         if Qt.CheckState(state) == Qt.CheckState.Checked:
             self._enable()
-            self._set_default()
         else:
             self._disable()
+            self._set_default()
 
     def _set_default(self):
         self.host_edit.setText('')

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -264,6 +264,34 @@ class SettingsDialog(QDialog):
                             self.lblSshPath,
                             self.lblSshCipher)
 
+
+        self.lblProxySubtitle = QLabel(
+            "<b>{}</b>:".format(
+                _("SSH Proxy (optional)"),
+            ),
+            self
+        )
+        self.lblProxySubtitle.setWordWrap(True)
+        vlayout.addWidget(self.lblProxySubtitle)
+
+        hlayout_ssh_proxy = QHBoxLayout()
+        vlayout.addLayout(hlayout_ssh_proxy)
+        self.lblSshProxyHost = QLabel(_('Host') + ':', self)
+        hlayout_ssh_proxy.addWidget(self.lblSshProxyHost)
+        self.txtSshProxyHost = QLineEdit(self)
+        hlayout_ssh_proxy.addWidget(self.txtSshProxyHost)
+
+        self.lblSshProxyPort = QLabel(_('Port') + ':', self)
+        hlayout_ssh_proxy.addWidget(self.lblSshProxyPort)
+        self.txtSshProxyPort = QLineEdit(self)
+        hlayout_ssh_proxy.addWidget(self.txtSshProxyPort)
+
+        self.lblSshProxyUser = QLabel(_('User') + ':', self)
+        hlayout_ssh_proxy.addWidget(self.lblSshProxyUser)
+        self.txtSshProxyUser = QLineEdit(self)
+        hlayout_ssh_proxy.addWidget(self.txtSshProxyUser)
+
+
         # encfs
         self.modeLocalEncfs = self.modeLocal
         self.modeSshEncfs = self.modeSsh
@@ -1300,6 +1328,9 @@ class SettingsDialog(QDialog):
         self.txtSshHost.setText(self.config.sshHost())
         self.txtSshPort.setText(str(self.config.sshPort()))
         self.txtSshUser.setText(self.config.sshUser())
+        self.txtSshProxyHost.setText(self.config.sshProxyHost())
+        self.txtSshProxyPort.setText(str(self.config.sshProxyPort()))
+        self.txtSshProxyUser.setText(self.config.sshProxyUser())
         self.txtSshPath.setText(self.config.sshSnapshotsPath())
         self.setComboValue(self.comboSshCipher,
                            self.config.sshCipher(),
@@ -1500,6 +1531,9 @@ class SettingsDialog(QDialog):
         self.config.setSshHost(self.txtSshHost.text())
         self.config.setSshPort(self.txtSshPort.text())
         self.config.setSshUser(self.txtSshUser.text())
+        self.config.setSshProxyHost(self.txtSshProxyHost.text())
+        self.config.setSshProxyPort(self.txtSshProxyPort.text())
+        self.config.setSshProxyUser(self.txtSshProxyUser.text())
         self.config.setSshSnapshotsPath(self.txtSshPath.text())
         self.config.setSshCipher(
             self.comboSshCipher.itemData(self.comboSshCipher.currentIndex()))
@@ -1680,6 +1714,9 @@ class SettingsDialog(QDialog):
                     self.config.sshUser(),
                     self.config.sshHost(),
                     port=str(self.config.sshPort()),
+                    proxy_user=self.config.sshProxyUser(),
+                    proxy_host=self.config.sshProxyHost(),
+                    proxy_port=self.config.sshProxyPort(),
                     askPass=tools.which('backintime-askpass'),
                     cipher=self.config.sshCipher()
                 )

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -121,7 +121,6 @@ class SshProxyWidget(QWidget):
             self._enable()
         else:
             self._disable()
-            self._set_default()
 
     def _set_default(self):
         self.host_edit.setText('')
@@ -129,6 +128,7 @@ class SshProxyWidget(QWidget):
         self.user_edit.setText(getpass.getuser())
 
     def _disable(self):
+        self._set_default()
         self._enable(False)
 
     def _enable(self, enable=True):

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -189,7 +189,7 @@ class SettingsDialog(QDialog):
         hlayout.addWidget(self.btnSnapshotsPath)
         self.btnSnapshotsPath.clicked.connect(self.btnSnapshotsPathClicked)
 
-        # SSH
+        # --- SSH ---
         groupBox = QGroupBox(self)
         self.modeSsh = groupBox
         groupBox.setTitle(_('SSH Settings'))
@@ -256,6 +256,7 @@ class SettingsDialog(QDialog):
         self.btnSshKeyGen.setMinimumSize(32, 28)
         hlayout3.addWidget(self.btnSshKeyGen)
         self.btnSshKeyGen.clicked.connect(self.btnSshKeyGenClicked)
+
         # Disable SSH key generation button if a key file is already set
         self.txtSshPrivateKeyFile.textChanged \
             .connect(lambda x: self.btnSshKeyGen.setEnabled(not x))
@@ -264,33 +265,8 @@ class SettingsDialog(QDialog):
                             self.lblSshPath,
                             self.lblSshCipher)
 
-
-        self.lblProxySubtitle = QLabel(
-            "<b>{}</b>:".format(
-                _("SSH Proxy (optional)"),
-            ),
-            self
-        )
-        self.lblProxySubtitle.setWordWrap(True)
-        vlayout.addWidget(self.lblProxySubtitle)
-
-        hlayout_ssh_proxy = QHBoxLayout()
-        vlayout.addLayout(hlayout_ssh_proxy)
-        self.lblSshProxyHost = QLabel(_('Host') + ':', self)
-        hlayout_ssh_proxy.addWidget(self.lblSshProxyHost)
-        self.txtSshProxyHost = QLineEdit(self)
-        hlayout_ssh_proxy.addWidget(self.txtSshProxyHost)
-
-        self.lblSshProxyPort = QLabel(_('Port') + ':', self)
-        hlayout_ssh_proxy.addWidget(self.lblSshProxyPort)
-        self.txtSshProxyPort = QLineEdit(self)
-        hlayout_ssh_proxy.addWidget(self.txtSshProxyPort)
-
-        self.lblSshProxyUser = QLabel(_('User') + ':', self)
-        hlayout_ssh_proxy.addWidget(self.lblSshProxyUser)
-        self.txtSshProxyUser = QLineEdit(self)
-        hlayout_ssh_proxy.addWidget(self.txtSshProxyUser)
-
+        self.wdgSshProxy = self._create_widget_ssh_proxy()
+        vlayout.addWidget(self.wdgSshProxy)
 
         # encfs
         self.modeLocalEncfs = self.modeLocal
@@ -1158,6 +1134,37 @@ class SettingsDialog(QDialog):
 
         self.finished.connect(self.cleanup)
 
+    def _create_widget_ssh_proxy(self):
+        """
+        Dev note by buhtz (2024-04): Just a quick n dirty solution until the
+        re-design and re-factoring of the whole dialog.
+        """
+        widget = QWidget(self)
+        vlayout = QVBoxLayout(widget)
+        # zero margins
+        vlayout.setContentsMargins(0, 0, 0, 0)
+
+        label = QLabel(_('SSH Proxy (optional)'), widget)
+        label.setWordWrap(True)
+        vlayout.addWidget(label)
+
+        hlayout = QHBoxLayout()
+        vlayout.addLayout(hlayout)
+
+        hlayout.addWidget(QLabel(_('Host:'), widget))
+        self.txtSshProxyHost = QLineEdit(widget)
+        hlayout.addWidget(self.txtSshProxyHost)
+
+        hlayout.addWidget(QLabel(_('Port:'), widget))
+        self.txtSshProxyPort = QLineEdit(widget)
+        hlayout.addWidget(self.txtSshProxyPort)
+
+        hlayout.addWidget(QLabel(_('User:'), widget))
+        self.txtSshProxyUser = QLineEdit(widget)
+        hlayout.addWidget(self.txtSshProxyUser)
+
+        return widget
+
     def addProfile(self):
         ret_val = QInputDialog.getText(self, _('New profile'), str())
         if not ret_val[1]:
@@ -1324,13 +1331,15 @@ class SettingsDialog(QDialog):
         self.editSnapshotsPath.setText(
             self.config.snapshotsPath(mode='local'))
 
-        # ssh
+        # SSH
         self.txtSshHost.setText(self.config.sshHost())
         self.txtSshPort.setText(str(self.config.sshPort()))
         self.txtSshUser.setText(self.config.sshUser())
         self.txtSshProxyHost.setText(self.config.sshProxyHost())
         self.txtSshProxyPort.setText(str(self.config.sshProxyPort()))
         self.txtSshProxyUser.setText(self.config.sshProxyUser())
+        print(f'{self.config.sshProxyHost()=}')
+        self.wdgSshProxy.setEnabled(self.config.sshProxyHost() != '')
         self.txtSshPath.setText(self.config.sshSnapshotsPath())
         self.setComboValue(self.comboSshCipher,
                            self.config.sshCipher(),

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -73,9 +73,6 @@ import sshtools
 import logger
 from exceptions import MountException, NoPubKeyLogin, KnownHost
 
-# That value is used to wrap tooltip strings (inserting newline characters).
-_TOOLTIP_WRAP_LENGTH = 72
-
 
 class SshProxyWidget(QWidget):
     """Used in SSH snapshot profiles on the General tab.
@@ -94,7 +91,7 @@ class SshProxyWidget(QWidget):
         # zero margins
         vlayout.setContentsMargins(0, 0, 0, 0)
 
-        checkbox = QCheckBox(_('SSH Proxy (optional)'), self)
+        checkbox = QCheckBox(_('SSH Proxy'), self)
         vlayout.addWidget(checkbox)
         checkbox.stateChanged.connect(self._slot_checkbox_changed)
 
@@ -116,6 +113,12 @@ class SshProxyWidget(QWidget):
         if host == '':
             self._disable()
 
+        qttools.set_wrapped_tooltip(
+            self,
+            'Connect to the target host via this proxy (also known as a jump '
+            'host). See "-J" in the "ssh" command documentation or '
+            '"ProxyJump" in "ssh_config" man page for details.')
+
     def _slot_checkbox_changed(self, state):
         if Qt.CheckState(state) == Qt.CheckState.Checked:
             self._enable()
@@ -135,7 +138,6 @@ class SshProxyWidget(QWidget):
         # QEdit and QLabel's
         lay = self.layout().itemAt(1)
         for idx in range(lay.count()):
-            print(lay.itemAt(idx).widget())
             lay.itemAt(idx).widget().setEnabled(enable)
 
     def values(self):
@@ -1106,10 +1108,11 @@ class SettingsDialog(QDialog):
         # one file system option
         self.cbOneFileSystem = QCheckBox(
             _('Restrict to one file system'), self)
-        self.cbOneFileSystem.setToolTip(
-            'uses \'rsync --one-file-system\'\n'
-            'From \'man rsync\':\n'
-            + '\n'.join(textwrap.wrap(
+        qttools.set_wrapped_tooltip(
+            self.cbOneFileSystem,
+            [
+                'uses \'rsync --one-file-system\'',
+                'From \'man rsync\':',
                 'This tells rsync to avoid crossing a filesystem boundary '
                 'when recursing. This does not limit the user\'s ability '
                 'to specify items to copy from multiple filesystems, just '
@@ -1117,8 +1120,8 @@ class SettingsDialog(QDialog):
                 'that the user specified, and also the analogous recursion '
                 'on the receiving side during deletion. Also keep in mind '
                 'that rsync treats a "bind" mount to the same device as '
-                'being on the same filesystem.',
-                _TOOLTIP_WRAP_LENGTH))
+                'being on the same filesystem.'
+            ]
         )
         layout.addWidget(self.cbOneFileSystem)
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -23,7 +23,6 @@ import copy
 import re
 import getpass
 import textwrap
-
 from PyQt6.QtGui import (QIcon,
                          QFont,
                          QPalette,


### PR DESCRIPTION
Implemented options for using a proxy/bastion host with SSH backups.
First contribution so please let me know if you are happy with the style, I've tried to maintain the existing style but balance it with pep8 where possible. I think I caught all the places that are required for this but this is my first dive into this codebase so I wouldn't be surprised if I missed some things.

I separated out the ssh-copy-id command generation into its own function so I can run tests on it. I was thinking of doing the same for the ssh default args - let me know what you think.

![image](https://github.com/bit-team/backintime/assets/929802/35079b38-51b4-41cc-96fb-e9ffd1b9484d)

This is my first time working with any desktop UI, more than open to suggestions of how it should work. I tried to be consistent with the rest of the dialog, however I think a checkbox or similar might be good for enabling these options.


Additionally, when doing a snapshot I found that because the `backup` method unmounts the mount at the end, the snapshot list no longer works and shows only "Now". If I comment the unmount out, it works as expected and shows the existing and new snapshots in the list. Is this a known issue?