### PR TITLE
refactor!: Remove test about sshkeygen (only running on Germar's machine)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Build: Activate PyLint error E0100 (init-is-generator), E0101 (return-in-init), E0102 (function-redefined), E0103 (not-in-loop), E0106 (return-arg-in-generator)
 * Fix: Names of weekdays and months translated correct (#1729)
 * Fix: Global flock for multiple users (#1122, #1676)
 * Fix bug: "Backup folders" list does reflect the selected snapshot (#1585) (@rafaelhdr Rafael Hurpia da Rocha)

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -76,13 +76,18 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
 
         # Explicit activate checks
         err_codes = [
+            'E0100',  # init-is-generator
+            'E0101',  # return-in-init
+            'E0102',  # function-redefined
+            'E0103',  # not-in-loop
+            'E0106',  # return-arg-in-generator
             'E0401',  # import-error
             'E0602',  # undefined-variable
             'E1101',  # no-member
+            'I0021',  # useless-suppression
             # 'W0611',  # unused-import
             'W1301',  # unused-format-string-key
             'W1401',  # anomalous-backslash-in-string (invalid escape sequence)
-            'I0021',  # useless-suppression
 
             # Enable asap. This list is selection of existing (not all!)
             # problems currently exiting in the BIT code base. Quit easy to fix

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -76,13 +76,18 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
 
         # Explicit activate checks
         err_codes = [
+            'E0100',  # init-is-generator
+            'E0101',  # return-in-init
+            'E0102',  # function-redefined
+            'E0103',  # not-in-loop
+            'E0106',  # return-arg-in-generator
             'E0401',  # import-error
             'E0602',  # undefined-variable
             'E1101',  # no-member
-            'W0611',  # unused-import
+            'I0021',  # useless-suppression
+            # 'W0611',  # unused-import
             'W1301',  # unused-format-string-key
             'W1401',  # anomalous-backslash-in-string (invalid escape sequence)
-            'I0021',  # useless-suppression
 
             # Enable asap. This list is selection of existing (not all!)
             # problems currently exiting in the BIT code base. Quit easy to fix


### PR DESCRIPTION
Remove a test about generating sshkey that runs only on Germar's machine.

Because the test only calls extern shell commands I see not much testable BIT-related behavior and removed it without replacement.

Fix #1298 