### PR TITLE
doc(README): Remove known problem about "apt-key keyring" / Copyright adjustments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,24 @@ Alternatively use `make test-v` for a more verbose output. The `make` system
 will use `pytest` as test runner if available otherwise Python's own `unittest`
 module.
 
+## SSH
+
+Some tests require an available SSH server. They get skipped if this is not the
+case. The goal is to log into the SSH server on your local computer via
+`ssh localhost` without using a password:
+
+- Generate an RSA key pair executing `ssh-keygen`. Use the default file name
+  and don't use a passphrase for the key.
+- Populate the public key to the server executing `ssh-copy-id`.
+- Make the `ssh` instance run.
+- The port `22` (SSH default) should be available.
+
+To test the connection just execute `ssh localhost` and you should see an
+SSH shell **without** being asked for a password.
+
+For detailed setup instructions see the
+[how to setup openssh for unit tests](common/doc-dev/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md).
+
 # Further reading
 - https://www.contribution-guide.org
 - https://mozillascience.github.io/working-open-workshop/contributing

--- a/FAQ.md
+++ b/FAQ.md
@@ -1057,5 +1057,5 @@ a SSH server on your system.
 
 ### Setup SSH Server to run unit tests
 
-Please see section [Testing & Building](CONTRIBUTING.md#testing--building).
+Please see section [Testing - SSH](CONTRIBUTING.md#testing).
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -1051,24 +1051,11 @@ A solution is described in
 
 ### SSH related tests are skipped
 
-Some tests require an available SSH server.
-They get skipped if this is not the case.
-Please see
-[Setup SSH Server to run unit tests](#setup-ssh-server-to-run-unit-tests).
+They get skipped if no SSH server is available. Please see section
+[Testing & Building](CONTRIBUTING.md#testing--building) about how to setup
+a SSH server on your system.
 
 ### Setup SSH Server to run unit tests
 
-For detailed setup instructions see the [how to setup openssh for unit tests](common/doc-dev/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md)
-
-The goal is to log into the SSH server on your local computer via `ssh localhost` without using
-a password:
-
-- Generate an RSA key pair executing `ssh-keygen`. Use the default file name
-  and don't use a passphrase for the key.
-- Populate the public key to the server executing `ssh-copy-id`.
-- Make the `ssh` instance run.
-- The port `22` (SSH default) should be available.
-
-To test the connection just execute `ssh localhost` and you should see an
-SSH shell without being asked for a password.
+Please see section [Testing & Building](CONTRIBUTING.md#testing--building).
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -41,8 +41,7 @@
    * [Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? I saw that it saves the names for uids and gids, so I assume it can restore correctly even if the ids change. Great! :-) Are there additional benefits?](#which-additional-features-on-top-of-a-gui-does-bit-provide-over-a-self-configured-rsync-backup-i-saw-that-it-saves-the-names-for-uids-and-gids-so-i-assume-it-can-restore-correctly-even-if-the-ids-change-great---are-there-additional-benefits)
    * [How to move snapshots to a new hard-drive?](#how-to-move-snapshots-to-a-new-hard-drive)
    * [How to move a large directory in the backup source without duplicating the files in the backup?](#how-to-move-a-large-directory-in-the-backup-source-without-duplicating-the-files-in-the-backup)
-   * [Ubuntu - Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))](#ubuntu-warning-apt-key-is-deprecated-manage-keyring-files-in-trustedgpgd-instead-see-apt-key8)
-
+   * [Ubuntu - Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))](#ubuntu---warning-apt-key-is-deprecated-manage-keyring-files-in-trustedgpgd-instead-see-apt-key8)
 - [Testing & Building](#testing--building)
    * [SSH related tests are skipped](#ssh-related-tests-are-skipped)
    * [Setup SSH Server to run unit tests](#setup-ssh-server-to-run-unit-tests)

--- a/FAQ.md
+++ b/FAQ.md
@@ -1057,5 +1057,5 @@ a SSH server on your system.
 
 ### Setup SSH Server to run unit tests
 
-Please see section [Testing - SSH](CONTRIBUTING.md#testing).
+Please see section [Testing - SSH](CONTRIBUTING.md#ssh).
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -41,6 +41,8 @@
    * [Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? I saw that it saves the names for uids and gids, so I assume it can restore correctly even if the ids change. Great! :-) Are there additional benefits?](#which-additional-features-on-top-of-a-gui-does-bit-provide-over-a-self-configured-rsync-backup-i-saw-that-it-saves-the-names-for-uids-and-gids-so-i-assume-it-can-restore-correctly-even-if-the-ids-change-great---are-there-additional-benefits)
    * [How to move snapshots to a new hard-drive?](#how-to-move-snapshots-to-a-new-hard-drive)
    * [How to move a large directory in the backup source without duplicating the files in the backup?](#how-to-move-a-large-directory-in-the-backup-source-without-duplicating-the-files-in-the-backup)
+   * [Ubuntu - Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))](#ubuntu-warning-apt-key-is-deprecated-manage-keyring-files-in-trustedgpgd-instead-see-apt-key8)
+
 - [Testing & Building](#testing--building)
    * [SSH related tests are skipped](#ssh-related-tests-are-skipped)
    * [Setup SSH Server to run unit tests](#setup-ssh-server-to-run-unit-tests)
@@ -1036,6 +1038,15 @@ You can avoid this by moving the file/folder in the last snapshot too:
 5. Remove the next to last snapshot (the one where you moved the folder manually)
    to avoid problems with permissions when you try to restore from that snapshot
 
+#### Ubuntu - Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8))
+
+In newer Ubuntu-based distros you may get this warning if you install _Back In
+Time_ from PPA.  The reason is that public keys of signed packages shall be
+stored in a new folder now (for details see
+https://itsfoss.com/apt-key-deprecated/).
+
+A solution is described in
+[#1338](https://github.com/bit-team/backintime/issues/1338#issuecomment-1454740118)
 
 ## Testing & Building
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ and [help wanted](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%
    questions and report bugs.
  * [Source code documentation for developers](https://backintime-dev.readthedocs.org)
 
----
-
 ## Installation
 
 _Back In Time_ is included in [many GNU/Linux distributions](https://repology.org/project/backintime/badges).
@@ -70,8 +68,6 @@ installation options provided and maintained by third parties.
 - [@Germar](https://github.com/germar)'s Personal Package Archive ([PPA](https://launchpad.net/ubuntu/+ppas)) offering [`ppa:bit-team/stable`](https://launchpad.net/~bit-team/+archive/ubuntu/stable) as stable and [`ppa:bit-team/testing`](https://launchpad.net/~bit-team/+archive/ubuntu/testing) as testing PPA.
 - [@jean-christophe-manciot](https://github.com/jean-christophe-manciot)'s PPA distributing [_Back In Time_ for the latest stable Ubuntu release](https://git.sdxlive.com/PPA/about). See [PPA requirements](https://git.sdxlive.com/PPA/about/#requirements) and [install instructions](https://git.sdxlive.com/PPA/about/#installing-the-ppa).
 - The Arch User Repository ([AUR](https://aur.archlinux.org/)) does offer [some packages](https://aur.archlinux.org/packages?K=backintime).
-
----
 
 ## Known Problems and Workarounds
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Back In Time
 <sub>Copyright (C) 2008-2024 Oprea Dan, Bart de Koning, Richard Bailey,
-Germar Reitze, Taylor Raack</sub>
+Germar Reitze, Taylor Raack</sub><br />
 <sub>Copyright (C) 2022 Christian Buhtz, Michael Büker, Jürgen Altfeld</sub>
  
 _Back In Time_ is an easy-to-use tool to backup files and folders.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 # Back In Time
 <sub>Copyright (C) 2008-2024 Oprea Dan, Bart de Koning, Richard Bailey,
-Germar Reitze, Taylor Raack, Christian Buhtz, Michael Büker, Jürgen Altfeld<sub>
+Germar Reitze, Taylor Raack</sub>
+<sub>Copyright (C) 2022 Christian Buhtz, Michael Büker, Jürgen Altfeld</sub>
  
 _Back In Time_ is an easy-to-use tool to backup files and folders.
 It runs on GNU Linux (not on Windows or OS X/macOS) and provides a command line tool `backintime` and a
@@ -39,7 +40,7 @@ and [help wanted](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%
 - [Documentation, FAQs, Support](#documentation-faqs-support)
 - [Installation](#installation)
 - [Known Problems and Workarounds](#known-problems-and-workarounds)
-- [CONTRIBUTING](CONTRIBUTING.md)
+- [Contributing and other ways to support the project](#contributing-and-other-ways-to-support-the-project)
 
 ## Documentation, FAQs, Support
 
@@ -52,6 +53,8 @@ and [help wanted](https://github.com/bit-team/backintime/issues?q=is%3Aissue+is%
  * Use [Issues](https://github.com/bit-team/backintime/issues) to ask
    questions and report bugs.
  * [Source code documentation for developers](https://backintime-dev.readthedocs.org)
+
+---
 
 ## Installation
 
@@ -68,11 +71,12 @@ installation options provided and maintained by third parties.
 - [@jean-christophe-manciot](https://github.com/jean-christophe-manciot)'s PPA distributing [_Back In Time_ for the latest stable Ubuntu release](https://git.sdxlive.com/PPA/about). See [PPA requirements](https://git.sdxlive.com/PPA/about/#requirements) and [install instructions](https://git.sdxlive.com/PPA/about/#installing-the-ppa).
 - The Arch User Repository ([AUR](https://aur.archlinux.org/)) does offer [some packages](https://aur.archlinux.org/packages?K=backintime).
 
+---
+
 ## Known Problems and Workarounds
 
 In the latest stable release:
 - [File permissions handling and therefore possible non-differential backups](#file-permissions-handling-and-therefore-possible-non-differential-backups)
-- [Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).](#warning-apt-key-is-deprecated-manage-keyring-files-in-trustedgpgd-instead-see-apt-key8)
 - [`qt5_probing.py` may hang with high CPU usage when running BiT as `root` via `cron`](#qt5_probingpy-may-hang-with-high-cpu-usage-when-running-bit-as-root-via-cron)
 
 In older releases:
@@ -99,19 +103,6 @@ If you don't like the new behavior, you can use _Expert Options_ -> _Paste addit
 to add `--no-perms --no-group --no-owner` to it.
 Note that the exact file permissions can still be found in `fileinfo.bz2` and are also considered when restoring
 files.
-
-#### Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
-
-In newer Ubuntu-based distros you may get this warning if you manually install _Back In Time_
-as described in the [Installation](#installation) section here.
-
-The reason is that public keys of signed packages shall be stored in a new folder now
-(for details see https://itsfoss.com/apt-key-deprecated/).
-
-You can currently ignore this warning until we have found a reliable way
-to support all Ubuntu distros (older and newer ones).
-
-This issue is tracked in [#1338](https://github.com/bit-team/backintime/issues/1338).
 
 #### `qt5_probing.py` may hang with high CPU usage when running BiT as `root` via `cron`
 
@@ -200,4 +191,7 @@ Ubuntu 22.04 LTS ships with Python 3.10 and backintime 1.2.1, but has applied
 to make it work. If you want to update _Back In Time_, you may use one of the
 [alternative options for installation](#alternative-installation-options).
 
-<sub>March 2024</sub>
+## Contributing and other ways to support the project
+See [CONTRIBUTING](CONTRIBUTING.md) file.
+
+<sub>April 2024</sub>


### PR DESCRIPTION
Removed known problem about "apt-key keyring" because not relevant anymore. Related issue is closed.
Also some minor adjustments.

About "Copyright" I modified in the README.md:
I did some intensive research about that topic related to another project. What I understood and learned.
 - Copyright is given always and implicit even if it is not written down somewhere. See [Berne Convention](https://en.wikipedia.org/wiki/Berne_Convention).
 - No need to increment the Copyright year. Copyright counts minimum 50 years **after the death** of the author ([source](https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code#why-not-bump-the-year-on-change)). Depending on the country that law is used, it is longer than 50 years (usually 70). Dan started BIT round about 1997 (emtiu knows better) and to my knowledge he still is alive. So we talk about year 2080 or later.