### PR TITLE
Feature: Warn if destination directory is formatted as ntfs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.5.3-dev (development of upcoming release)
+* Feature: Warn if destination directory is formatted as NTFS
 * Breaking Change: Minimal Python version 3.9 required (#1731)
 * Fix: Prevent duplicates in Exclude/Include list of Manage Profiles dialog
 * Fix: Fix Qt segmentation fault when canceling out of unconfigured BiT (#1095) (Derek Veit @DerekVeit)

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Back In Time
 
 Version 1.5.3-dev (development of upcoming release)
-* Feature: Warn if destination directory is formatted as NTFS
+* Feature: Warn if destination directory is formatted as NTFS (#1854) (David Gibbs @fallingrock)
 * Breaking Change: Minimal Python version 3.9 required (#1731)
 * Fix: Prevent duplicates in Exclude/Include list of Manage Profiles dialog
 * Fix: Fix Qt segmentation fault when canceling out of unconfigured BiT (#1095) (Derek Veit @DerekVeit)

--- a/FAQ.md
+++ b/FAQ.md
@@ -34,6 +34,7 @@
    * [What happens if I hibernate the computer while a backup is running?](#what-happens-if-i-hibernate-the-computer-while-a-backup-is-running)
    * [What happens if I power down the computer while a backup is running, or if a power outage happens?](#what-happens-if-i-power-down-the-computer-while-a-backup-is-running-or-if-a-power-outage-happens)
    * [What happens if there is not enough disk space for the current backup?](#what-happens-if-there-is-not-enough-disk-space-for-the-current-backup)
+   * [NTFS Compatability](#ntfs-compatability)
 - [user-callback and other PlugIns](#user-callback-and-other-plugins)
    * [How to backup Debian/Ubuntu Package selection?](#how-to-backup-debianubuntu-package-selection)
    * [How to restore Debian/Ubuntu Package selection?](#how-to-restore-debianubuntu-package-selection)
@@ -587,6 +588,28 @@ snapshot will be kept and marked ``With Errors`` or it will be removed.
 By default, *Back In Time* will finally remove the oldest snapshots until there is
 more than 1 GiB free space again.
 
+## NTFS Compatability
+Although devices formatted with the NTFS file system can generally be used with *Back In Time*, there are some limitations to be aware of.
+
+NTFS File systems do not support the following characters in filenames or directories:
+
+```text
+< (less than)
+> (greater than)
+: (colon)
+" (double quote)
+/ (forward slash)
+\ (backslash)
+| (vertical bar or pipe)
+? (question mark)
+* (asterisk)
+```
+
+If *Back In Time* tries to copy files where the filename contains those character, an "Invalid argument (22)" error message will be displayed.
+
+It is recommended that only devices formatted with Unix style file systems (such as ext4) be used.
+
+For more information, refer to [this Microsoft page](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions).
 
 # user-callback and other PlugIns
 

--- a/common/config.py
+++ b/common/config.py
@@ -133,6 +133,9 @@ class Config(configfile.ConfigFileWithProfiles):
     ENCODE = encfstools.Bounce()
     PLUGIN_MANAGER = pluginmanager.PluginManager()
 
+    NTFS_FILESYSTEM_WARNING = _('The destination filesystem for {path} is formatted with NTFS, '
+                                'which has known incompatibilities with Unix-style filesystems.')
+
     def __init__(self, config_path=None, data_path=None):
         """Back In Time configuration (and much more then this).
 
@@ -495,10 +498,7 @@ class Config(configfile.ConfigFileWithProfiles):
             return False
 
         elif fs.startswith('ntfs'):
-            self.notifyError(
-                _('Destination filesystem for {path} is formatted with NTFS '
-                  'which has known incompatibilities with Unix style file systems.')
-                .format(path=value))
+            self.notifyError(self.NTFS_FILESYSTEM_WARNING.format(path=value))
 
         elif fs == 'cifs' and not self.copyLinks():
             self.notifyError(_(

--- a/common/config.py
+++ b/common/config.py
@@ -494,6 +494,12 @@ class Config(configfile.ConfigFileWithProfiles):
 
             return False
 
+        elif fs.startswith('ntfs'):
+            self.notifyError(
+                _('Destination filesystem for {path} is formatted with NTFS '
+                  'which has known incompatibilities with Unix style file systems.')
+                .format(path=value))
+
         elif fs == 'cifs' and not self.copyLinks():
             self.notifyError(_(
                 'Destination filesystem for {path} is an SMB-mounted share. '

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1947,10 +1947,11 @@ class SettingsDialog(QDialog):
 
                 self.config.removeProfileKey('snapshots.path.uuid')
 
-            if tools.filesystem(path).startswith('ntfs'):
-                text = _('Warning: {path} is formatted as NTFS which has known incompatibilities '
-                         'with unix style file systems.\nAre you sure you want to use it as '
-                         'your backup destination?')
+            fs = tools.filesystem(path)
+            if fs.startswith('ntfs'):
+                text = _('Warning: Destination filesystem for {path} is formatted with NTFS '
+                         'which has known incompatibilities with Unix style file systems.\n'
+                         'Are you sure you want to use it as your backup destination?')
                 question = text.format(path=path)
                 if not self.questionHandler(question):
                     return

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1950,10 +1950,9 @@ class SettingsDialog(QDialog):
             fs = tools.filesystem(path)
             if fs.startswith('ntfs'):
                 text = '\n'.join([
-                       _('Warning: The destination filesystem for {path} is formatted with NTFS, '
-                         'which has known incompatibilities with Unix-style filesystems.'),                             
-                       _('Is this the backup destination to be used?')
-                })
+                    self.config.NTFS_FILESYSTEM_WARNING,
+                    _('Is this the backup destination to be used?')
+                ])
                 question = text.format(path=path)
                 if not self.questionHandler(question):
                     return

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -15,7 +15,6 @@ import datetime
 import copy
 import re
 import getpass
-import psutil
 from PyQt6.QtGui import (QIcon,
                          QFont,
                          QPalette,
@@ -1948,7 +1947,7 @@ class SettingsDialog(QDialog):
 
                 self.config.removeProfileKey('snapshots.path.uuid')
 
-            if self.get_fs_type(path).startswith('ntfs'):
+            if tools.filesystem(path).startswith('ntfs'):
                 text = _('Warning: {0} is formatted as NTFS which has known incompatabilities '
                          'with unix style file systems.\n\n'
                          'Are you sure you want to use it as your backup destination?')
@@ -1957,19 +1956,6 @@ class SettingsDialog(QDialog):
                     return
 
             self.editSnapshotsPath.setText(self.config.preparePath(path))
-
-    def get_fs_type(self, mypath):
-        root_type = ""
-        for part in psutil.disk_partitions():
-            if part.mountpoint == '/':
-                root_type = part.fstype
-                continue
-
-            if mypath.startswith(part.mountpoint):
-                return part.fstype
-
-        return root_type
-
 
     def btnSshPrivateKeyFileClicked(self):
         old_file = self.txtSshPrivateKeyFile.text()

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -15,6 +15,7 @@ import datetime
 import copy
 import re
 import getpass
+import psutil
 from PyQt6.QtGui import (QIcon,
                          QFont,
                          QPalette,
@@ -1947,7 +1948,28 @@ class SettingsDialog(QDialog):
 
                 self.config.removeProfileKey('snapshots.path.uuid')
 
+            if self.get_fs_type(path).startswith('ntfs'):
+                text = _('Warning: {0} is formatted as NTFS which has known incompatabilities '
+                         'with unix style file systems.\n\n'
+                         'Are you sure you want to use it as your backup destination?')
+                question = text.format(path)
+                if not self.questionHandler(question):
+                    return
+
             self.editSnapshotsPath.setText(self.config.preparePath(path))
+
+    def get_fs_type(self, mypath):
+        root_type = ""
+        for part in psutil.disk_partitions():
+            if part.mountpoint == '/':
+                root_type = part.fstype
+                continue
+
+            if mypath.startswith(part.mountpoint):
+                return part.fstype
+
+        return root_type
+
 
     def btnSshPrivateKeyFileClicked(self):
         old_file = self.txtSshPrivateKeyFile.text()

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1949,9 +1949,11 @@ class SettingsDialog(QDialog):
 
             fs = tools.filesystem(path)
             if fs.startswith('ntfs'):
-                text = _('Warning: Destination filesystem for {path} is formatted with NTFS '
-                         'which has known incompatibilities with Unix style file systems.\n'
-                         'Are you sure you want to use it as your backup destination?')
+                text = '\n'.join([
+                       _('Warning: The destination filesystem for {path} is formatted with NTFS, '
+                         'which has known incompatibilities with Unix-style filesystems.'),                             
+                       _('Is this the backup destination to be used?')
+                })
                 question = text.format(path=path)
                 if not self.questionHandler(question):
                     return

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1948,10 +1948,10 @@ class SettingsDialog(QDialog):
                 self.config.removeProfileKey('snapshots.path.uuid')
 
             if tools.filesystem(path).startswith('ntfs'):
-                text = _('Warning: {0} is formatted as NTFS which has known incompatabilities '
-                         'with unix style file systems.\n\n'
-                         'Are you sure you want to use it as your backup destination?')
-                question = text.format(path)
+                text = _('Warning: {path} is formatted as NTFS which has known incompatibilities '
+                         'with unix style file systems.\nAre you sure you want to use it as '
+                         'your backup destination?')
+                question = text.format(path=path)
                 if not self.questionHandler(question):
                     return
 


### PR DESCRIPTION
Warn user if destination directory is formatted as ntfs to avoid "Unsupported operation" errors.

Fix #1854