### PR TITLE
refactor: Enable and fix PyLint rules C0305 (trailing-newlines), C0324 (superfluous-parens), C0410 (multiple-imports), E0213 (no-self-argument)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.4.4-dev (development of upcoming release)
+* Build: Enable PyLint rules C0305 (trailing-newlines), C0324 (superfluous-parens), C0410 (multiple-imports), E0213 (no-self-argument)
 * Build: Activate PyLint error E0100 (init-is-generator), E0101 (return-in-init), E0102 (function-redefined), E0103 (not-in-loop), E0106 (return-arg-in-generator)
 * Fix: Names of weekdays and months translated correct (#1729)
 * Fix: Global flock for multiple users (#1122, #1676)

--- a/common/cli.py
+++ b/common/cli.py
@@ -189,7 +189,9 @@ def terminalSize():
     """
     for fd in (sys.stdin, sys.stdout, sys.stderr):
         try:
-            import fcntl, termios, struct
+            import fcntl
+            import termios
+            import struct
             return [int(x) for x in struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))]
         except:
             pass

--- a/common/cli.py
+++ b/common/cli.py
@@ -193,7 +193,7 @@ def terminalSize():
             import termios
             import struct
             return [int(x) for x in struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))]
-        except:
+        except ImportError:
             pass
     return [24, 80]
 

--- a/common/mount.py
+++ b/common/mount.py
@@ -1039,7 +1039,7 @@ class MountControl(object):
         Returns:
             str:        hash of string ``s``
         """
-        return('%X' % (crc32(s.encode()) & 0xFFFFFFFF))
+        return '%X' % (crc32(s.encode()) & 0xFFFFFFFF)
 
     def hashIdPath(self, hash_id = None):
         """

--- a/common/password.py
+++ b/common/password.py
@@ -110,9 +110,9 @@ class Password_Cache(tools.Daemon):
         """
         time.sleep(2)
         cfgPath = self.config._LOCAL_CONFIG_PATH
-        del(self.config)
+        del self.config
         self.config = config.Config(cfgPath)
-        del(self.dbKeyring)
+        del self.dbKeyring
         self.dbKeyring = {}
         self.collectPasswords()
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1003,7 +1003,7 @@ class Snapshots:
                 pg.setStrValue('speed', m.group(3))
                 #pg.setStrValue('eta', m.group(4))
                 pg.save()
-                del(pg)
+                del pg
             else:
                 ret.append(l)
         return '\n'.join(ret)

--- a/common/test/test_config_crontab.py
+++ b/common/test/test_config_crontab.py
@@ -78,7 +78,7 @@ class CrontabDebug(pyfakefs_ut.TestCase):
 
         self.config_fp = self._create_config_file(parent_path=self.temp_path)
 
-    def _create_config_file(self, cls, parent_path):
+    def _create_config_file(self, parent_path):
         """Minimal config file"""
         cfg_content = inspect.cleandoc('''
             config.version=6

--- a/common/test/test_config_crontab.py
+++ b/common/test/test_config_crontab.py
@@ -78,7 +78,7 @@ class CrontabDebug(pyfakefs_ut.TestCase):
 
         self.config_fp = self._create_config_file(parent_path=self.temp_path)
 
-    def _create_config_file(cls, parent_path):
+    def _create_config_file(self, cls, parent_path):
         """Minimal config file"""
         cfg_content = inspect.cleandoc('''
             config.version=6

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -76,11 +76,15 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
 
         # Explicit activate checks
         err_codes = [
+            'C0305',  # trailing-newlines
+            'C0324',  # superfluous-parens
+            'C0410',  # multiple-imports
             'E0100',  # init-is-generator
             'E0101',  # return-in-init
             'E0102',  # function-redefined
             'E0103',  # not-in-loop
             'E0106',  # return-arg-in-generator
+            'E0213',  # no-self-argument
             'E0401',  # import-error
             'E0602',  # undefined-variable
             'E1101',  # no-member
@@ -93,10 +97,6 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
             # 'C0303',  # trailing-whitespace
-            'C0305',  # trailing-newlines
-            'C0324',  # superfluous-parens
-            'C0410',  # multiple-imports
-            'E0213',  # no-self-argument
             # 'R0201',  # no-self-use
             # 'R0202',  # no-classmethod-decorator
             # 'R0203',  # no-staticmethod-decorator

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -93,10 +93,10 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
             # 'C0303',  # trailing-whitespace
-            # 'C0305',  # trailing-newlines
-            # 'C0324',  # superfluous-parens
-            # 'C0410',  # multiple-imports
-            # 'E0213',  # no-self-argument
+            'C0305',  # trailing-newlines
+            'C0324',  # superfluous-parens
+            'C0410',  # multiple-imports
+            'E0213',  # no-self-argument
             # 'R0201',  # no-self-use
             # 'R0202',  # no-classmethod-decorator
             # 'R0203',  # no-staticmethod-decorator

--- a/common/test/test_snapshotlog.py
+++ b/common/test/test_snapshotlog.py
@@ -86,7 +86,7 @@ class TestLogFilter(generic.TestCase):
             self.assertEqual(line, logFilter.filter(line))
         for line in (self.e, self.c, self.i, self.h):
             self.assertIsNone(logFilter.filter(line))
-        for line in (self.n):
+        for line in self.n:
             self.assertEqual(line, logFilter.filter(line))  # empty line stays empty line
 
 class TestSnapshotLog(generic.SnapshotsTestCase):

--- a/common/tools.py
+++ b/common/tools.py
@@ -563,7 +563,7 @@ def checkCommand(cmd):
 
     return which(cmd) is not None
 
-  
+
 def which(cmd):
     """Get the fullpath of executable command ``cmd``.
 
@@ -1231,7 +1231,7 @@ def envLoad(f):
             continue
         if not key in list(env.keys()):
             os.environ[key] = value
-    del(env_file)
+    del env_file
 
 
 def envSave(f):
@@ -2201,7 +2201,7 @@ class ShutDown(object):
                 sessionbus = dbus.SessionBus()
             systembus  = dbus.SystemBus()
         except:
-            return((None, None))
+            return (None, None)
         des = list(self.DBUS_SHUTDOWN.keys())
         des.sort()
         for de in des:
@@ -2215,23 +2215,23 @@ class ShutDown(object):
                     bus = systembus
                 interface = bus.get_object(dbus_props['service'], dbus_props['objectPath'])
                 proxy = interface.get_dbus_method(dbus_props['method'], dbus_props['interface'])
-                return((proxy, dbus_props['arguments']))
+                return (proxy, dbus_props['arguments'])
             except dbus.exceptions.DBusException:
                 continue
-        return((None, None))
+        return (None, None)
 
     def canShutdown(self):
         """
         Indicate if a valid dbus service is available to shutdown system.
         """
-        return(not self.proxy is None or self.is_root)
+        return not self.proxy is None or self.is_root
 
     def askBeforeQuit(self):
         """
         Indicate if ShutDown is ready to fire and so the application
         shouldn't be closed.
         """
-        return(self.activate_shutdown and not self.started)
+        return self.activate_shutdown and not self.started
 
     def shutdown(self):
         """
@@ -2239,7 +2239,7 @@ class ShutDown(object):
         call the dbus proxy to start the shutdown.
         """
         if not self.activate_shutdown:
-            return(False)
+            return False
 
         if self.is_root:
             self.started = True
@@ -2248,12 +2248,12 @@ class ShutDown(object):
             return proc.returncode
 
         if self.proxy is None:
-            return(False)
+            return False
 
         else:
             self.started = True
 
-            return(self.proxy(*self.args))
+            return self.proxy(*self.args)
 
     def unity7(self):
         """

--- a/qt/messagebox.py
+++ b/qt/messagebox.py
@@ -48,9 +48,9 @@ def askPasswordDialog(parent, title, prompt, language_code, timeout):
         password = dialog.textValue()
     else:
         password = ''
-    del(dialog)
+    del dialog
 
-    return(password)
+    return password
 
 def info(text, title=None, widget_to_center_on=None):
     """Show a modal information message box.

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -701,4 +701,3 @@ class ProfileCombo(SortedComboBox):
             if self.itemData(i) == profileID:
                 self.setCurrentIndex(i)
                 break
-

--- a/qt/qttools_path.py
+++ b/qt/qttools_path.py
@@ -37,4 +37,3 @@ def registerBackintimePath(*path):
 
     if path not in sys.path:
         sys.path.insert(0, path)
-

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -76,11 +76,15 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
 
         # Explicit activate checks
         err_codes = [
+            'C0305',  # trailing-newlines
+            'C0324',  # superfluous-parens
+            'C0410',  # multiple-imports
             'E0100',  # init-is-generator
             'E0101',  # return-in-init
             'E0102',  # function-redefined
             'E0103',  # not-in-loop
             'E0106',  # return-arg-in-generator
+            'E0213',  # no-self-argument
             'E0401',  # import-error
             'E0602',  # undefined-variable
             'E1101',  # no-member
@@ -93,10 +97,6 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
             # 'C0303',  # trailing-whitespace
-            'C0305',  # trailing-newlines
-            'C0324',  # superfluous-parens
-            'C0410',  # multiple-imports
-            'E0213',  # no-self-argument
             # 'R0201',  # no-self-use
             # 'R0202',  # no-classmethod-decorator
             # 'R0203',  # no-staticmethod-decorator

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -93,10 +93,10 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # problems currently exiting in the BIT code base. Quit easy to fix
             # because there count is low.
             # 'C0303',  # trailing-whitespace
-            # 'C0305',  # trailing-newlines
-            # 'C0324',  # superfluous-parens
-            # 'C0410',  # multiple-imports
-            # 'E0213',  # no-self-argument
+            'C0305',  # trailing-newlines
+            'C0324',  # superfluous-parens
+            'C0410',  # multiple-imports
+            'E0213',  # no-self-argument
             # 'R0201',  # no-self-use
             # 'R0202',  # no-classmethod-decorator
             # 'R0203',  # no-staticmethod-decorator


### PR DESCRIPTION
Fixing the pylint errors for 
 'C0305',  # trailing-newlines
 'C0324',  # superfluous-parens
 'C0410',  # multiple-imports
 'E0213',  # no-self-argument