### PR TITLE
fix: Empty EncFS snapshotpath field in Manage profiles dialog

### DIFF
--- a/qt/app.py
+++ b/qt/app.py
@@ -901,8 +901,7 @@ class MainWindow(QMainWindow):
         # EncFS deprecation warning (see #1734)
         current_mode = self.config.snapshotsMode(self.config.currentProfile())
         if current_mode in ('local_encfs', 'ssh_encfs'):
-            # In the main window show the profile specific warning dialog only
-            # once per profile.
+            # Show the profile specific warning dialog only once per profile.
             if self.config.profileBoolValue('msg_shown_encfs') is False:
                 self.config.setProfileBoolValue('msg_shown_encfs', True)
                 dlg = encfsmsgbox.EncfsCreateWarning(self)

--- a/qt/app.py
+++ b/qt/app.py
@@ -898,6 +898,16 @@ class MainWindow(QMainWindow):
         self.updatePlaces()
         self.updateFilesView(0)
 
+        # EncFS deprecation warning (see #1734)
+        current_mode = self.config.snapshotsMode(self.config.currentProfile())
+        if current_mode in ('local_encfs', 'ssh_encfs'):
+            # In the main window show the profile specific warning dialog only
+            # once per profile.
+            if self.config.profileBoolValue('msg_shown_encfs') is False:
+                self.config.setProfileBoolValue('msg_shown_encfs', True)
+                dlg = encfsmsgbox.EncfsCreateWarning(self)
+                dlg.exec()
+
     def comboProfileChanged(self, index):
         if self.disableProfileChanged:
             return

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -2262,15 +2262,19 @@ class SettingsDialog(QDialog):
         self.cbSshCheckPing.setHidden(not enabled)
         self.cbSshCheckCommands.setHidden(not enabled)
 
-        # EncFS deprecation warnings
+        # EncFS deprecation warnings (see #1734)
         if active_mode in ('local_encfs', 'ssh_encfs'):
             self.encfsWarning.setHidden(False)
 
             # Workaround to avoid showing the warning messagebox just when
             # opening the manage profiles dialog.
             if self.isVisible():
-                dlg = encfsmsgbox.EncfsCreateWarning(self)
-                dlg.exec()
+                # Show the profile specific warning dialog only once per
+                # profile.
+                if self.config.profileBoolValue('msg_shown_encfs') is False:
+                    self.config.setProfileBoolValue('msg_shown_encfs', True)
+                    dlg = encfsmsgbox.EncfsCreateWarning(self)
+                    dlg.exec()
         else:
             self.encfsWarning.setHidden(True)
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -384,6 +384,9 @@ class SettingsDialog(QDialog):
         self.keyringSupported = tools.keyringSupported()
         self.cbPasswordSave.setEnabled(self.keyringSupported)
 
+        # mode change
+        self.comboModes.currentIndexChanged.connect(self.comboModesChanged)
+
         # host, user, profile id
         groupBox = QGroupBox(self)
         self.frameAdvanced = groupBox
@@ -1245,9 +1248,6 @@ class SettingsDialog(QDialog):
 
         self.updateProfiles()
         self.comboModesChanged()
-
-        # mode change
-        self.comboModes.currentIndexChanged.connect(self.comboModesChanged)
 
         # enable tabs scroll buttons again but keep dialog size
         size = self.sizeHint()


### PR DESCRIPTION
Fix #1808
Related to #1806 
Related to #1734

The problem described in #1808 causing an empty snapshotpath field in the Manage profiles dialog is fixed.

Beside of that the profile specific encfs-deprecation-warning dialog now is shown not only in Manage profiles dialog but also in MainWindow when an EncFS profile is selected. But it is shown only once. Otherwise it would be to annoying.

I will merge this soon and integrate it into the release candidate (PR #1806) and go on with manual testing.