### PR TITLE
Support ed25519 SSH keys for SSH tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,8 @@ case. The goal is to log into the SSH server on your local computer via
 - Populate the public key to the server executing `ssh-copy-id`.
 - Make the `ssh` instance run.
 - The port `22` (SSH default) should be available.
+- _Authorize_ the key with `$ ssh localhost` and insert your user accounts
+  password.
 
 To test the connection just execute `ssh localhost` and you should see an
 SSH shell **without** being asked for a password.

--- a/common/doc-dev/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md
+++ b/common/doc-dev/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md
@@ -70,20 +70,28 @@ required changes.
    Check if you already have a key pair:
 
    ```
-   ls -l ~/.ssh/id_rsa
+   ls -l ~/.ssh/id_*
    ```
    
-   If no `id_rsa` file exists create a new public/private key:
+   If no `id_rsa` or `id_ed25519` file exists create a new public/private key:
 
    ```commandline
+   # Generate RSA key
    ssh-keygen -t rsa -b 4096  # saves in ~/.ssh/id_rsa and id_rsa.pub by default
+
+   # OR generate ed25519 key
+   ssh-keygen -t ed25519 # saves in ~/.ssh/id_ed25519 and id_ed25519.pub by default
    # Enter and a remember a passphrase to protect your private key!
    ```
 
    Now copy the public key to the ssh server's `autorized_keys` file:
 
    ```commandline
-   ssh-copy-id -i ~/.ssh/id_rsa.pub username@localhost
+   # If you have id_rsa.pub:
+   cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+
+   # OR if you have id_ed25519.pub
+   cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
    ```
 
 1. Run the BiT unit tests to check if ssh tests do work now

--- a/common/doc-dev/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md
+++ b/common/doc-dev/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md
@@ -1,4 +1,14 @@
 # How to set up a local `openssh-server` to enable ssh unit tests
+<!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
+- [Motivation](#motivation)
+- [How the unit tests access the ssh server](#how-the-unit-tests-access-the-ssh-server)
+- [Installation](#installation)
+- [Optionally configure your local firewall to restrict ssh access](#optionally-configure-your-local-firewall-to-restrict-ssh-access)
+- [FAQ](#faq)
+  * [How can I temporarily disable the ssh unit tests since they consume too much time](#how-can-i-temporarily-disable-the-ssh-unit-tests-since-they-consume-too-much-time)
+  * [How can I permanently enable or disable the ssh server (sshd)?](#how-can-i-permanently-enable-or-disable-the-ssh-server-sshd)
+  * [How can I find out if my ssh server (sshd) is running?](#how-can-i-find-out-if-my-ssh-server-sshd-is-running)
+<!-- TOC end -->
 
 # Motivation
 
@@ -84,7 +94,10 @@ required changes.
    # Enter and a remember a passphrase to protect your private key!
    ```
 
-   Now copy the public key to the ssh server's `autorized_keys` file:
+   Now authorize the public key via adding it to the server's `autorized_keys`
+   file. This can be done with your first connection to the server (via `$ ssh
+   localhost`) and type in your password. Or it can be done manually by the
+   following commands: 
 
    ```commandline
    # If you have id_rsa.pub:
@@ -94,7 +107,7 @@ required changes.
    cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
    ```
 
-1. Run the BiT unit tests to check if ssh tests do work now
+1. Run the BIT unit tests to check if ssh tests do work now
 
    ```commandline
    cd common

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -1,27 +1,18 @@
-# Back In Time
-# Copyright (C) 2016-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2016-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2023 Christian BUHTZ <c.buhtz@posteo.jp>
+# SPDX-FileCopyrightText: © 2024 David Wales (@daviewales)
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
 """This module offers some helpers and tools for unittesting.
 
 Most of the content are `unittest.TestCase` derived classed doing basic setup
 for the testing environment. They are dealing with snapshot path's, SSH,
 config files and things like set.
 """
-
 import os
 import pathlib
 import sys
@@ -43,18 +34,20 @@ import snapshots
 tools.registerBackintimePath('qt', 'plugins')
 
 TMP_FLOCK = NamedTemporaryFile(prefix='backintime', suffix='.flock')
-# A simple (local) RSA key pair via "ssh-keygen" and activate it
-# via "ssh-copy-id localhost".
-RSA_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh' / 'id_rsa.pub'
-ED25519_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh' / 'id_ed25519.pub'
-
-AUTHORIZED_KEYS_FILE = pathlib.Path.home() / '.ssh' / 'authorized_keys'
+SSH_PATH = pathlib.Path.home() / '.ssh'
+AUTHORIZED_KEYS_FILE = SSH_PATH / 'authorized_keys'
 DUMMY = 'dummy_test_process.sh'
 
-public_keys = [RSA_PUBLIC_KEY_FILE, ED25519_PUBLIC_KEY_FILE]
-existing_public_keys = filter(lambda k: k.exists(), public_keys)
+public_keys = (
+    # RSA key
+    SSH_PATH / 'id_rsa.pub',
+    # ed25519 key
+    SSH_PATH / 'id_ed25519.pub',
+)
+existing_public_keys = tuple(filter(lambda k: k.exists(), public_keys))
 authorised_public_keys = []
 
+# Check if the existing keys are in authorized file
 if AUTHORIZED_KEYS_FILE.exists():
     with AUTHORIZED_KEYS_FILE.open('rb') as auth:
         auth_keys = auth.readlines()
@@ -70,11 +63,14 @@ if authorised_public_keys:
     PRIV_KEY_FILE = PUBLIC_KEY_FILE.with_suffix('')
 else:
     KEY_IN_AUTH = False
-    # Later code expects these to be defined. They won't work, because
-    # they are not authorised!
-    # TODO: Refactor to avoid needing to define these.
-    PUBLIC_KEY_FILE = public_keys[0]
-    PRIV_KEY_FILE = PUBLIC_KEY_FILE.with_suffix('')
+    try:
+        PUBLIC_KEY_FILE = existing_public_keys[0]
+        PRIV_KEY_FILE = PUBLIC_KEY_FILE.with_suffix('')
+    except IndexError:
+        PUBLIC_KEY_FILE = None
+        PRIV_KEY_FILE = None
+
+PRIV_KEY_IS_FILE = PRIV_KEY_FILE.is_file() if PRIV_KEY_FILE else False
 
 # check if port 22 on localhost is available
 # sshd should be there...
@@ -89,14 +85,21 @@ ON_RTD = os.environ.get('READTHEDOCS', 'None').lower() == 'true'
 
 SKIP_SSH_TEST_MESSAGE = 'Skip as this test requires a local ssh server, ' \
                         'public and private keys installed'
+# DEBUG
+print(f"{tools.processExists('sshd')=}")
+print(f'{PUBLIC_KEY_FILE=}')
+print(f'{PRIV_KEY_FILE=}')
+print(f'{PRIV_KEY_IS_FILE=}')
+print(f'{KEY_IN_AUTH=}')
+print(f'{sshdPortAvailable=}')
 
 # If False all SSH related tests are skipped.
 # On TravisCI that tests are enforced and never skipped.
 LOCAL_SSH = True if ON_TRAVIS else all([
     # Server process running?
     tools.processExists('sshd'),
-    # Privat keyfile (id_rsa)
-    PRIV_KEY_FILE.is_file(),
+    # Privat keyfile
+    PRIV_KEY_IS_FILE,
     # Key known (copied via "ssh-copy-id")
     KEY_IN_AUTH,
     # SSH port (22) available at the server

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -45,17 +45,36 @@ tools.registerBackintimePath('qt', 'plugins')
 TMP_FLOCK = NamedTemporaryFile(prefix='backintime', suffix='.flock')
 # A simple (local) RSA key pair via "ssh-keygen" and activate it
 # via "ssh-copy-id localhost".
-PRIV_KEY_FILE = pathlib.Path.home() / '.ssh' / 'id_rsa'
-PUBLIC_KEY_FILE = PRIV_KEY_FILE.with_suffix('.pub')
+RSA_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh/id_rsa.pub'
+ED25519_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh/id_ed25519.pub'
+
 AUTHORIZED_KEYS_FILE = pathlib.Path.home() / '.ssh' / 'authorized_keys'
 DUMMY = 'dummy_test_process.sh'
 
-if all([PUBLIC_KEY_FILE.exists(), AUTHORIZED_KEYS_FILE.exists()]):
-    with PUBLIC_KEY_FILE.open('rb') as pub:
-        with AUTHORIZED_KEYS_FILE.open('rb') as auth:
-            KEY_IN_AUTH = pub.read() in auth.readlines()
+public_keys = [RSA_PUBLIC_KEY_FILE, ED25519_PUBLIC_KEY_FILE]
+existing_public_keys = filter(lambda k: k.exists(), public_keys)
+authorised_public_keys = []
+
+if AUTHORIZED_KEYS_FILE.exists():
+    with AUTHORIZED_KEYS_FILE.open('rb') as auth:
+        auth_keys = auth.readlines()
+
+    for key in existing_public_keys:
+        with key.open('rb') as pub:
+            if pub.read() in auth_keys:
+                authorised_public_keys.append(key)
+
+if authorised_public_keys:
+    KEY_IN_AUTH = True
+    PUBLIC_KEY_FILE = authorised_public_keys[0]
+    PRIV_KEY_FILE = PUBLIC_KEY_FILE.with_suffix('')
 else:
     KEY_IN_AUTH = False
+    # Later code expects these to be defined. They won't work, because
+    # they are not authorised!
+    # TODO: Refactor to avoid needing to define these.
+    PUBLIC_KEY_FILE = public_keys[0]
+    PRIV_KEY_FILE = PUBLIC_KEY_FILE.with_suffix('')
 
 # check if port 22 on localhost is available
 # sshd should be there...

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -85,13 +85,13 @@ ON_RTD = os.environ.get('READTHEDOCS', 'None').lower() == 'true'
 
 SKIP_SSH_TEST_MESSAGE = 'Skip as this test requires a local ssh server, ' \
                         'public and private keys installed'
-# DEBUG
-print(f"{tools.processExists('sshd')=}")
-print(f'{PUBLIC_KEY_FILE=}')
-print(f'{PRIV_KEY_FILE=}')
-print(f'{PRIV_KEY_IS_FILE=}')
-print(f'{KEY_IN_AUTH=}')
-print(f'{sshdPortAvailable=}')
+# # DEBUG
+# print(f"{tools.processExists('sshd')=}")
+# print(f'{PUBLIC_KEY_FILE=}')
+# print(f'{PRIV_KEY_FILE=}')
+# print(f'{PRIV_KEY_IS_FILE=}')
+# print(f'{KEY_IN_AUTH=}')
+# print(f'{sshdPortAvailable=}')
 
 # If False all SSH related tests are skipped.
 # On TravisCI that tests are enforced and never skipped.

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -45,8 +45,8 @@ tools.registerBackintimePath('qt', 'plugins')
 TMP_FLOCK = NamedTemporaryFile(prefix='backintime', suffix='.flock')
 # A simple (local) RSA key pair via "ssh-keygen" and activate it
 # via "ssh-copy-id localhost".
-RSA_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh/id_rsa.pub'
-ED25519_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh/id_ed25519.pub'
+RSA_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh' / 'id_rsa.pub'
+ED25519_PUBLIC_KEY_FILE = pathlib.Path.home() / '.ssh' / 'id_ed25519.pub'
 
 AUTHORIZED_KEYS_FILE = pathlib.Path.home() / '.ssh' / 'authorized_keys'
 DUMMY = 'dummy_test_process.sh'

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -276,13 +276,6 @@ class TestSshKey(generic.TestCaseCfg):
 
         hostKey = '/etc/ssh/ssh_host_{}_key.pub'.format(keyType.lower())
         self.assertExists(hostKey)
-        self.assertEqual(3, len(keyHash.split()))
-        try:
-            with open(hostKey, 'rt') as f:
-                pubKey = f.read().split()[1]
-            self.assertEqual(pubKey, keyHash.split()[2])
-        except (IOError, IndexError):
-            pass
 
     def test_writeKnownHostFile(self):
         KEY = '|1|abcdefghijklmnopqrstuvwxyz= ecdsa-sha2-nistp256 AAAAABCDEFGHIJKLMNOPQRSTUVWXYZ='


### PR DESCRIPTION
Experiment with allowing ed25519 SSH keys for SSH tests.

Note, I think this should work. However, I haven't been able to test it properly, because the SSH tests are unable to unlock my SSH key. This is strange, because I can `ssh user@localhost` without specifying a password, so I know that `authorized_keys` is setup correctly.

These changes do appear to correctly detect which kind of key I have, whether it is authorised, and pass it through to the tests.

The error looks like this:

<details>

```
/usr/bin/python3 -m unittest  -b test/test_restore.py
WARNING: Failed to read process stat from /proc/21142/stat: [2] No such file or directory
.........E
Stderr:
WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpny1rrgcg'>
  _warnings.warn(warn_message, ResourceWarning)
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpgdzbjznm'>
  _warnings.warn(warn_message, ResourceWarning)
ERROR: Failed to unlock SSH private key /home/dwales/.ssh/id_ed25519: WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/getpass.py:91: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.
Enter password for SSH private key profile "Main profile": Traceback (most recent call last):
  File "/usr/lib/python3.12/getpass.py", line 69, in unix_getpass
    old = termios.tcgetattr(fd)     # a copy to save
          ^^^^^^^^^^^^^^^^^^^^^
termios.error: (25, 'Inappropriate ioctl for device')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/backintime/common/askpass.py", line 45, in <module>
    print(pw.password(None, profile_id, mode))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 205, in password
    password = self.passwordFromUser(parent, profile_id, mode, pw_id)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 291, in passwordFromUser
    password = getpass.getpass(prompt + ' ')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 91, in unix_getpass
    passwd = fallback_getpass(prompt, stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 126, in fallback_getpass
    return _raw_input(prompt, stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 148, in _raw_input
    raise EOFError
EOFError

E
Stderr:
WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmp67sd_znp'>
  _warnings.warn(warn_message, ResourceWarning)
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpn16ifmox'>
  _warnings.warn(warn_message, ResourceWarning)
/usr/lib/python3.12/subprocess.py:1127: ResourceWarning: subprocess 21306 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
ERROR: Failed to unlock SSH private key /home/dwales/.ssh/id_ed25519: WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/getpass.py:91: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.
Enter password for SSH private key profile "Main profile": Traceback (most recent call last):
  File "/usr/lib/python3.12/getpass.py", line 69, in unix_getpass
    old = termios.tcgetattr(fd)     # a copy to save
          ^^^^^^^^^^^^^^^^^^^^^
termios.error: (25, 'Inappropriate ioctl for device')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/backintime/common/askpass.py", line 45, in <module>
    print(pw.password(None, profile_id, mode))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 205, in password
    password = self.passwordFromUser(parent, profile_id, mode, pw_id)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 291, in passwordFromUser
    password = getpass.getpass(prompt + ' ')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 91, in unix_getpass
    passwd = fallback_getpass(prompt, stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 126, in fallback_getpass
    return _raw_input(prompt, stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 148, in _raw_input
    raise EOFError
EOFError


======================================================================
ERROR: test_restore (test.test_restore.TestRestoreSSH.test_restore)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dwales/code/not-my-code/backintime/common/test/test_restore.py", line 189, in setUp
    self.cfg.setCurrentHashId(mount.Mount(cfg = self.cfg).mount())
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dwales/code/not-my-code/backintime/common/mount.py", line 221, in mount
    backend = mounttools(cfg = self.config,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dwales/code/not-my-code/backintime/common/sshtools.py", line 180, in __init__
    self.unlockSshAgent()
  File "/home/dwales/code/not-my-code/backintime/common/sshtools.py", line 443, in unlockSshAgent
    raise MountException(
exceptions.MountException: Could not unlock ssh private key. Wrong password or password not available for cron.

Stderr:
WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpny1rrgcg'>
  _warnings.warn(warn_message, ResourceWarning)
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpgdzbjznm'>
  _warnings.warn(warn_message, ResourceWarning)
ERROR: Failed to unlock SSH private key /home/dwales/.ssh/id_ed25519: WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/getpass.py:91: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.
Enter password for SSH private key profile "Main profile": Traceback (most recent call last):
  File "/usr/lib/python3.12/getpass.py", line 69, in unix_getpass
    old = termios.tcgetattr(fd)     # a copy to save
          ^^^^^^^^^^^^^^^^^^^^^
termios.error: (25, 'Inappropriate ioctl for device')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/backintime/common/askpass.py", line 45, in <module>
    print(pw.password(None, profile_id, mode))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 205, in password
    password = self.passwordFromUser(parent, profile_id, mode, pw_id)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 291, in passwordFromUser
    password = getpass.getpass(prompt + ' ')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 91, in unix_getpass
    passwd = fallback_getpass(prompt, stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 126, in fallback_getpass
    return _raw_input(prompt, stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 148, in _raw_input
    raise EOFError
EOFError


======================================================================
ERROR: test_restore_file_with_spaces (test.test_restore.TestRestoreSSH.test_restore_file_with_spaces)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dwales/code/not-my-code/backintime/common/test/test_restore.py", line 189, in setUp
    self.cfg.setCurrentHashId(mount.Mount(cfg = self.cfg).mount())
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dwales/code/not-my-code/backintime/common/mount.py", line 221, in mount
    backend = mounttools(cfg = self.config,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dwales/code/not-my-code/backintime/common/sshtools.py", line 180, in __init__
    self.unlockSshAgent()
  File "/home/dwales/code/not-my-code/backintime/common/sshtools.py", line 443, in unlockSshAgent
    raise MountException(
exceptions.MountException: Could not unlock ssh private key. Wrong password or password not available for cron.

Stderr:
WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmp67sd_znp'>
  _warnings.warn(warn_message, ResourceWarning)
/usr/lib/python3.12/tempfile.py:1075: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpn16ifmox'>
  _warnings.warn(warn_message, ResourceWarning)
/usr/lib/python3.12/subprocess.py:1127: ResourceWarning: subprocess 21306 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback
ERROR: Failed to unlock SSH private key /home/dwales/.ssh/id_ed25519: WARNING: Failed to connect to Udev serviceHelper daemon via D-Bus: org.freedesktop.DBus.Error.ServiceUnknown
WARNING: D-Bus message: The name net.launchpad.backintime.serviceHelper was not provided by any .service files
WARNING: Udev-based profiles cannot be changed or checked due to Udev serviceHelper connection failure
/usr/lib/python3.12/getpass.py:91: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.
Enter password for SSH private key profile "Main profile": Traceback (most recent call last):
  File "/usr/lib/python3.12/getpass.py", line 69, in unix_getpass
    old = termios.tcgetattr(fd)     # a copy to save
          ^^^^^^^^^^^^^^^^^^^^^
termios.error: (25, 'Inappropriate ioctl for device')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/backintime/common/askpass.py", line 45, in <module>
    print(pw.password(None, profile_id, mode))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 205, in password
    password = self.passwordFromUser(parent, profile_id, mode, pw_id)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 291, in passwordFromUser
    password = getpass.getpass(prompt + ' ')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 91, in unix_getpass
    passwd = fallback_getpass(prompt, stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 126, in fallback_getpass
    return _raw_input(prompt, stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 148, in _raw_input
    raise EOFError
EOFErro
```

</details>

The interesting bits are:

``` python
/usr/lib/python3.12/getpass.py:91: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.
Enter password for SSH private key profile "Main profile": Traceback (most recent call last):
  File "/usr/lib/python3.12/getpass.py", line 69, in unix_getpass
    old = termios.tcgetattr(fd)     # a copy to save
          ^^^^^^^^^^^^^^^^^^^^^
termios.error: (25, 'Inappropriate ioctl for device')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/share/backintime/common/askpass.py", line 45, in <module>
    print(pw.password(None, profile_id, mode))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 205, in password
    password = self.passwordFromUser(parent, profile_id, mode, pw_id)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/backintime/common/password.py", line 291, in passwordFromUser
    password = getpass.getpass(prompt + ' ')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 91, in unix_getpass
    passwd = fallback_getpass(prompt, stream)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 126, in fallback_getpass
    return _raw_input(prompt, stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/getpass.py", line 148, in _raw_input
    raise EOFError
EOFError


======================================================================
ERROR: test_restore (test.test_restore.TestRestoreSSH.test_restore)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dwales/code/not-my-code/backintime/common/test/test_restore.py", line 189, in setUp
    self.cfg.setCurrentHashId(mount.Mount(cfg = self.cfg).mount())
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dwales/code/not-my-code/backintime/common/mount.py", line 221, in mount
    backend = mounttools(cfg = self.config,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dwales/code/not-my-code/backintime/common/sshtools.py", line 180, in __init__
    self.unlockSshAgent()
  File "/home/dwales/code/not-my-code/backintime/common/sshtools.py", line 443, in unlockSshAgent
    raise MountException(
exceptions.MountException: Could not unlock ssh private key. Wrong password or password not available for cron.
```

Very strangely, if I print out the result from `sshtools.py:374`, I get:

```
output='The agent has no identities.\n'
```

But if I run the following manually, it is able to access my key:

```
>>> proc = subprocess.Popen(['ssh-add', '-l'],
...                         stdout=subprocess.PIPE,
...                         universal_newlines=True)
...
>>> output = proc.communicate()[0]
>>> print(f"{output=}")
output='256 SHA256:5F... \n'
```

So, I suspect that the tests are running in an isolated way which prevents them from accessing my `ssh-agent`. This then triggers an issue with fetching my credentials with `backintime-askpass`.

**EDIT**: I can see that the tests run find in CI, so perhaps it's just an issue with my setup.