### PR TITLE
refactor: Enable and fix PyLint rule C0303 (trailing-whitespaces)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Build: Activate PyLint error C0303 (trailing-whitespaces)
 * Fix: Names of weekdays and months translated correct (#1729)
 * Fix: Global flock for multiple users (#1122, #1676)
 * Fix bug: "Backup folders" list does reflect the selected snapshot (#1585) (@rafaelhdr Rafael Hurpia da Rocha)

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -87,7 +87,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # Enable asap. This list is selection of existing (not all!)
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
-            # 'C0303',  # trailing-whitespace
+            'C0303',  # trailing-whitespace
             # 'C0305',  # trailing-newlines
             # 'C0324',  # superfluous-parens
             # 'C0410',  # multiple-imports

--- a/common/tools.py
+++ b/common/tools.py
@@ -563,7 +563,6 @@ def checkCommand(cmd):
 
     return which(cmd) is not None
 
-  
 def which(cmd):
     """Get the fullpath of executable command ``cmd``.
 

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -87,7 +87,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # Enable asap. This list is selection of existing (not all!)
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
-            # 'C0303',  # trailing-whitespace
+            'C0303',  # trailing-whitespace
             # 'C0305',  # trailing-newlines
             # 'C0324',  # superfluous-parens
             # 'C0410',  # multiple-imports


### PR DESCRIPTION
Don't forget the changelog entry! ;)

Did you run "codespell"?

