### PR TITLE
fix(gui): Improved Exclude tab in Manage profiles dialog with SSH encrypted profiles

### DIFF
--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -610,22 +610,19 @@ class SettingsDialog(QDialog):
         self.tabs.addTab(tabWidget, _('&Exclude'))
         layout = QVBoxLayout(tabWidget)
 
-        # DEBUG
-        brush = QPalette().brush(QPalette.ColorGroup.Normal,
-                                 QPalette.ColorRole.Link)
-        hex_foreground = brush.color().name()
-
         self.lblSshEncfsExcludeWarning = QLabel(
-            f"foobar <span style='background-color: {hex_foreground};'>ROT</span> normal",
-            # "<b>{}:</b> {}".format(
-            #     _("Warning"),
-            #     _(
-            #         "Wildcards ({example1}) will be ignored "
-            #         "with mode 'SSH encrypted'.\nOnly single or double "
-            #         "asterisks are allowed ({example2})"
-            #     ).format(example1="'foo*', '[fF]oo', 'fo?'",
-            #              example2="'foo/*', 'foo/**/bar'")
-            # ),
+            "<b>{}:</b> {}".format(
+                _("Warning"),
+                _(
+                    "In 'SSH encrypted' mode, only single or double asterisks "
+                    "are functional (e.g. {example2}). Other types of "
+                    "wildcards and patterns (e.g. {example1}) will be ignored."
+                ).format(example1="<code>'foo*'</code>, "
+                                  "<code>'[fF]oo'</code>, "
+                                  "<code>'fo?'</code>",
+                         example2="<code>'foo/*'</code>, "
+                                  "<code>'foo/**/bar'</code>")
+            ),
             self
         )
         self.lblSshEncfsExcludeWarning.setWordWrap(True)
@@ -2217,7 +2214,7 @@ class SettingsDialog(QDialog):
         item.setData(
             0,
             Qt.ItemDataRole.ToolTipRole,
-            _("Disabled because this pattern can not be handled in "
+            _("Disabled because this pattern is not functional in "
               "mode 'SSH encrypted'.")
         )
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -617,6 +617,8 @@ class SettingsDialog(QDialog):
                     "In 'SSH encrypted' mode, only single or double asterisks "
                     "are functional (e.g. {example2}). Other types of "
                     "wildcards and patterns will be ignored (e.g. {example1})."
+                    "Filenames are unpredictable in this mode due to "
+                    "encryption by EncFS."
                 ).format(example1="<code>'foo*'</code>, "
                                   "<code>'[fF]oo'</code>, "
                                   "<code>'fo?'</code>",

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -610,16 +610,22 @@ class SettingsDialog(QDialog):
         self.tabs.addTab(tabWidget, _('&Exclude'))
         layout = QVBoxLayout(tabWidget)
 
+        # DEBUG
+        brush = QPalette().brush(QPalette.ColorGroup.Normal,
+                                 QPalette.ColorRole.Link)
+        hex_foreground = brush.color().name()
+
         self.lblSshEncfsExcludeWarning = QLabel(
-            "<b>{}:</b> {}".format(
-                _("Warning"),
-                _(
-                    "Wildcards ({example1}) will be ignored "
-                    "with mode 'SSH encrypted'.\nOnly single or double "
-                    "asterisks are allowed ({example2})"
-                ).format(example1="'foo*', '[fF]oo', 'fo?'",
-                         example2="'foo/*', 'foo/**/bar'")
-            ),
+            f"foobar <span style='background-color: {hex_foreground};'>ROT</span> normal",
+            # "<b>{}:</b> {}".format(
+            #     _("Warning"),
+            #     _(
+            #         "Wildcards ({example1}) will be ignored "
+            #         "with mode 'SSH encrypted'.\nOnly single or double "
+            #         "asterisks are allowed ({example2})"
+            #     ).format(example1="'foo*', '[fF]oo', 'fo?'",
+            #              example2="'foo/*', 'foo/**/bar'")
+            # ),
             self
         )
         self.lblSshEncfsExcludeWarning.setWordWrap(True)
@@ -2205,8 +2211,11 @@ class SettingsDialog(QDialog):
                 and tools.patternHasNotEncryptableWildcard(item.text(0))):
 
             item.setIcon(0, self.icon.INVALID_EXCLUDE)
-            item.setBackground(0, QPalette().brush(QPalette.ColorGroup.Active,
-                                                   QPalette.ColorRole.Link))
+            item.setBackground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
+                                                   QPalette.ColorRole.Window))
+            item.setForeground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
+                                                   QPalette.ColorRole.Text))
+
             return
 
         # default background color

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -612,7 +612,7 @@ class SettingsDialog(QDialog):
 
         self.lblSshEncfsExcludeWarning = QLabel(
             "<b>{}:</b> {}".format(
-                _("Warning"),
+                _('Info'),
                 _(
                     "In 'SSH encrypted' mode, only single or double asterisks "
                     "are functional (e.g. {example2}). Other types of "

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -616,7 +616,7 @@ class SettingsDialog(QDialog):
                 _(
                     "In 'SSH encrypted' mode, only single or double asterisks "
                     "are functional (e.g. {example2}). Other types of "
-                    "wildcards and patterns (e.g. {example1}) will be ignored."
+                    "wildcards and patterns will be ignored (e.g. {example1})."
                 ).format(example1="<code>'foo*'</code>, "
                                   "<code>'[fF]oo'</code>, "
                                   "<code>'fo?'</code>",

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -2203,31 +2203,54 @@ class SettingsDialog(QDialog):
             item = self.listExclude.topLevelItem(index)
             self._formatExcludeItem(item)
 
+
+    def _format_exclude_item_encfs_invalid(self, item):
+        """Modify visual appearance of an item in the exclude list widget to
+        express that the item is invalid.
+
+        See :py:func:`_formatExcludeItem` for details.
+        """
+        # Icon
+        item.setIcon(0, self.icon.INVALID_EXCLUDE)
+
+        # ToolTip
+        item.setData(
+            0,
+            Qt.ItemDataRole.ToolTipRole,
+            _("Disabled because this pattern can not be handled in "
+              "mode 'SSH encrypted'.")
+        )
+
+        # Fore- and Backgroundcolor (as disabled)
+        item.setBackground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
+                                                QPalette.ColorRole.Window))
+        item.setForeground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
+                                                QPalette.ColorRole.Text))
+
+
     def _formatExcludeItem(self, item):
         """Modify visual appearance of an item in the exclude list widget.
         """
-        # Invalid item (because of encfs restrictions)
         if (self.mode == 'ssh_encfs'
                 and tools.patternHasNotEncryptableWildcard(item.text(0))):
+            # Invalid item (because of encfs restrictions)
+            self._format_exclude_item_encfs_invalid(item)
 
-            item.setIcon(0, self.icon.INVALID_EXCLUDE)
-            item.setBackground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
-                                                   QPalette.ColorRole.Window))
-            item.setForeground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
-                                                   QPalette.ColorRole.Text))
+        else:
+            # default background color
+            item.setBackground(0, QBrush())
+            item.setForeground(0, QBrush())
 
-            return
+            # Remove items tooltip
+            item.setData(0, Qt.ItemDataRole.ToolTipRole, None)
 
-        # default background color
-        item.setBackground(0, QBrush())
+            # Icon: default exclude item
+            if item.text(0) in self.config.DEFAULT_EXCLUDE:
+                item.setIcon(0, self.icon.DEFAULT_EXCLUDE)
 
-        # Icon: default exclude item
-        if item.text(0) in self.config.DEFAULT_EXCLUDE:
-            item.setIcon(0, self.icon.DEFAULT_EXCLUDE)
-            return
-
-        # Icon: user definied
-        item.setIcon(0, self.icon.EXCLUDE)
+            else:
+                # Icon: user definied
+                item.setIcon(0, self.icon.EXCLUDE)
 
 
     def customSortOrder(self, header, loop, newColumn, newOrder):


### PR DESCRIPTION
The Exclude TAB in Manage profiles improved in context of SSH encrypted mode (using encfs). As explained in #1618 some exclude patterns are not functional with EncFS so they are ignored and visually disabled.

- The items fore and background ColroRole now try to imitate disabled state. But they are still selectable (e.g. to delete them).
- That items now have a tool tip to explain why they are disabled.
- warning message on top of the exclude list:
   - improved wording
   - Examples in brackets now using monotyp font (via `<code>` tag in richtext mode)
- Slightly refactoring of some code.

![1618_light](https://github.com/bit-team/backintime/assets/11861496/f78827a7-bad4-4538-9490-811a91e8a8eb)
![1618_dark](https://github.com/bit-team/backintime/assets/11861496/ec11d831-0148-4595-aa87-96acdb62b84d)

Wouldn't give this an extra changelog.

Close #1618
