### PR TITLE
refactor!: Remove "filesystem_mounts" and "snapshot_version" field in backup "info" file

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Removed: Field "filesystem_mount" and "snapshot_version" in "info" file (#1684)
 * Feature: Support SSH proxy (jump) host (#1688) (@cgrinham, Christie Grinham)
 * Removed: Context menu in LogViewDialog (#1578)
 * Refactor: Replace Config.user() with getpass.getuser() (#1694)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1117,27 +1117,32 @@ class Snapshots:
                         f' command was {cmd}. Also see the previous '
                         'WARNING message for a more details.', parent=self)
 
-    def backupInfo(self, sid):
+    def _backup_info_file(self, sid):
         """
-        Save infos about the snapshot into the 'info' file.
+        Save infos about the snapshot into the 'info' file. The result is
+        stored in 'sid.info' also.
 
         Args:
-            sid (SID):  snapshot that should get an info file
+            sid (SID): Snapshot that should get the info file.
         """
-        logger.info("Create info file", self)
+        logger.debug(
+            f'Create info file for snapshot "{sid.displayName}".', self)
+
         machine = self.config.host()
         user = getpass.getuser()
         profile_id = self.config.currentProfile()
+
         i = configfile.ConfigFile()
-        i.setIntValue('snapshot_version', self.SNAPSHOT_VERSION)
         i.setStrValue('snapshot_date', sid.withoutTag)
         i.setStrValue('snapshot_machine', machine)
         i.setStrValue('snapshot_user', user)
         i.setIntValue('snapshot_profile_id', profile_id)
         i.setIntValue('snapshot_tag', sid.tag)
-        i.setListValue('user', ('int:uid', 'str:name'), list(self.userCache.items()))
-        i.setListValue('group', ('int:gid', 'str:name'), list(self.groupCache.items()))
-        i.setStrValue('filesystem_mounts', json.dumps(tools.filesystemMountInfo()))
+        i.setListValue(
+            'user', ('int:uid', 'str:name'), list(self.userCache.items()))
+        i.setListValue(
+            'group', ('int:gid', 'str:name'), list(self.groupCache.items()))
+
         sid.info = i
 
     def backupPermissions(self, sid):
@@ -1502,7 +1507,7 @@ class Snapshots:
 
             return [False, True]
 
-        self.backupInfo(sid)
+        self._backup_info_file(sid)
 
         if not has_errors and not list(self.config.anacrontabFiles()):
             tools.writeTimeStamp(self.config.anacronSpoolFile())

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -46,12 +46,18 @@ class TestBackInTime(generic.TestCase):
         functionality, and output all work as expected is NOT intended to
         replace individual method tests, which are incredibly useful as well.
 
-        Development notes (by Buhtz):
-        Multiple tests do compare return codes and output on stdout. The
-        intention might be an integration tests. But the asserts not qualified
-        to answer the important questions and observe the intended behavior.
-        Heavy refactoring is needed. But because of the "level" of that tests
-        it won't happen in the near future.
+        Development notes (by Buhtz, 2023):
+        Multiple tests do compare return codes and output on stdout. It is NOT
+        tested what is on the file system. The intention might be a system
+        test. But the asserts not qualified to answer the important questions
+        and observe the intended behavior.  Heavy refactoring is needed. But
+        because of the "level" of that tests it won't happen in the near
+        future. Also maintenance costs of this tests are damn high because
+        every tiny modifcation of BIT gives a false fail of this test.
+
+        Development notes (by Buhtz, 2024-05):
+        It is just dumb stdout parsing. I tend to remove this test because of
+        the calculation of its value and its maintenance costs.
         """
 
         # ensure that we see full diffs of assert output if there are any
@@ -187,7 +193,6 @@ INFO: Take a new snapshot. Profile: 1 Main profile
 INFO: Call rsync to take the snapshot
 INFO: Save config file
 INFO: Save permissions
-INFO: Create info file
 INFO: Unlock''', re.MULTILINE))
 
         # get snapshot id

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -528,18 +528,23 @@ class TestSnapshotWithSID(generic.SnapshotsWithSidTestCase):
         self.assertEqual(tools.md5sum(self.sid.path('config')),
                          tools.md5sum(self.cfgFile))
 
-    def test_backupInfo(self):
-        self.sn.backupInfo(self.sid)
-        self.assertIsFile(self.sid.path('info'))
-        with open(self.sid.path('info'), 'rt') as f:
-            self.assertRegex(f.read(), re.compile('''filesystem_mounts=.+
-group.size=.+
+    def test_backup_info_file(self):
+        """Creation and content of the 'info' file contained in each snapshot
+        """
+
+        # Create the file
+        self.sn._backup_info_file(self.sid)
+        sut_fp = pathlib.Path(self.sid.path('info'))
+
+        self.assertTrue(sut_fp.is_file())
+
+        sut = sut_fp.read_text()
+        self.assertRegex(sut, re.compile('''group.size=.+
 snapshot_date=20151219-010324
 snapshot_machine=.+
 snapshot_profile_id=1
 snapshot_tag=123
 snapshot_user=.+
-snapshot_version=.+
 user.size=.+''', re.MULTILINE))
 
     def test_backupPermissions(self):

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, write to the Free Software Foundation,Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
 import os
 import sys
 import subprocess
@@ -417,18 +416,6 @@ class TestTools(generic.TestCase):
         self.assertEqual(procArgs[0], 'proc')
         self.assertEqual(procArgs[1], '/proc')
         self.assertEqual(procArgs[2], 'proc')
-
-    @unittest.skipIf(not DISK_BY_UUID_AVAILABLE and not UDEVADM_HAS_UUID,
-                     'No UUIDs available on this system.')
-    def test_filesystemMountInfo(self):
-        """
-        Basic sanity checks on returned structure
-        """
-        mounts = tools.filesystemMountInfo()
-        self.assertIsInstance(mounts, dict)
-        self.assertGreater(len(mounts.items()), 0)
-        self.assertIn('/', mounts)
-        self.assertIn('original_uuid', mounts.get('/'))
 
     def test_isRoot(self):
         self.assertIsInstance(tools.isRoot(), bool)

--- a/common/tools.py
+++ b/common/tools.py
@@ -1558,22 +1558,6 @@ def uuidFromPath(path):
     return uuidFromDev(device(path))
 
 
-def filesystemMountInfo():
-    """
-    Get a dict of mount point string -> dict of filesystem info for
-    entire system.
-
-    Returns:
-        dict:   {MOUNTPOINT: {'original_uuid': UUID}}
-    """
-    # There may be multiple mount points inside of the root (/) mount, so
-    # iterate over mtab to find all non-special mounts.
-    with open('/etc/mtab', 'r') as mounts:
-        return {items[1]: {'original_uuid': uuidFromDev(items[0])} for items in
-                [mount_line.strip('\n').split(' ')[:2] for mount_line in mounts]
-                if uuidFromDev(items[0]) != None}
-
-
 def isRoot():
     """
     Check if we are root.


### PR DESCRIPTION
Each snapshot contains an "info" file. This PR remove the two fields "filesystem_mounts" and "snapshot_version" from it because they are not used.

Additionally related code and unit tests are removed or modified.

There is no strict need but I created a changelog entry if it might impacts someone.

Close #1684