### PR TITLE
fix(gui): SSHProxyWidget handle port values of type integer

### DIFF
--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -85,6 +85,9 @@ class SshProxyWidget(QWidget):
             port = ''
             user = ''
 
+        elif isinstance(port, int):
+            port = str(port)
+
         vlayout = QVBoxLayout(self)
         # zero margins
         vlayout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
Fix crash with SSHProxyWidget when port was of type int.

Related to #1688