### PR TITLE
feat: Warn if cron is not running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@
 
 os: linux
  
-# ensures that we have UUID filesystem mounts for proper testing
-dist: focal
+# dist: focal
+dist: jammy
 
 language: python
 
@@ -40,6 +40,7 @@ jobs:
     - python: "3.9"
     - python: "3.10"
     - python: "3.11"
+    - python: "3.12"
 
 install:
   - pip install pylint coveralls pyfakefs keyring

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@
 
 os: linux
  
+# Support End of "Focal" (20.04 LTS) is April 2025
 # dist: focal
+# Support End of "Jammy" (22.04 LTS) is April 2027
 dist: jammy
 
 language: python
@@ -43,6 +45,7 @@ jobs:
     - python: "3.12"
 
 install:
+  - pip install -U pip
   - pip install pylint coveralls pyfakefs keyring
   - pip install pyqt6 dbus-python
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - sudo apt-key del 90CFB1F5
   - sudo apt-get -qq update
   # install screen, and util-linux (provides flock) for test_sshtools
-  - sudo apt-get install -y sshfs screen util-linux
+  - sudo apt-get install -y sshfs screen util-linux libdbus-1-dev
 
 jobs:
   exclude:

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Feature: Warn if Cron is not running (#1747)
 * Build: Activate PyLint error E0100 (init-is-generator), E0101 (return-in-init), E0102 (function-redefined), E0103 (not-in-loop), E0106 (return-arg-in-generator)
 * Fix: Names of weekdays and months translated correct (#1729)
 * Fix: Global flock for multiple users (#1122, #1676)

--- a/common/config.py
+++ b/common/config.py
@@ -1627,6 +1627,7 @@ class Config(configfile.ConfigFileWithProfiles):
         # Add a new entry to existing crontab content based on the current
         # snapshot profile and its schedule settings.
         crontab_lines = schedule.append_bit_to_crontab(
+            crontab_lines,
             self.profiles_cron_lines())
 
         # Save Udev rules
@@ -1643,19 +1644,21 @@ class Config(configfile.ConfigFileWithProfiles):
         if crontab_lines == org_crontab_lines:
             return True
 
-        # TODO (buhtz): Again a crontab check. Refactore somehow.
-        if not tools.checkCommand('crontab'):
-            logger.error('crontab not found.', self)
-            self.notifyError(_(
-                "Can't find crontab.\n"
-                "Are you sure cron is installed?\n"
-                "If not you should disable all automatic backups."))
-
-            return False
-
         if schedule.write_crontab(crontab_lines) == False:
+            logger.error('Failed to write new crontab.')
             self.notifyError(_('Failed to write new crontab.'))
             return False
+
+        if not schedule.is_cron_running():
+            logger.error(
+                'Cron is not running despite the crontab command is available'
+                '. Scheduled backup jobs will not run.')
+            self.notifyError(_(
+                'Cron is not running despite the crontab command is available.'
+                ' Scheduled backup jobs will not run. '
+                'It might be that Cron is installed but not enabled. Try '
+                'the command "systemctl enable cron" or consulte the support '
+                'channels of your GNU Linux distribution.'))
 
         return True
 
@@ -1666,14 +1669,12 @@ class Config(configfile.ConfigFileWithProfiles):
             list: The list of crontab lines.
         """
         profile_ids = self.profiles()
-        print(f'{profile_ids=}')  # DEBUG
 
         # For each profile: cronline and the command (backintime)
         cron_lines = [
             self._cron_line(pid).replace('{cmd}', self._cron_cmd(pid))
             for pid in profile_ids
         ]
-        print(f'{cron_lines=}')  # DEBUG
 
         # Remove empty lines (profiles not scheduled)
         cron_lines = list(filter(None, cron_lines))

--- a/common/config.py
+++ b/common/config.py
@@ -1651,14 +1651,14 @@ class Config(configfile.ConfigFileWithProfiles):
 
         if not schedule.is_cron_running():
             logger.error(
-                'Cron is not running despite the crontab command is available'
-                '. Scheduled backup jobs will not run.')
+                'Cron is not running despite the crontab command being '
+                'available. Scheduled backup jobs will not run.')
             self.notifyError(_(
-                'Cron is not running despite the crontab command is available.'
-                ' Scheduled backup jobs will not run. '
-                'It might be that Cron is installed but not enabled. Try '
-                'the command "systemctl enable cron" or consulte the support '
-                'channels of your GNU Linux distribution.'))
+                'Cron is not running despite the crontab command being '
+                'available. Scheduled backup jobs will not run. '
+                'Cron might be installed but not enabled. Try the command '
+                '"systemctl enable cron" or consulte the support channels of '
+                'your GNU Linux distribution.'))
 
         return True
 

--- a/common/doc-dev/BiT_release_process.md
+++ b/common/doc-dev/BiT_release_process.md
@@ -15,7 +15,9 @@ using a "feature" branch and sending a pull request asking for a review.
 
 - Developers agreed on the new version number.
 - Most-recent translations were merged into `dev` branch. See the [localization documentation](2_localization.md).
-- Full CI build pipeline matrix is activate (see [#1529](https://github.com/bit-team/backintime/issues/1529)).
+- Full CI build pipeline matrix is activate (see
+  [#1529](https://github.com/bit-team/backintime/issues/1529)). This is related
+  to the Python versions and also to the Ubuntu Distro versions.
 - `dev` version was tested (CLI in `common` and GUI in `qt`) and testers/developers agreed on "readiness to be released".
 
 

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -136,10 +136,40 @@ def remove_bit_from_crontab(crontab):
 
 
 def append_bit_to_crontab(crontab, bit_lines):
-    # Add a new entry to existing crontab content based on the current
-    # snapshot profile and its schedule settings.
+    """Add new entries to existing crontab content.
+
+    Args:
+        crontab(list): A list of strings as crontab lines.
+        bit_lines(list): A list of strings as new crontab lines.
+
+    Returns:
+        list: The new crontab lines.
+    """
     for line in bit_lines:
         crontab.append(_MARKER)
         crontab.append(line)
 
     return crontab
+
+
+def is_cron_running():
+    """Validate if a cron instance is running.
+
+    The string ``cron`` is search case-insensitive in the output of ``ps``.
+
+    Returns:
+        bool: The answer.
+    """
+
+    with subprocess.Popen(['ps', '-eo', 'comm'], stdout=subprocess.PIPE) as ps:
+        try:
+            grep = subprocess.run(
+                ['grep', '--ignore-case', 'Xron'],
+                stdin=ps.stdout,
+                stdout=subprocess.PIPE,
+                check=True
+            )
+        except subprocess.CalledProcessError:
+            return False
+
+    return True

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -155,7 +155,8 @@ def append_bit_to_crontab(crontab, bit_lines):
 def is_cron_running():
     """Validate if a cron instance is running.
 
-    The string ``cron`` is search case-insensitive in the output of ``ps``.
+    The output of ``ps`` is searched (case-insensitive) via ``grep`` for the
+    string ``cron``.
 
     Returns:
         bool: The answer.

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -164,7 +164,7 @@ def is_cron_running():
     with subprocess.Popen(['ps', '-eo', 'comm'], stdout=subprocess.PIPE) as ps:
         try:
             grep = subprocess.run(
-                ['grep', '--ignore-case', 'Xron'],
+                ['grep', '--ignore-case', 'cron'],
                 stdin=ps.stdout,
                 stdout=subprocess.PIPE,
                 check=True

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -93,6 +93,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
             # 'C0303',  # trailing-whitespace
+            # 'C0304',  # missing-final-newline
             # 'C0305',  # trailing-newlines
             # 'C0324',  # superfluous-parens
             # 'C0410',  # multiple-imports

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -93,6 +93,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
             # 'C0303',  # trailing-whitespace
+            # 'C0304',  # missing-final-newline
             # 'C0305',  # trailing-newlines
             # 'C0324',  # superfluous-parens
             # 'C0410',  # multiple-imports


### PR DESCRIPTION
Warn if no Cron instance is running.

The running processes are grepped case-insensitive for the string `cron`. That would catch cronie, fcron and others. This will help on Arch-based system often installing cron but not enabling it.

The resulting warning dialog and log output looks like this:
![image](https://github.com/bit-team/backintime/assets/11861496/7bea2ca8-fed9-4e3e-9c6c-4c7ff117f0a1)

Modified TravisCI to use only the oldest supported Python version (3.8) because we run out of credits again. Also upgraded Ubuntu from Focal (20.04 LTS) to Jammy (22.04 LTS).

Fix a minor bug introduced by me with #1747.

Fix #1741 
Fix #1765