### PR TITLE
fix(build): Remove debian/copyright from configure script (#1548)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,13 @@ script:
   - cd common
   - ./configure  --python=python3
   - make unittest-v
-  - make install
+  - sudo make install
   - cd ..
   - cd qt
   - ./configure --python=python3
   - make
   - pytest
-  - make install
+  - sudo make install
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,13 @@ script:
   - cd common
   - ./configure  --python=python3
   - make unittest-v
+  - make install
   - cd ..
   - cd qt
   - ./configure --python=python3
   - make
   - pytest
+  - make install
 
 after_success:
   - coverage combine

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,11 @@ script:
   - cd common
   - ./configure  --python=python3
   - make unittest-v
-  - sudo make install
   - cd ..
   - cd qt
   - ./configure --python=python3
   - make
   - pytest
-  - sudo make install
 
 after_success:
   - coverage combine

--- a/common/configure
+++ b/common/configure
@@ -194,7 +194,6 @@ addNewline
 
 addComment "documentation"
 addInstallDir                        "/share/doc/backintime-common"
-addInstallFile "../debian/copyright" "/share/doc/backintime-common"
 addInstallFile "../AUTHORS"          "/share/doc/backintime-common"
 addInstallFile "../LICENSE"          "/share/doc/backintime-common"
 addInstallFile "../README.md"        "/share/doc/backintime-common"

--- a/qt/configure
+++ b/qt/configure
@@ -201,7 +201,6 @@ addNewline
 
 addComment "documentation"
 addInstallDir                        "/share/doc/backintime-qt"
-addInstallFile "../debian/copyright" "/share/doc/backintime-qt"
 addInstallFile "../AUTHORS"          "/share/doc/backintime-qt"
 addInstallFile "../LICENSE"          "/share/doc/backintime-qt"
 addInstallFile "../README.md"        "/share/doc/backintime-qt"


### PR DESCRIPTION
Another issue related to debian-folder removal (#1548). ~I will investigate why Travis didn't catch it.~ Travis didn't catch it because `make install` is not run there. I tried it but ran into several problems that might be related to the docker-like environment running on Travis. But I am not sure.