### PR TITLE
refactor: Use new-style class definitions

### DIFF
--- a/common/cli.py
+++ b/common/cli.py
@@ -203,7 +203,7 @@ def frame(msg, size = 32):
     ret += ' +' + '-' * size +       '+'
     return ret
 
-class RestoreDialog(object):
+class RestoreDialog:
     def __init__(self, cfg, sid, what, where, **kwargs):
         self.config = cfg
         self.sid = sid

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -22,7 +22,7 @@ import re
 import logger
 
 
-class ConfigFile(object):
+class ConfigFile:
     """Store options in a plain text file in form of: key=value
     """
 

--- a/common/encfstools.py
+++ b/common/encfstools.py
@@ -341,7 +341,7 @@ class EncFS_SSH(EncFS_mount):
                 d['hash_id'] = d['hash_id_1']
             return d
 
-class Encode(object):
+class Encode:
     """
     encode path with encfsctl.
     ENCFS_SSH will replace config.ENCODE with this
@@ -463,7 +463,7 @@ class Encode(object):
             logger.debug('stop \'encfsctl encode\' process', self)
             self.p.communicate()
 
-class Bounce(object):
+class Bounce:
     """
     Dummy class that will simply return all input.
     This is the standard for config.ENCODE
@@ -486,7 +486,7 @@ class Bounce(object):
     def close(self):
         pass
 
-class Decode(object):
+class Decode:
     """
     decode path with encfsctl.
     """

--- a/common/mount.py
+++ b/common/mount.py
@@ -118,7 +118,7 @@ import tools
 from exceptions import HashCollision, MountException
 
 
-class Mount(object):
+class Mount:
     """
     This is the high-level mount API. This will handle mount, umount, remount
     and checks on the low-level :py:class:`MountControl` subclass backends for
@@ -375,7 +375,7 @@ class Mount(object):
             self.profile_id = new_profile_id
             return self.mount(mode = mode, **kwargs)
 
-class MountControl(object):
+class MountControl:
     """This is the low-level mount API. This should be subclassed by backends.
 
     Subclasses should have its own ``__init__`` but **must** also call the

--- a/common/password.py
+++ b/common/password.py
@@ -147,7 +147,7 @@ class Password_Cache(daemon.Daemon):
         self.fifo.delfifo()
         super(Password_Cache, self).cleanupHandler(signum, frame)
 
-class Password(object):
+class Password:
     """Provide passwords for BIT either from keyring, Password_Cache or
     by asking user.
     """

--- a/common/password_ipc.py
+++ b/common/password_ipc.py
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 
 import logger
 
-class FIFO(object):
+class FIFO:
     """
     interprocess-communication with named pipes
     """

--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -23,7 +23,7 @@ import snapshots
 import tools
 
 
-class LogFilter(object):
+class LogFilter:
     """
     A Filter for snapshot logs which will both decode log lines and filter them
     for the requested ``mode``.
@@ -145,7 +145,7 @@ class LogFilter(object):
         else:
             return line
 
-class SnapshotLog(object):
+class SnapshotLog:
     """
     Read and write Snapshot log to "~/.local/share/backintime/takesnapshot_<N>.log".
     Where <N> is the profile ID ``profile``.

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2392,7 +2392,7 @@ class FileInfoDict(dict):
         super(FileInfoDict, self).__setitem__(key, value)
 
 
-class SID(object):
+class SID:
     """
     Snapshot ID object used to gather all information for a snapshot
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -1980,7 +1980,7 @@ class UniquenessSet:
             return self.reference == (st.st_size, int(st.st_mtime))
 
 
-class Alarm(object):
+class Alarm:
     """
     Establish a callback function that is called after a timeout.
 
@@ -2053,7 +2053,7 @@ class Alarm(object):
             self.callback()
 
 
-class ShutDown(object):
+class ShutDown:
     """
     Shutdown the system after the current snapshot has finished.
     This should work for KDE, Gnome, Unity, Cinnamon, XFCE, Mate and E17.
@@ -2241,7 +2241,7 @@ class ShutDown(object):
         return m and Version(m.group(1)) >= Version('7.0') and processExists('unity-panel-service')
 
 
-class SetupUdev(object):
+class SetupUdev:
     """
     Setup Udev rules for starting BackInTime when a drive get connected.
     This is done by serviceHelper.py script (included in backintime-qt)
@@ -2333,7 +2333,7 @@ class SetupUdev(object):
         self.iface.clean()
 
 
-class PathHistory(object):
+class PathHistory:
     def __init__(self, path):
         self.history = [path,]
         self.index = 0
@@ -2368,7 +2368,7 @@ class PathHistory(object):
         self.index = 0
 
 
-class Execute(object):
+class Execute:
     """Execute external commands and handle its output.
 
     Args:

--- a/qt/serviceHelper.py
+++ b/qt/serviceHelper.py
@@ -338,7 +338,7 @@ class UdevRules(dbus.service.Object):
             raise PermissionDeniedByPolicy(privilege)
 
 
-class SenderInfo(object):
+class SenderInfo:
     def __init__(self, sender, conn):
         self.sender = sender
         self.dbus_info = dbus.Interface(conn.get_object('org.freedesktop.DBus',


### PR DESCRIPTION
In Python 3 new-style classes are default.
It's no longer necessary to subclass `object`.

Classes defined like this:

    class MyClass(object):

are redefined as:

    class MyClass:

This change was generated with the following command:

    find . -name '*.py' -exec sed -i 's/\(class .*\)(object):/\1:/' {} +

