### PR TITLE
chore: Clean update-version script from "debian" folder

### DIFF
--- a/updatecopyright.sh
+++ b/updatecopyright.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-find ./ -type f                \
-  ! -wholename "./common/po/*" \
-  ! -wholename "./.git/*"      \
-  -exec sed                    \
-  -e "/Germar Reitze/s/[cC]opyright ([cC]) \([0-9]*\)-\([0-9]*\) /Copyright (C) \1-$(date +%Y) /g" \
-  -e "/Germar Reitze/s/[cC]opyright ([cC]) \([0-9]*\) /Copyright (C) \1-$(date +%Y) /g" \
-  -i {} +

--- a/updateversion.sh
+++ b/updateversion.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Updates all version numbers using the VERSION file
 # and creates a new DEBIAN changelog file for this version
 # by extracting the changes of this version from the
@@ -31,9 +30,6 @@
 # TODO Make sure this script works idempotent (multiple calls = same result)
 # TODO This script does not update release dates scattered around in
 #      different files (eg. common/man/C/backintime.1 line 1)
-
-
-
 VERSION=`cat VERSION`
 
 if [[ $VERSION == *-dev ]]
@@ -46,12 +42,6 @@ echo VERSION: $VERSION
 MAINTAINER="Germar Reitze <germar.reitze@gmail.com>"
 # MAINTAINER="BIT Team <dan@le-web.org>"
 # MAINTAINER="BIT Team <bit-dev@python.org>"
-
-# update_sphinx_config () {
-#   echo "Update '$1'"
-#   sed -e "s/^\(\s*\)version = '.*'$/\1version = '$VERSION'/" \
-#       -i $1
-# }
 
 update_app_version () {
   echo "Update '$1'"
@@ -71,29 +61,7 @@ update_omf () {
       -i $1
 }
 
-# Extract all changelog lines of the specified version from the CHANGES file
-# into the file given by the first argument ($1).
-# This does only work if you strictly use the correct version headlines
-# in the changes file:
-# Version x.y.z and whatever you want # x.y.z must match $VERSION (from the VERSION file)
-update_changelog () {
-  echo "Update '$1'"
-  echo "backintime ($VERSION) unstable; urgency=low" > $1
-  # The following awk code extracts the changelog
-  # starting from the "Version" headline of $VERSION
-  # until the next "Version" headline
-  # and create a new file with all the lines in between.
-  cat CHANGES | awk 'BEGIN {ins=0} /^Version '$VERSION'/ && (ins == 0) {ins=1; next} /^Version [0-9.]+/ && (ins == 1) {exit 0} (ins == 1) {print "  "$0}' >> $1
-  if [ $(cat $1 | wc -l) -eq 1 ]; then
-      echo "  * TODO prepare next version" >> $1
-  fi
-  echo  " -- ${MAINTAINER}  $(date -R)" >> $1
-}
-
 update_app_version common/version.py
-
-# Sphinx now ask "backintime" itself about its version
-# update_sphinx_config common/doc-dev/conf.py
 
 update_man_page common/man/C/backintime.1
 
@@ -102,5 +70,3 @@ update_man_page common/man/C/backintime-config.1
 update_man_page common/man/C/backintime-askpass.1
 
 update_man_page qt/man/C/backintime-qt.1
-
-update_changelog debian/changelog


### PR DESCRIPTION
Based on the [latest comments](https://aur.archlinux.org/packages/backintime-git#comment-981159) on the AUR package `backintime-git`.

That script try to touch `debian/changelog` which doesn't exist anymore (see #1548).

Also removed `updatecopyright.sh` which is legally irrelevant. Copyright ends (depending on the country) **minimal** 50 years after the death of the author; in most cases much longer. In short: Copyright needs a start year but not refresh every year ([see](https://matija.suklje.name/how-and-why-to-properly-write-copyright-statements-in-your-code#why-not-bump-the-year-on-change)). See also the [Berne Convention](https://www.wipo.int/treaties/en/ip/berne/).