### PR TITLE
refactor: Activate and fix PyLint rule W0311 (bad indentation)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Build: Activate PyLint error W0311 (bad-indentation)
 * Fix: Names of weekdays and months translated correct (#1729)
 * Fix: Global flock for multiple users (#1122, #1676)
 * Fix bug: "Backup folders" list does reflect the selected snapshot (#1585) (@rafaelhdr Rafael Hurpia da Rocha)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,6 +285,7 @@ The codebase does not adhere to [PEP8](https://peps.python.org/pep-0008/),
 which serves as the minimum Python coding style. Utilizing linters in their
 default configuration is currently not feasible. One of our objectives is to
 align with PEP8 standards and meet the requirements of code linters.
+See [Issue #1755](https://github.com/bit-team/backintime/issues/1755) about it.
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,6 +307,8 @@ replacing it, with [GoCryptFS](https://github.com/rfjakob/gocryptfs) as a
 potential candidate. However, lack of resources hinders this effort. If no
 volunteers step forward, the encryption feature will be removed, prioritizing
 user security and team maintenance efforts.
+See [Issue #1734](https://github.com/bit-team/backintime/issues/1734) about the
+transation process and the discussion about alternatives to EncFS.
 
 Besides replacing EncFS there is also a
 [discussion](https://mail.python.org/archives/list/bit-dev@python.org/thread/D2GXCCVUAVZ2E5ELBHUZGT7ITUN4ADEP)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,4 +348,4 @@ Keep in mind as you contribute, that code, docs and other material submitted to
 the project are considered licensed under the same terms (see
 [LICENSE](LICENSE)) as the rest of the work.
 
-<sub>May 2024</sub>
+<sub>July 2024</sub>

--- a/TRANSLATIONS
+++ b/TRANSLATIONS
@@ -10,7 +10,9 @@ Japanese [ja]: Ayako Buhtz
 Nynorsk (Norwegian) [nn]
  - Hans Fredrik Nordhaug <hansfn@gmail.com>
  - VL
-Persian (Farsi) [fa]: Farooq Karimi Zadeh <hapu@riseup.net>
+Persian (Farsi) [fa]:
+ - Farooq Karimi Zadeh <hapu@riseup.net>
+ - Parsa Ranjbar
 Polish [pl]: Paweł Hołuj <pholuj@gmail.com>
 Portuguese (Brazilian) [pt_BR]:
  - Scythemare

--- a/common/encfstools.py
+++ b/common/encfstools.py
@@ -293,10 +293,10 @@ class EncFS_SSH(EncFS_mount):
         """
         call preMountCheck for sshfs, encfs --reverse and encfs
         """
-        if self.ssh.preMountCheck(*args, **kwargs) and \
-           self.rev_root.preMountCheck(*args, **kwargs) and \
-           super(EncFS_SSH, self).preMountCheck(*args, **kwargs):
-                return True
+        if (self.ssh.preMountCheck(*args, **kwargs)
+                and self.rev_root.preMountCheck(*args, **kwargs)
+                and super(EncFS_SSH, self).preMountCheck(*args, **kwargs)):
+            return True
 
     def splitKwargs(self, mode):
         """

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -79,6 +79,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             'E0401',  # import-error
             'E0602',  # undefined-variable
             'E1101',  # no-member
+            'W0311',  # bad-indentation
             # 'W0611',  # unused-import
             'W1301',  # unused-format-string-key
             'W1401',  # anomalous-backslash-in-string (invalid escape sequence)
@@ -99,7 +100,6 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # 'W0123',  # eval-used
             # 'W0237',  # arguments-renamed
             # 'W0221',  # arguments-differ
-            # 'W0311',  # bad-indentation
             # 'W0404',  # reimported
             # 'W4902',  # deprecated-method
             # 'W4904',  # deprecated-class

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -79,6 +79,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             'E0401',  # import-error
             'E0602',  # undefined-variable
             'E1101',  # no-member
+            'W0311',  # bad-indentation
             'W0611',  # unused-import
             'W1301',  # unused-format-string-key
             'W1401',  # anomalous-backslash-in-string (invalid escape sequence)
@@ -99,7 +100,6 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # 'W0123',  # eval-used
             # 'W0237',  # arguments-renamed
             # 'W0221',  # arguments-differ
-            # 'W0311',  # bad-indentation
             # 'W0404',  # reimported
             # 'W4902',  # deprecated-method
             # 'W4904',  # deprecated-class


### PR DESCRIPTION
Because of #1757 activate PyLint rule W0311 about bad indentation.

Related to meta issue #1755 

Don't merge before #1747