### PR TITLE
refactor!: Remove tools.syncfs()

### DIFF
--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -430,9 +430,6 @@ class TestTools(generic.TestCase):
         self.assertIn('/', mounts)
         self.assertIn('original_uuid', mounts.get('/'))
 
-    def test_syncfs(self):
-        self.assertTrue(tools.syncfs())
-
     def test_isRoot(self):
         self.assertIsInstance(tools.isRoot(), bool)
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -89,6 +89,7 @@ DISK_BY_UUID = '/dev/disk/by-uuid'
 # | Handling paths  |
 # |-----------------|
 
+
 def sharePath():
     """Get path where Back In Time is installed.
 
@@ -110,6 +111,7 @@ def sharePath():
         return share
 
     return '/usr/share'
+
 
 def backintimePath(*path):
     """
@@ -349,8 +351,10 @@ def registerBackintimePath(*path):
         would need this to actually import :py:mod:`tools`.
     """
     path = backintimePath(*path)
-    if not path in sys.path:
+
+    if path not in sys.path:
         sys.path.insert(0, path)
+
 
 def runningFromSource():
     """
@@ -361,6 +365,7 @@ def runningFromSource():
     """
     return os.path.isfile(backintimePath('common', 'backintime'))
 
+
 def addSourceToPathEnviron():
     """
     Add 'backintime/common' path to 'PATH' environ variable.
@@ -368,7 +373,8 @@ def addSourceToPathEnviron():
     source = backintimePath('common')
     path = os.getenv('PATH')
     if path and source not in path.split(':'):
-        os.environ['PATH'] = '%s:%s' %(source, path)
+        os.environ['PATH'] = '%s:%s' % (source, path)
+
 
 def get_git_repository_info(path=None, hash_length=None):
     """Return the current branch and last commit hash.
@@ -456,6 +462,7 @@ def readFile(path, default=None):
 
     return ret_val
 
+
 def readFileLines(path, default = None):
     """
     Read the file in ``path`` or its '.gz' compressed variant and return its
@@ -484,6 +491,7 @@ def readFileLines(path, default = None):
 
     return ret_val
 
+
 def checkCommand(cmd):
     """
     Check if command ``cmd`` is a file in 'PATH' environ.
@@ -501,7 +509,9 @@ def checkCommand(cmd):
 
     if os.path.isfile(cmd):
         return True
+
     return not which(cmd) is None
+
 
 def which(cmd):
     """
@@ -518,13 +528,18 @@ def which(cmd):
     pathenv = os.getenv('PATH', '')
     path = pathenv.split(":")
     common = backintimePath('common')
+
     if runningFromSource() and common not in path:
         path.insert(0, common)
+
     for directory in path:
         fullpath = os.path.join(directory, cmd)
+
         if os.path.isfile(fullpath) and os.access(fullpath, os.X_OK):
             return fullpath
+
     return None
+
 
 def makeDirs(path):
     """
@@ -542,15 +557,19 @@ def makeDirs(path):
 
     if os.path.isdir(path):
         return True
+
     else:
+
         try:
             os.makedirs(path)
         except Exception as e:
             logger.error("Failed to make dirs '%s': %s"
-                         %(path, str(e)), traceDepth = 1)
+                         % (path, str(e)), traceDepth=1)
+
     return os.path.isdir(path)
 
-def mkdir(path, mode = 0o755, enforce_permissions = True):
+
+def mkdir(path, mode=0o755, enforce_permissions=True):
     """
     Create directory ``path``.
 
@@ -567,14 +586,18 @@ def mkdir(path, mode = 0o755, enforce_permissions = True):
                 os.chmod(path, mode)
         except:
             return False
+
         return True
+
     else:
         os.mkdir(path, mode)
+
         if mode & 0o002 == 0o002:
-            #make file world (other) writable was requested
-            #debian and ubuntu won't set o+w with os.mkdir
-            #this will fix it
+            # make file world (other) writable was requested
+            # debian and ubuntu won't set o+w with os.mkdir
+            # this will fix it
             os.chmod(path, mode)
+
     return os.path.isdir(path)
 
 
@@ -1105,6 +1128,7 @@ def checkCronPattern(s):
     except ValueError:
         return False
 
+
 #TODO: check if this is still necessary
 def checkHomeEncrypt():
     """
@@ -1131,6 +1155,7 @@ def checkHomeEncrypt():
                 return True
     return False
 
+
 def envLoad(f):
     """
     Load environ variables from file ``f`` into current environ.
@@ -1150,6 +1175,7 @@ def envLoad(f):
             os.environ[key] = value
     del(env_file)
 
+
 def envSave(f):
     """
     Save environ variables to file that are needed by cron
@@ -1168,6 +1194,7 @@ def envSave(f):
             env_file.setStrValue(key, env[key])
 
     env_file.save(f)
+
 
 def keyringSupported():
     """
@@ -1275,11 +1302,13 @@ def password(*args):
         return keyring.get_password(*args)
     return None
 
+
 def setPassword(*args):
 
     if is_keyring_available:
         return keyring.set_password(*args)
     return False
+
 
 def mountpoint(path):
     """
@@ -1317,6 +1346,7 @@ def decodeOctalEscape(s):
     def repl(m):
         return chr(int(m.group(1), 8))
     return re.sub(r'\\(\d{3})', repl, s)
+
 
 def mountArgs(path):
     """
@@ -1543,16 +1573,6 @@ def filesystemMountInfo():
                 [mount_line.strip('\n').split(' ')[:2] for mount_line in mounts]
                 if uuidFromDev(items[0]) != None}
 
-
-def syncfs():
-    """
-    Sync any data buffered in memory to disk.
-
-    Returns:
-        bool:   ``True`` if successful
-    """
-    if checkCommand('sync'):
-        return(Execute(['sync']).run() == 0)
 
 def isRoot():
     """
@@ -1887,6 +1907,7 @@ def fdDup(old, new_fd, mode = 'w'):
     except OSError as e:
         logger.debug('Failed to redirect {}: {}'.format(old, str(e)))
 
+
 class UniquenessSet:
     """
     Check for uniqueness or equality of files.
@@ -2003,6 +2024,7 @@ class UniquenessSet:
         else:
             return self.reference == (st.st_size, int(st.st_mtime))
 
+
 class Alarm(object):
     """
     Establish a callback function that is called after a timeout.
@@ -2077,6 +2099,7 @@ class Alarm(object):
             raise Timeout()
         else:
             self.callback()
+
 
 class ShutDown(object):
     """
@@ -2237,7 +2260,6 @@ class ShutDown(object):
             return(False)
 
         if self.is_root:
-            syncfs()
             self.started = True
             proc = subprocess.Popen(['shutdown', '-h', 'now'])
             proc.communicate()
@@ -2247,7 +2269,6 @@ class ShutDown(object):
             return(False)
 
         else:
-            syncfs()
             self.started = True
 
             return(self.proxy(*self.args))
@@ -2343,6 +2364,7 @@ class SetupUdev(object):
             return
         self.iface.clean()
 
+
 class PathHistory(object):
     def __init__(self, path):
         self.history = [path,]
@@ -2376,6 +2398,7 @@ class PathHistory(object):
     def reset(self, path):
         self.history = [path,]
         self.index = 0
+
 
 class OrderedSet(MutableSet):
     """
@@ -2437,6 +2460,7 @@ class OrderedSet(MutableSet):
         if isinstance(other, OrderedSet):
             return len(self) == len(other) and list(self) == list(other)
         return set(self) == set(other)
+
 
 class Execute(object):
     """
@@ -2642,6 +2666,7 @@ class Execute(object):
         if self.pausable and self.currentProc:
             logger.info('Kill process "%s"' %self.printable_cmd, self.parent, 2)
             return self.currentProc.kill()
+
 
 class Daemon:
     """


### PR DESCRIPTION
Remove the function `tools.syncfs()` and its unit test. It was used in `shutdown()` only. Shutodwn cause an unmount which itself cause synfs on OS level. No need for BIT to do it explict. Additionally minor PEP8 improvements.

No changelog because the modification do not modify, break or remove existing behavior in BIT.

Close #1685 