### PR TITLE
Fix/1864setsnapshotspath

### DIFF
--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
 #
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
 # General Public License v2 (GPLv2).

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Basic constants used in multiple modules."""
 
 # See issue #1734 and #1735

--- a/common/cli.py
+++ b/common/cli.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 import os
 import sys
 import tools

--- a/common/cli.py
+++ b/common/cli.py
@@ -99,9 +99,10 @@ def checkConfig(cfg, crontab = True):
 
     test = 'Check/prepare snapshot path'
     announceTest()
-    snapshots_path = cfg.snapshotsPath(mode = mode, tmp_mount = True)
+    snapshots_mountpoint = cfg.get_snapshots_mountpoint(tmp_mount=True)
 
-    if not cfg.setSnapshotsPath(snapshots_path, mode = mode):
+    # if not cfg.setSnapshotsPath(snapshots_path, mode = mode):
+    if not cfg.extra_magic_for_set_snapshots_path(snapshots_mountpoint):
         failed()
         return False
     okay()

--- a/common/cli.py
+++ b/common/cli.py
@@ -1,21 +1,11 @@
-# -*- coding: utf-8 -*-
-#    Back In Time
-#    Copyright (C) 2012-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
 #
-#    This program is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation; either version 2 of the License, or
-#    (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License along
-#    with this program; if not, write to the Free Software Foundation, Inc.,
-#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
 import os
 import sys
 import tools

--- a/common/cli.py
+++ b/common/cli.py
@@ -91,8 +91,13 @@ def checkConfig(cfg, crontab = True):
     announceTest()
     snapshots_mountpoint = cfg.get_snapshots_mountpoint(tmp_mount=True)
 
-    # if not cfg.setSnapshotsPath(snapshots_path, mode = mode):
-    if not tools.validate_snapshots_path(snapshots_mountpoint, cfg):
+    ret = tools.validate_snapshots_path(
+        path=snapshots_mountpoint,
+        host_user_profile=cfg.hostUserProfile(),
+        mode=mode,
+        copy_links=cfg.copyLinks(),
+        error_handler=cfg.notifyError)
+    if not ret:
         failed()
         return False
     okay()

--- a/common/cli.py
+++ b/common/cli.py
@@ -102,17 +102,17 @@ def checkConfig(cfg, crontab = True):
     snapshots_mountpoint = cfg.get_snapshots_mountpoint(tmp_mount=True)
 
     # if not cfg.setSnapshotsPath(snapshots_path, mode = mode):
-    if not cfg.extra_magic_for_set_snapshots_path(snapshots_mountpoint):
+    if not tools.validate_snapshots_path(snapshots_mountpoint, cfg):
         failed()
         return False
     okay()
 
-    #umount
+    # umount
     if not cfg.SNAPSHOT_MODES[mode][0] is None:
         test = 'Unmount'
         announceTest()
         try:
-            mnt.umount(hash_id = hash_id)
+            mnt.umount(hash_id=hash_id)
         except MountException as ex:
             failed()
             print(str(ex))

--- a/common/cli.py
+++ b/common/cli.py
@@ -91,7 +91,7 @@ def checkConfig(cfg, crontab = True):
     announceTest()
     snapshots_mountpoint = cfg.get_snapshots_mountpoint(tmp_mount=True)
 
-    ret = tools.validate_snapshots_path(
+    ret = tools.validate_and_prepare_snapshots_path(
         path=snapshots_mountpoint,
         host_user_profile=cfg.hostUserProfile(),
         mode=mode,

--- a/common/config.py
+++ b/common/config.py
@@ -397,9 +397,6 @@ class Config(configfile.ConfigFileWithProfiles):
                         return False
         return True
 
-    # def pid(self):
-    #     return str(os.getpid())
-
     def host(self):
         return socket.gethostname()
 
@@ -447,149 +444,6 @@ class Config(configfile.ConfigFileWithProfiles):
 
         self.setProfileStrValue('snapshots.path', value, profile_id)
 
-    # def is_filesystem_valid(self, full_path, msg_path, mode):
-    #     """
-    #     Args:
-    #         full_path: The path to validate.
-    #         msg_path: The path used for display in error messages.
-    #         mode: Snapshot profile mode.
-
-    #     Returns:
-    #         bool: ``False`` if `full_path` lives in a known problematic filesystem.
-    #     """
-    #     fs = tools.filesystem(
-    #         full_path if isinstance(full_path, str) else str(full_path))
-
-    #     # DEV NOTE
-    #     # notifyError() results in a messagebox
-    #     # Might be a candidate for a simple error-event-handler
-
-    #     if fs == 'vfat':
-    #         self.notifyError(_(
-    #             "Destination filesystem for {path} is formatted with FAT "
-    #             "which doesn't support hard-links. "
-    #             "Please use a native Linux filesystem.")
-    #             .format(path=msg_path))
-
-    #         return False
-
-    #     elif fs == 'cifs' and not self.copyLinks():
-    #         self.notifyError(_(
-    #             'Destination filesystem for {path} is an SMB-mounted share. '
-    #             'Please make sure the remote SMB server supports symlinks or '
-    #             'activate {copyLinks} in {expertOptions}.')
-    #             .format(path=msg_path,
-    #                     copyLinks=_('Copy links (dereference symbolic links)'),
-    #                     expertOptions=_('Expert Options')))
-
-    #     elif fs == 'fuse.sshfs' and mode not in ('ssh', 'ssh_encfs'):
-    #         self.notifyError(_(
-    #             "Destination filesystem for {path} is an sshfs-mounted share."
-    #             " Sshfs doesn't support hard-links. "
-    #             "Please use mode 'SSH' instead.")
-    #             .format(path=msg_path))
-
-    #         return False
-
-    #     return True
-
-    # def is_writeable(self, folder):
-    #     # Test write access for the folder
-
-    #     if not isinstance(folder, Path):
-    #         folder = Path(folder)
-
-    #     check_path = folder / 'check'
-
-    #     try:
-    #         check_path.mkdir(
-    #             # Do not create parent folders
-    #             parents=False,
-    #             # Raise error if exists
-    #             exist_ok=False
-    #         )
-
-    #     except PermissionError:
-    #         self.notifyError('\n'.join([
-    #             _('File creation failed in this folder:'),
-    #             str(folder),
-    #             _('Write access may be restricted.')]))
-    #         return False
-
-    #     else:
-    #         check_path.rmdir()
-
-    #     return True
-
-    # def extra_magic_for_set_snapshots_path(self, value, profile_id=None):
-    #     """Sets the snapshot path to value, initializes, and checks it
-    #     """
-    #     if not isinstance(value, Path):
-    #         value = Path(value)
-
-    #     if profile_id is None:
-    #         profile_id = self.currentProfile()
-
-    #     mode = self.snapshotsMode(profile_id)
-
-    #     if not value.is_dir():
-    #         self.notifyError(_('Invalid option. {path} is not a folder.')
-    #                          .format(path=value))
-    #         return False
-
-    #     # build full path
-    #     # <path>/backintime/<host>/<user>/<profile_id>
-    #     host, user, profile = self.hostUserProfile(profile_id)
-    #     full_path = value / 'backintime' / host / user / profile
-
-    #     # create full_path
-    #     try:
-    #         full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
-    #     except PermissionError:
-    #         self.notifyError('\n'.join([
-    #             _('Creation of following folder failed:'),
-    #             str(full_path),
-    #             _(f'Write access may be restricted.')]))
-    #         return False
-
-    #     # Test filesystem
-    #     if self.is_filesystem_valid(full_path, value, mode) is False:
-    #         return False
-
-    #     # Test write access for the folder
-    #     if self.is_writeable(full_path) is False:
-    #         return False
-
-    #     return True
-
-    # def setSnapshotsPath(self, value, profile_id = None, mode = None):
-    #     """
-    #     Sets the snapshot path to value, initializes, and checks it
-    #     """
-    #     if not value:
-    #         return False
-
-    #     if profile_id == None:
-    #         profile_id = self.currentProfile()
-
-    #     if mode is None:
-    #         mode = self.snapshotsMode(profile_id)
-
-    #     rc = tools.validate_snapshots_path(
-    #         path=value, cfg=self, profile_id=profile_id)
-    #     # rc = self.extra_magic_for_set_snapshots_path(value, profile_id)
-    #     if rc is False:
-    #         return False
-
-    #     # Need "mounttools"? (yes, if not "local")
-    #     if self.SNAPSHOT_MODES[mode][0] is None:
-    #         self.setProfileStrValue('snapshots.path', value, profile_id)
-    #     else:
-    #         # DEBUG
-    #         logger.error('Config.setSnapshotsPath() called with mode other than "local".')
-
-    #     return True
-
     def snapshotsMode(self, profile_id=None):
         #? Use mode (or backend) for this snapshot. Look at 'man backintime'
         #? section 'Modes'.;local|local_encfs|ssh|ssh_encfs
@@ -597,14 +451,6 @@ class Config(configfile.ConfigFileWithProfiles):
 
     def setSnapshotsMode(self, value, profile_id = None):
         self.setProfileStrValue('snapshots.mode', value, profile_id)
-
-    # def snapshotsSymlink(self, profile_id = None, tmp_mount = False):
-    #     if profile_id is None:
-    #         profile_id = self.current_profile_id
-    #     symlink = '%s_%s' % (profile_id, self.pid())
-    #     if tmp_mount:
-    #         symlink = 'tmp_%s' % symlink
-    #     return symlink
 
     def setCurrentHashId(self, hash_id):
         self.current_hash_id = hash_id

--- a/common/config.py
+++ b/common/config.py
@@ -52,6 +52,7 @@ import encfstools
 import password
 import pluginmanager
 import schedule
+from pathlib import Path
 from exceptions import PermissionDeniedByPolicy, \
                        InvalidChar, \
                        InvalidCmd, \
@@ -437,19 +438,16 @@ class Config(configfile.ConfigFileWithProfiles):
         host, user, profile = self.hostUserProfile(profile_id)
         return os.path.join(self.snapshotsPath(profile_id), 'backintime', host, user, profile)
 
-    def setSnapshotsPath(self, value, profile_id = None, mode = None):
+    def set_snapshots_path(self, value, profile_id=None):
+        """Sets the snapshot path to value, initializes, and checks it
         """
-        Sets the snapshot path to value, initializes, and checks it
-        """
-        logger.info(f'{"X"*20} setSnapshotsPath() :: {value=}', self)
-        if not value:
-            return False
+        logger.info(f'{"X"*20} set_snapshots_path() :: {value=}', self)
 
-        if profile_id == None:
+        if profile_id is None:
             profile_id = self.currentProfile()
 
-        if mode is None:
-            mode = self.snapshotsMode(profile_id)
+        # if mode is None:
+        #     mode = self.snapshotsMode(profile_id)
 
         if not os.path.isdir(value):
             self.notifyError(_('Invalid option. {path} is not a folder.').format(path=value))
@@ -530,6 +528,137 @@ class Config(configfile.ConfigFileWithProfiles):
             self.setProfileStrValue('snapshots.path', value, profile_id)
 
         print(f"{self.dict['profile3.snapshots.path']=}")
+        return True
+
+    def is_filesystem_valid(self, full_path, msg_path, mode):
+        """
+        Args:
+            full_path: The path to validate.
+            msg_path: The path used for display in error messages.
+            mode: Snapshot profile mode.
+
+        Returns:
+            bool: ``False`` if `full_path` lives in a known problematic filesystem.
+        """
+        fs = tools.filesystem(
+            full_path if isinstance(full_path, str) else str(full_path))
+
+        # DEV NOTE
+        # notifyError() results in a messagebox
+        # Might be a candidate for a simple error-event-handler
+
+        if fs == 'vfat':
+            self.notifyError(_(
+                "Destination filesystem for {path} is formatted with FAT "
+                "which doesn't support hard-links. "
+                "Please use a native Linux filesystem.")
+                .format(path=msg_path))
+
+            return False
+
+        elif fs == 'cifs' and not self.copyLinks():
+            self.notifyError(_(
+                'Destination filesystem for {path} is an SMB-mounted share. '
+                'Please make sure the remote SMB server supports symlinks or '
+                'activate {copyLinks} in {expertOptions}.')
+                .format(path=msg_path,
+                        copyLinks=_('Copy links (dereference symbolic links)'),
+                        expertOptions=_('Expert Options')))
+
+        elif fs == 'fuse.sshfs' and mode not in ('ssh', 'ssh_encfs'):
+            self.notifyError(_(
+                "Destination filesystem for {path} is an sshfs-mounted share."
+                " Sshfs doesn't support hard-links. "
+                "Please use mode 'SSH' instead.")
+                .format(path=msg_path))
+
+            return False
+
+        return True
+
+    def is_writeable(self, folder):
+        # Test write access for the folder
+
+        if not isinstance(folder, Path):
+            folder = Path(folder)
+
+        check_path = folder / 'check'
+
+        try:
+            check_path.mkdir(parent=False, exist_ok=False)
+
+        except PermissionError:
+            self.notifyError(_(
+                f"Can't write to: {folder}\nAre you sure you have "
+                "write access?"))
+
+            return False
+
+        else:
+            check_path.rmdir()
+
+        return True
+
+    def extra_magic_for_set_snapshots_path(self, value, profile_id=None, mode=None):
+        """Sets the snapshot path to value, initializes, and checks it
+        """
+        if not isinstance(value, Path):
+            value = Path(value)
+
+        logger.info(f'extra_magic_for_set_snapshots_path() :: {value=}', self)
+
+        if profile_id is None:
+            profile_id = self.currentProfile()
+
+        if mode is None:
+            mode = self.snapshotsMode(profile_id)
+
+        if not value.is_dir():
+            self.notifyError(_('Invalid option. {path} is not a folder.').format(path=value))
+            return False
+
+        # build full path
+        # <path>/backintime/<host>/<user>/<profile_id>
+        host, user, profile = self.hostUserProfile(profile_id)
+        full_path = value / 'backintime' / host / user / profile
+
+        # create full_path
+        full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
+
+        # Test filesystem
+        if self.is_filesystem_valid(full_path, value, mode) is False:
+            return False
+
+        # Test write access for the folder
+        if self.is_writeable(full_path) is False:
+            return False
+
+        return True
+
+    def setSnapshotsPath(self, value, profile_id = None, mode = None):
+        """
+        Sets the snapshot path to value, initializes, and checks it
+        """
+        logger.info(f'{"X"*20} setSnapshotsPath() :: {value=}', self)
+        if not value:
+            return False
+
+        if profile_id == None:
+            profile_id = self.currentProfile()
+
+        if mode is None:
+            mode = self.snapshotsMode(profile_id)
+
+        self.extra_magic_for_set_snapshots_path(value, profile_id, mode)
+
+        # Need "mounttools"? (yes, if not "local")
+        if self.SNAPSHOT_MODES[mode][0] is None:
+            logger.info(f'    setProfileStrValue(snapshots.path, {value=})', self)
+            self.setProfileStrValue('snapshots.path', value, profile_id)
+        else:
+            # DEBUG
+            logger.error('Config.setSnapshotsPath() called with mode other than "local".')
+
         return True
 
     def snapshotsMode(self, profile_id=None):

--- a/common/config.py
+++ b/common/config.py
@@ -515,9 +515,9 @@ class Config(configfile.ConfigFileWithProfiles):
 
         except PermissionError:
             self.notifyError('\n'.join([
-                _(f'File creation of in following folder failed:'),
+                _('File creation failed in this folder:'),
                 str(folder),
-                _(f'Write access may be restricted.')]))
+                _('Write access may be restricted.')]))
             return False
 
         else:
@@ -554,7 +554,7 @@ class Config(configfile.ConfigFileWithProfiles):
             full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
         except PermissionError:
             self.notifyError('\n'.join([
-                _(f'Creation of following folder failed:'),
+                _('Creation of following folder failed:'),
                 str(full_path),
                 _(f'Write access may be restricted.')]))
             return False

--- a/common/config.py
+++ b/common/config.py
@@ -1,21 +1,15 @@
-# Back In Time
-# Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey,
-# Germar Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-"""Configuration logic.
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""Configuration handling and logic.
 
 This module and its `Config` class contain the application logic handling the
 configuration of Back In Time. The handling of the configuration file itself
@@ -403,8 +397,8 @@ class Config(configfile.ConfigFileWithProfiles):
                         return False
         return True
 
-    def pid(self):
-        return str(os.getpid())
+    # def pid(self):
+    #     return str(os.getpid())
 
     def host(self):
         return socket.gethostname()
@@ -417,16 +411,20 @@ class Config(configfile.ConfigFileWithProfiles):
         mode = self.snapshotsMode(profile_id)
 
         if mode == 'local':
-            return self.get_snapshots_path_and_only_that(profile_id)
+            return self.get_snapshots_path(profile_id)
 
-        # ssh/local_encfs/ssh_encfs
-        symlink = self.snapshotsSymlink(
-            profile_id=profile_id, tmp_mount=tmp_mount)
+        # else: ssh/local_encfs/ssh_encfs
+
+        symlink = f'{profile_id}_{os.getpid()}'
+        if tmp_mount:
+            symlink = f'tmp_{symlink}'
 
         return os.path.join(self._LOCAL_MOUNT_ROOT, symlink)
 
     def snapshotsPath(self, profile_id=None, mode=None, tmp_mount=False):
         """Return the snapshot path (backup destination) as a mount point.
+
+        That method is a surrogate for `self.get_snapshots_mountpoint()`.
         """
         return self.get_snapshots_mountpoint(
             profile_id=profile_id, tmp_mount=tmp_mount)
@@ -438,13 +436,12 @@ class Config(configfile.ConfigFileWithProfiles):
         host, user, profile = self.hostUserProfile(profile_id)
         return os.path.join(self.snapshotsPath(profile_id), 'backintime', host, user, profile)
 
-    def get_snapshots_path_and_only_that(self, profile_id):
+    def get_snapshots_path(self, profile_id):
         """Return the value of the snapshot path (backup destination) field."""
         return self.profileStrValue('snapshots.path', '', profile_id)
 
-    def set_snapshots_path_and_only_that(self, value, profile_id=None):
-        """Sets the snapshot path to value, initializes, and checks it
-        """
+    def set_snapshots_path(self, value, profile_id=None):
+        """Sets the snapshot path to value."""
         if profile_id is None:
             profile_id = self.currentProfile()
 
@@ -565,33 +562,33 @@ class Config(configfile.ConfigFileWithProfiles):
 
     #     return True
 
-    def setSnapshotsPath(self, value, profile_id = None, mode = None):
-        """
-        Sets the snapshot path to value, initializes, and checks it
-        """
-        if not value:
-            return False
+    # def setSnapshotsPath(self, value, profile_id = None, mode = None):
+    #     """
+    #     Sets the snapshot path to value, initializes, and checks it
+    #     """
+    #     if not value:
+    #         return False
 
-        if profile_id == None:
-            profile_id = self.currentProfile()
+    #     if profile_id == None:
+    #         profile_id = self.currentProfile()
 
-        if mode is None:
-            mode = self.snapshotsMode(profile_id)
+    #     if mode is None:
+    #         mode = self.snapshotsMode(profile_id)
 
-        rc = tools.validate_snapshots_path(
-            path=value, cfg=self, profile_id=profile_id)
-        # rc = self.extra_magic_for_set_snapshots_path(value, profile_id)
-        if rc is False:
-            return False
+    #     rc = tools.validate_snapshots_path(
+    #         path=value, cfg=self, profile_id=profile_id)
+    #     # rc = self.extra_magic_for_set_snapshots_path(value, profile_id)
+    #     if rc is False:
+    #         return False
 
-        # Need "mounttools"? (yes, if not "local")
-        if self.SNAPSHOT_MODES[mode][0] is None:
-            self.setProfileStrValue('snapshots.path', value, profile_id)
-        else:
-            # DEBUG
-            logger.error('Config.setSnapshotsPath() called with mode other than "local".')
+    #     # Need "mounttools"? (yes, if not "local")
+    #     if self.SNAPSHOT_MODES[mode][0] is None:
+    #         self.setProfileStrValue('snapshots.path', value, profile_id)
+    #     else:
+    #         # DEBUG
+    #         logger.error('Config.setSnapshotsPath() called with mode other than "local".')
 
-        return True
+    #     return True
 
     def snapshotsMode(self, profile_id=None):
         #? Use mode (or backend) for this snapshot. Look at 'man backintime'
@@ -601,13 +598,13 @@ class Config(configfile.ConfigFileWithProfiles):
     def setSnapshotsMode(self, value, profile_id = None):
         self.setProfileStrValue('snapshots.mode', value, profile_id)
 
-    def snapshotsSymlink(self, profile_id = None, tmp_mount = False):
-        if profile_id is None:
-            profile_id = self.current_profile_id
-        symlink = '%s_%s' % (profile_id, self.pid())
-        if tmp_mount:
-            symlink = 'tmp_%s' % symlink
-        return symlink
+    # def snapshotsSymlink(self, profile_id = None, tmp_mount = False):
+    #     if profile_id is None:
+    #         profile_id = self.current_profile_id
+    #     symlink = '%s_%s' % (profile_id, self.pid())
+    #     if tmp_mount:
+    #         symlink = 'tmp_%s' % symlink
+    #     return symlink
 
     def setCurrentHashId(self, hash_id):
         self.current_hash_id = hash_id

--- a/common/config.py
+++ b/common/config.py
@@ -441,6 +441,7 @@ class Config(configfile.ConfigFileWithProfiles):
         """
         Sets the snapshot path to value, initializes, and checks it
         """
+        logger.info(f'{"X"*20} setSnapshotsPath() :: {value=}', self)
         if not value:
             return False
 
@@ -522,8 +523,13 @@ class Config(configfile.ConfigFileWithProfiles):
             return False
 
         os.rmdir(check_path)
+
+        # Need "mounttools"? (yes, if not "local")
         if self.SNAPSHOT_MODES[mode][0] is None:
+            logger.info(f'    setProfileStrValue(snapshots.path, {value=})', self)
             self.setProfileStrValue('snapshots.path', value, profile_id)
+
+        print(f"{self.dict['profile3.snapshots.path']=}")
         return True
 
     def snapshotsMode(self, profile_id=None):

--- a/common/config.py
+++ b/common/config.py
@@ -7,8 +7,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Configuration handling and logic.
 
 This module and its `Config` class contain the application logic handling the

--- a/common/config.py
+++ b/common/config.py
@@ -52,7 +52,6 @@ import encfstools
 import password
 import pluginmanager
 import schedule
-from pathlib import Path
 from exceptions import PermissionDeniedByPolicy, \
                        InvalidChar, \
                        InvalidCmd, \
@@ -451,123 +450,120 @@ class Config(configfile.ConfigFileWithProfiles):
 
         self.setProfileStrValue('snapshots.path', value, profile_id)
 
-    def is_filesystem_valid(self, full_path, msg_path, mode):
-        """
-        Args:
-            full_path: The path to validate.
-            msg_path: The path used for display in error messages.
-            mode: Snapshot profile mode.
+    # def is_filesystem_valid(self, full_path, msg_path, mode):
+    #     """
+    #     Args:
+    #         full_path: The path to validate.
+    #         msg_path: The path used for display in error messages.
+    #         mode: Snapshot profile mode.
 
-        Returns:
-            bool: ``False`` if `full_path` lives in a known problematic filesystem.
-        """
-        fs = tools.filesystem(
-            full_path if isinstance(full_path, str) else str(full_path))
+    #     Returns:
+    #         bool: ``False`` if `full_path` lives in a known problematic filesystem.
+    #     """
+    #     fs = tools.filesystem(
+    #         full_path if isinstance(full_path, str) else str(full_path))
 
-        # DEV NOTE
-        # notifyError() results in a messagebox
-        # Might be a candidate for a simple error-event-handler
+    #     # DEV NOTE
+    #     # notifyError() results in a messagebox
+    #     # Might be a candidate for a simple error-event-handler
 
-        if fs == 'vfat':
-            self.notifyError(_(
-                "Destination filesystem for {path} is formatted with FAT "
-                "which doesn't support hard-links. "
-                "Please use a native Linux filesystem.")
-                .format(path=msg_path))
+    #     if fs == 'vfat':
+    #         self.notifyError(_(
+    #             "Destination filesystem for {path} is formatted with FAT "
+    #             "which doesn't support hard-links. "
+    #             "Please use a native Linux filesystem.")
+    #             .format(path=msg_path))
 
-            return False
+    #         return False
 
-        elif fs == 'cifs' and not self.copyLinks():
-            self.notifyError(_(
-                'Destination filesystem for {path} is an SMB-mounted share. '
-                'Please make sure the remote SMB server supports symlinks or '
-                'activate {copyLinks} in {expertOptions}.')
-                .format(path=msg_path,
-                        copyLinks=_('Copy links (dereference symbolic links)'),
-                        expertOptions=_('Expert Options')))
+    #     elif fs == 'cifs' and not self.copyLinks():
+    #         self.notifyError(_(
+    #             'Destination filesystem for {path} is an SMB-mounted share. '
+    #             'Please make sure the remote SMB server supports symlinks or '
+    #             'activate {copyLinks} in {expertOptions}.')
+    #             .format(path=msg_path,
+    #                     copyLinks=_('Copy links (dereference symbolic links)'),
+    #                     expertOptions=_('Expert Options')))
 
-        elif fs == 'fuse.sshfs' and mode not in ('ssh', 'ssh_encfs'):
-            self.notifyError(_(
-                "Destination filesystem for {path} is an sshfs-mounted share."
-                " Sshfs doesn't support hard-links. "
-                "Please use mode 'SSH' instead.")
-                .format(path=msg_path))
+    #     elif fs == 'fuse.sshfs' and mode not in ('ssh', 'ssh_encfs'):
+    #         self.notifyError(_(
+    #             "Destination filesystem for {path} is an sshfs-mounted share."
+    #             " Sshfs doesn't support hard-links. "
+    #             "Please use mode 'SSH' instead.")
+    #             .format(path=msg_path))
 
-            return False
+    #         return False
 
-        return True
+    #     return True
 
-    def is_writeable(self, folder):
-        # Test write access for the folder
+    # def is_writeable(self, folder):
+    #     # Test write access for the folder
 
-        if not isinstance(folder, Path):
-            folder = Path(folder)
+    #     if not isinstance(folder, Path):
+    #         folder = Path(folder)
 
-        check_path = folder / 'check'
+    #     check_path = folder / 'check'
 
-        try:
-            check_path.mkdir(
-                # Do not create parent folders
-                parents=False,
-                # Raise error if exists
-                exist_ok=False
-            )
+    #     try:
+    #         check_path.mkdir(
+    #             # Do not create parent folders
+    #             parents=False,
+    #             # Raise error if exists
+    #             exist_ok=False
+    #         )
 
-        except PermissionError:
-            self.notifyError('\n'.join([
-                _('File creation failed in this folder:'),
-                str(folder),
-                _('Write access may be restricted.')]))
-            return False
+    #     except PermissionError:
+    #         self.notifyError('\n'.join([
+    #             _('File creation failed in this folder:'),
+    #             str(folder),
+    #             _('Write access may be restricted.')]))
+    #         return False
 
-        else:
-            check_path.rmdir()
+    #     else:
+    #         check_path.rmdir()
 
-        return True
+    #     return True
 
-    def extra_magic_for_set_snapshots_path(self, value, profile_id=None):
-        """Sets the snapshot path to value, initializes, and checks it
-        """
-        if not isinstance(value, Path):
-            value = Path(value)
+    # def extra_magic_for_set_snapshots_path(self, value, profile_id=None):
+    #     """Sets the snapshot path to value, initializes, and checks it
+    #     """
+    #     if not isinstance(value, Path):
+    #         value = Path(value)
 
-        mode = self.snapshotsMode(profile_id)
+    #     if profile_id is None:
+    #         profile_id = self.currentProfile()
 
-        if profile_id is None:
-            profile_id = self.currentProfile()
+    #     mode = self.snapshotsMode(profile_id)
 
-        if mode is None:
-            mode = self.snapshotsMode(profile_id)
+    #     if not value.is_dir():
+    #         self.notifyError(_('Invalid option. {path} is not a folder.')
+    #                          .format(path=value))
+    #         return False
 
-        if not value.is_dir():
-            self.notifyError(_('Invalid option. {path} is not a folder.')
-                             .format(path=value))
-            return False
+    #     # build full path
+    #     # <path>/backintime/<host>/<user>/<profile_id>
+    #     host, user, profile = self.hostUserProfile(profile_id)
+    #     full_path = value / 'backintime' / host / user / profile
 
-        # build full path
-        # <path>/backintime/<host>/<user>/<profile_id>
-        host, user, profile = self.hostUserProfile(profile_id)
-        full_path = value / 'backintime' / host / user / profile
+    #     # create full_path
+    #     try:
+    #         full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
+    #     except PermissionError:
+    #         self.notifyError('\n'.join([
+    #             _('Creation of following folder failed:'),
+    #             str(full_path),
+    #             _(f'Write access may be restricted.')]))
+    #         return False
 
-        # create full_path
-        try:
-            full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
-        except PermissionError:
-            self.notifyError('\n'.join([
-                _('Creation of following folder failed:'),
-                str(full_path),
-                _(f'Write access may be restricted.')]))
-            return False
+    #     # Test filesystem
+    #     if self.is_filesystem_valid(full_path, value, mode) is False:
+    #         return False
 
-        # Test filesystem
-        if self.is_filesystem_valid(full_path, value, mode) is False:
-            return False
+    #     # Test write access for the folder
+    #     if self.is_writeable(full_path) is False:
+    #         return False
 
-        # Test write access for the folder
-        if self.is_writeable(full_path) is False:
-            return False
-
-        return True
+    #     return True
 
     def setSnapshotsPath(self, value, profile_id = None, mode = None):
         """
@@ -582,7 +578,9 @@ class Config(configfile.ConfigFileWithProfiles):
         if mode is None:
             mode = self.snapshotsMode(profile_id)
 
-        rc = self.extra_magic_for_set_snapshots_path(value, profile_id)
+        rc = tools.validate_snapshots_path(
+            path=value, cfg=self, profile_id=profile_id)
+        # rc = self.extra_magic_for_set_snapshots_path(value, profile_id)
         if rc is False:
             return False
 

--- a/common/config.py
+++ b/common/config.py
@@ -506,13 +506,18 @@ class Config(configfile.ConfigFileWithProfiles):
         check_path = folder / 'check'
 
         try:
-            check_path.mkdir(parent=False, exist_ok=False)
+            check_path.mkdir(
+                # Do not create parent folders
+                parents=False,
+                # Raise error if exists
+                exist_ok=False
+            )
 
         except PermissionError:
-            self.notifyError(_(
-                f"Can't write to: {folder}\nAre you sure you have "
-                "write access?"))
-
+            self.notifyError('\n'.join([
+                _(f'File creation of in following folder failed:'),
+                str(folder),
+                _(f'Write access may be restricted.')]))
             return False
 
         else:
@@ -526,8 +531,6 @@ class Config(configfile.ConfigFileWithProfiles):
         if not isinstance(value, Path):
             value = Path(value)
 
-        logger.info(f'extra_magic_for_set_snapshots_path() :: {value=}', self)
-
         mode = self.snapshotsMode(profile_id)
 
         if profile_id is None:
@@ -537,7 +540,8 @@ class Config(configfile.ConfigFileWithProfiles):
             mode = self.snapshotsMode(profile_id)
 
         if not value.is_dir():
-            self.notifyError(_('Invalid option. {path} is not a folder.').format(path=value))
+            self.notifyError(_('Invalid option. {path} is not a folder.')
+                             .format(path=value))
             return False
 
         # build full path
@@ -546,7 +550,14 @@ class Config(configfile.ConfigFileWithProfiles):
         full_path = value / 'backintime' / host / user / profile
 
         # create full_path
-        full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
+        try:
+            full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
+        except PermissionError:
+            self.notifyError('\n'.join([
+                _(f'Creation of following folder failed:'),
+                str(full_path),
+                _(f'Write access may be restricted.')]))
+            return False
 
         # Test filesystem
         if self.is_filesystem_valid(full_path, value, mode) is False:
@@ -562,7 +573,6 @@ class Config(configfile.ConfigFileWithProfiles):
         """
         Sets the snapshot path to value, initializes, and checks it
         """
-        logger.info(f'{"X"*20} setSnapshotsPath() :: {value=}', self)
         if not value:
             return False
 
@@ -572,13 +582,12 @@ class Config(configfile.ConfigFileWithProfiles):
         if mode is None:
             mode = self.snapshotsMode(profile_id)
 
-        rc = self.extra_magic_for_set_snapshots_path(value, profile_id, mode)
+        rc = self.extra_magic_for_set_snapshots_path(value, profile_id)
         if rc is False:
             return False
 
         # Need "mounttools"? (yes, if not "local")
         if self.SNAPSHOT_MODES[mode][0] is None:
-            logger.info(f'    setProfileStrValue(snapshots.path, {value=})', self)
             self.setProfileStrValue('snapshots.path', value, profile_id)
         else:
             # DEBUG

--- a/common/config.py
+++ b/common/config.py
@@ -410,26 +410,27 @@ class Config(configfile.ConfigFileWithProfiles):
     def host(self):
         return socket.gethostname()
 
+    def get_snapshots_mountpoint(self, profile_id=None, tmp_mount=False):
+        """Return the profiles snapshot path in form of a mount point."""
+        if profile_id is None:
+            profile_id = self.currentProfile()
+
+        mode = self.snapshotsMode(profile_id)
+
+        if mode == 'local':
+            return self.get_snapshots_path_and_only_that(profile_id)
+
+        # ssh/local_encfs/ssh_encfs
+        symlink = self.snapshotsSymlink(
+            profile_id=profile_id, tmp_mount=tmp_mount)
+
+        return os.path.join(self._LOCAL_MOUNT_ROOT, symlink)
+
     def snapshotsPath(self, profile_id=None, mode=None, tmp_mount=False):
-        """Return the snapshot path (backup destination).
+        """Return the snapshot path (backup destination) as a mount point.
         """
-        if mode is None:
-            mode = self.snapshotsMode(profile_id)
-
-        # If there are <mounttools> for this mode, then
-        # the path need to be mounted.
-        if self.SNAPSHOT_MODES[mode][0] == None:
-            # No mount needed
-            #?Where to save snapshots in mode 'local'. This path must contain a
-            #?folderstructure like 'backintime/<HOST>/<USER>/<PROFILE_ID>';absolute path
-            return self.profileStrValue('snapshots.path', '', profile_id)
-
-        else:
-            # Mode need to be mounted; return mountpoint
-            symlink = self.snapshotsSymlink(
-                profile_id=profile_id, tmp_mount=tmp_mount)
-
-            return os.path.join(self._LOCAL_MOUNT_ROOT, symlink)
+        return self.get_snapshots_mountpoint(
+            profile_id=profile_id, tmp_mount=tmp_mount)
 
     def snapshotsFullPath(self, profile_id = None):
         """
@@ -438,97 +439,17 @@ class Config(configfile.ConfigFileWithProfiles):
         host, user, profile = self.hostUserProfile(profile_id)
         return os.path.join(self.snapshotsPath(profile_id), 'backintime', host, user, profile)
 
-    def set_snapshots_path(self, value, profile_id=None):
+    def get_snapshots_path_and_only_that(self, profile_id):
+        """Return the value of the snapshot path (backup destination) field."""
+        return self.profileStrValue('snapshots.path', '', profile_id)
+
+    def set_snapshots_path_and_only_that(self, value, profile_id=None):
         """Sets the snapshot path to value, initializes, and checks it
         """
-        logger.info(f'{"X"*20} set_snapshots_path() :: {value=}', self)
-
         if profile_id is None:
             profile_id = self.currentProfile()
 
-        # if mode is None:
-        #     mode = self.snapshotsMode(profile_id)
-
-        if not os.path.isdir(value):
-            self.notifyError(_('Invalid option. {path} is not a folder.').format(path=value))
-            return False
-
-        # Initialize the snapshots folder
-        logger.debug("Check snapshot folder: %s" % value, self)
-
-        host, user, profile = self.hostUserProfile(profile_id)
-
-        if not all((host, user, profile)):
-            self.notifyError(_('Host/User/Profile-ID must not be empty.'))
-            return False
-
-        full_path = os.path.join(value, 'backintime', host, user, profile)
-        if not os.path.isdir(full_path):
-            logger.debug("Create folder: %s" % full_path, self)
-            tools.makeDirs(full_path)
-
-            if not os.path.isdir(full_path):
-                self.notifyError(_(
-                    "Can't write to: {path}\nAre you sure you have "
-                    "write access?").format(path=value))
-                return False
-
-            for p in (os.path.join(value, 'backintime'),
-                      os.path.join(value, 'backintime', host)):
-                try:
-                    os.chmod(p, 0o777)
-                except PermissionError as e:
-                    msg = "Failed to set permissions world-writable for '{}': {}"
-                    logger.warning(msg.format(p, str(e)), self)
-
-        # Test filesystem
-        fs = tools.filesystem(full_path)
-
-        if fs == 'vfat':
-            self.notifyError(_(
-                "Destination filesystem for {path} is formatted with FAT "
-                "which doesn't support hard-links. "
-                "Please use a native Linux filesystem.")
-                .format(path=value))
-
-            return False
-
-        elif fs == 'cifs' and not self.copyLinks():
-            self.notifyError(_(
-                'Destination filesystem for {path} is an SMB-mounted share. '
-                'Please make sure the remote SMB server supports symlinks or '
-                'activate {copyLinks} in {expertOptions}.')
-                .format(path=value,
-                        copyLinks=_('Copy links (dereference symbolic links)'),
-                        expertOptions=_('Expert Options')))
-
-        elif fs == 'fuse.sshfs' and mode not in ('ssh', 'ssh_encfs'):
-            self.notifyError(_(
-                "Destination filesystem for {path} is an sshfs-mounted share."
-                " Sshfs doesn't support hard-links. "
-                "Please use mode 'SSH' instead.")
-                .format(path=value))
-
-            return False
-
-        #Test write access for the folder
-        check_path = os.path.join(full_path, 'check')
-        tools.makeDirs(check_path)
-        if not os.path.isdir(check_path):
-            self.notifyError(_(
-                "Can't write to: {path}\nAre you sure you have "
-                "write access?").format(path=full_path))
-            return False
-
-        os.rmdir(check_path)
-
-        # Need "mounttools"? (yes, if not "local")
-        if self.SNAPSHOT_MODES[mode][0] is None:
-            logger.info(f'    setProfileStrValue(snapshots.path, {value=})', self)
-            self.setProfileStrValue('snapshots.path', value, profile_id)
-
-        print(f"{self.dict['profile3.snapshots.path']=}")
-        return True
+        self.setProfileStrValue('snapshots.path', value, profile_id)
 
     def is_filesystem_valid(self, full_path, msg_path, mode):
         """
@@ -599,13 +520,15 @@ class Config(configfile.ConfigFileWithProfiles):
 
         return True
 
-    def extra_magic_for_set_snapshots_path(self, value, profile_id=None, mode=None):
+    def extra_magic_for_set_snapshots_path(self, value, profile_id=None):
         """Sets the snapshot path to value, initializes, and checks it
         """
         if not isinstance(value, Path):
             value = Path(value)
 
         logger.info(f'extra_magic_for_set_snapshots_path() :: {value=}', self)
+
+        mode = self.snapshotsMode(profile_id)
 
         if profile_id is None:
             profile_id = self.currentProfile()
@@ -649,7 +572,9 @@ class Config(configfile.ConfigFileWithProfiles):
         if mode is None:
             mode = self.snapshotsMode(profile_id)
 
-        self.extra_magic_for_set_snapshots_path(value, profile_id, mode)
+        rc = self.extra_magic_for_set_snapshots_path(value, profile_id, mode)
+        if rc is False:
+            return False
 
         # Need "mounttools"? (yes, if not "local")
         if self.SNAPSHOT_MODES[mode][0] is None:

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Provides the ability to collect diagnostic information on Back In Time.
 
 These are version numbers of the dependent tools, environment variables,

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2022 Christian BUHTZ <c.buhtz@posteo.jp>
 #
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
 # General Public License v2 (GPLv2).

--- a/common/mount.py
+++ b/common/mount.py
@@ -442,7 +442,7 @@ class MountControl:
 
         self.local_host = self.config.host()
         self.local_user = getpass.getuser()
-        self.pid = self.config.pid()
+        self.pid = str(os.getpid())
 
         self.all_kwargs = {}
 

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -4,7 +4,7 @@
 # SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
 # SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
 #
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
 # General Public License v2 (GPLv2).

--- a/common/test/test_applicationinstance.py
+++ b/common/test/test_applicationinstance.py
@@ -25,8 +25,8 @@ from test import generic
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from applicationinstance import ApplicationInstance
 import tools
+from applicationinstance import ApplicationInstance
 
 
 class TestApplicationInstance(generic.TestCase):

--- a/common/test/test_backintime.py
+++ b/common/test/test_backintime.py
@@ -1,36 +1,23 @@
-# Back In Time
-# Copyright (C) 2016 Taylor Raack
+# SPDX-FileCopyrightText: 2016 Taylor Raack
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation,Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# This file is part of the program "Back In time" which is released under GNU
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 import os
 import re
 import subprocess
 import sys
 from test import generic
 import json
-
 import config
 import version
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 
-class TestBackInTime(generic.TestCase):
-    def setUp(self):
-        super(TestBackInTime, self).setUp()
-
+class BackInTime(generic.TestCase):
     def test_quiet_mode(self):
         output = subprocess.getoutput('python3 backintime.py --quiet')
 

--- a/common/test/test_config.py
+++ b/common/test/test_config.py
@@ -1,19 +1,10 @@
-# Back In Time
-# Copyright (C) 2016 Taylor Raack
+# SPDX-FileCopyrightText: © 2016 Taylor Raack
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation,Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
 """Tests about config module.
 """
 import os
@@ -24,6 +15,7 @@ from unittest import mock
 from test import generic
 from tempfile import TemporaryDirectory
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
 
 class TestConfig(generic.TestCaseCfg):
     def test_set_snapshots_path_test_writes(self):

--- a/common/test/test_config.py
+++ b/common/test/test_config.py
@@ -17,23 +17,6 @@ from tempfile import TemporaryDirectory
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 
-class TestConfig(generic.TestCaseCfg):
-    def test_set_snapshots_path_test_writes(self):
-        with TemporaryDirectory() as dirpath:
-            self.assertTrue(self.cfg.setSnapshotsPath(dirpath))
-
-    def test_set_snapshots_path_fails_on_ro(self):
-        with TemporaryDirectory() as dirpath:
-            # set directory to read only
-            with generic.mockPermissions(dirpath, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH):
-                self.assertFalse(self.cfg.setSnapshotsPath(dirpath))
-
-    @mock.patch('os.chmod')
-    def test_set_snapshots_path_permission_fail(self, mock_chmod):
-        mock_chmod.side_effect = PermissionError()
-        with TemporaryDirectory() as dirpath:
-            self.assertTrue(self.cfg.setSnapshotsPath(dirpath))
-
 
 class TestSshCommand(generic.SSHTestCase):
     @classmethod

--- a/common/test/test_config.py
+++ b/common/test/test_config.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Tests about config module.
 """
 import os

--- a/common/test/test_config.py
+++ b/common/test/test_config.py
@@ -8,14 +8,10 @@
 """Tests about config module.
 """
 import os
-import stat
 import sys
 import getpass
-from unittest import mock
 from test import generic
-from tempfile import TemporaryDirectory
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-
 
 
 class TestSshCommand(generic.SSHTestCase):

--- a/common/test/test_schedule.py
+++ b/common/test/test_schedule.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
 #
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
 # General Public License v2 (GPLv2).

--- a/common/test/test_schedule.py
+++ b/common/test/test_schedule.py
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 import unittest
 import schedule
 

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -710,9 +710,9 @@ class TestRemoveSnapshot(generic.SnapshotsWithSidTestCase):
 
 
 @unittest.skipIf(not generic.LOCAL_SSH, generic.SKIP_SSH_TEST_MESSAGE)
-class TestSshSnapshots(generic.SSHTestCase):
+class SshSnapshots(generic.SSHTestCase):
     def setUp(self):
-        super(TestSshSnapshots, self).setUp()
+        super().setUp()
         self.sn = snapshots.Snapshots(self.cfg)
         os.makedirs(self.remoteFullPath)
 
@@ -980,7 +980,7 @@ def _init_mounting(cfg):
 
 
 @unittest.skipIf(not generic.LOCAL_SSH, generic.SKIP_SSH_TEST_MESSAGE)
-class TestSshPermissions(unittest.TestCase):
+class SshPermissions(unittest.TestCase):
     """Testing to backup the file permissions in a "SSH local"
     snapshot profile.
     """
@@ -1047,7 +1047,7 @@ class TestSshPermissions(unittest.TestCase):
 
 
 @unittest.skipIf(not generic.LOCAL_SSH, generic.SKIP_SSH_TEST_MESSAGE)
-class TestSshRemoveSnapshots(unittest.TestCase):
+class SshRemoveSnapshots(unittest.TestCase):
     """Testing to remove snapshots(SID) in a "SSH local" snapshot profile.
     """
 

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -823,7 +823,7 @@ class Tools_FakeFS(pyfakefs_ut.TestCase):
 class ValidateSnapshotsPath(generic.TestCaseCfg):
     def test_writes(self):
         with TemporaryDirectory() as dirpath:
-            ret = tools.validate_snapshots_path(
+            ret = tools.validate_and_prepare_snapshots_path(
                 path=dirpath,
                 host_user_profile=self.cfg.hostUserProfile(),
                 mode=self.cfg.snapshotsMode(),
@@ -836,7 +836,7 @@ class ValidateSnapshotsPath(generic.TestCaseCfg):
             # set directory to read only
             ro_dir_stats = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
             with generic.mockPermissions(dirpath, ro_dir_stats):
-                ret = tools.validate_snapshots_path(
+                ret = tools.validate_and_prepare_snapshots_path(
                     path=dirpath,
                     host_user_profile=self.cfg.hostUserProfile(),
                     mode=self.cfg.snapshotsMode(),
@@ -848,7 +848,7 @@ class ValidateSnapshotsPath(generic.TestCaseCfg):
     def test_permission_fail(self, mock_chmod):
         mock_chmod.side_effect = PermissionError()
         with TemporaryDirectory() as dirpath:
-            ret = tools.validate_snapshots_path(
+            ret = tools.validate_and_prepare_snapshots_path(
                 path=dirpath,
                 host_user_profile=self.cfg.hostUserProfile(),
                 mode=self.cfg.snapshotsMode(),

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -823,18 +823,35 @@ class Tools_FakeFS(pyfakefs_ut.TestCase):
 class ValidateSnapshotsPath(generic.TestCaseCfg):
     def test_writes(self):
         with TemporaryDirectory() as dirpath:
-            self.assertTrue(tools.validate_snapshots_path(dirpath, self.cfg))
+            ret = tools.validate_snapshots_path(
+                path=dirpath,
+                host_user_profile=self.cfg.hostUserProfile(),
+                mode=self.cfg.snapshotsMode(),
+                copy_links=self.cfg.copyLinks(),
+                error_handler=self.cfg.notifyError)
+            self.assertTrue(ret)
 
     def test_fails_on_ro(self):
         with TemporaryDirectory() as dirpath:
             # set directory to read only
             ro_dir_stats = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
             with generic.mockPermissions(dirpath, ro_dir_stats):
-                self.assertFalse(
-                    tools.validate_snapshots_path(dirpath, self.cfg))
+                ret = tools.validate_snapshots_path(
+                    path=dirpath,
+                    host_user_profile=self.cfg.hostUserProfile(),
+                    mode=self.cfg.snapshotsMode(),
+                    copy_links=self.cfg.copyLinks(),
+                    error_handler=self.cfg.notifyError)
+                self.assertFalse(ret)
 
     @patch('os.chmod')
     def test_permission_fail(self, mock_chmod):
         mock_chmod.side_effect = PermissionError()
         with TemporaryDirectory() as dirpath:
-            self.assertTrue(tools.validate_snapshots_path(dirpath, self.cfg))
+            ret = tools.validate_snapshots_path(
+                path=dirpath,
+                host_user_profile=self.cfg.hostUserProfile(),
+                mode=self.cfg.snapshotsMode(),
+                copy_links=self.cfg.copyLinks(),
+                error_handler=self.cfg.notifyError)
+            self.assertTrue(ret)

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -821,11 +821,11 @@ class Tools_FakeFS(pyfakefs_ut.TestCase):
 
 
 class ValidateSnapshotsPath(generic.TestCaseCfg):
-    def test_set_snapshots_path_test_writes(self):
+    def test_writes(self):
         with TemporaryDirectory() as dirpath:
             self.assertTrue(tools.validate_snapshots_path(dirpath, self.cfg))
 
-    def test_set_snapshots_path_fails_on_ro(self):
+    def test_fails_on_ro(self):
         with TemporaryDirectory() as dirpath:
             # set directory to read only
             ro_dir_stats = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
@@ -834,7 +834,7 @@ class ValidateSnapshotsPath(generic.TestCaseCfg):
                     tools.validate_snapshots_path(dirpath, self.cfg))
 
     @patch('os.chmod')
-    def test_set_snapshots_path_permission_fail(self, mock_chmod):
+    def test_permission_fail(self, mock_chmod):
         mock_chmod.side_effect = PermissionError()
         with TemporaryDirectory() as dirpath:
             self.assertTrue(tools.validate_snapshots_path(dirpath, self.cfg))

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -74,11 +74,11 @@ class TestTools(generic.TestCase):
     """
 
     def setUp(self):
-        super(TestTools, self).setUp()
+        super().setUp()
         self.subproc = None
 
     def tearDown(self):
-        super(TestTools, self).tearDown()
+        super().tearDown()
         self._kill_process()
 
     def _create_process(self, *args):
@@ -547,16 +547,16 @@ class Environ(generic.TestCase):
     """
 
     def __init__(self, *args, **kwargs):
-        super(TestToolsEnviron, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.env = deepcopy(os.environ)
 
     def setUp(self):
-        super(TestToolsEnviron, self).setUp()
+        super().setUp()
         self.temp_file = '/tmp/temp.txt'
         os.environ = deepcopy(self.env)
 
     def tearDown(self):
-        super(TestToolsEnviron, self).tearDown()
+        super().tearDown()
         if os.path.exists(self.temp_file):
             os.remove(self.temp_file)
         os.environ = deepcopy(self.env)

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -1,20 +1,16 @@
-# Back In Time
-# Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey,
-# Germar Reitze, Taylor Raack
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Taylor Raack
+# SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation,Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""Tests about the tools module."""
 import os
 import sys
 import subprocess
@@ -30,7 +26,6 @@ from copy import deepcopy
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 import pyfakefs.fake_filesystem_unittest as pyfakefs_ut
 from test import generic
-
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import tools
 import configfile
@@ -823,3 +818,23 @@ class Tools_FakeFS(pyfakefs_ut.TestCase):
                 'branch': 'fix/foobar'
             }
         )
+
+
+class ValidateSnapshotsPath(generic.TestCaseCfg):
+    def test_set_snapshots_path_test_writes(self):
+        with TemporaryDirectory() as dirpath:
+            self.assertTrue(tools.validate_snapshots_path(dirpath, self.cfg))
+
+    def test_set_snapshots_path_fails_on_ro(self):
+        with TemporaryDirectory() as dirpath:
+            # set directory to read only
+            ro_dir_stats = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+            with generic.mockPermissions(dirpath, ro_dir_stats):
+                self.assertFalse(
+                    tools.validate_snapshots_path(dirpath, self.cfg))
+
+    @patch('os.chmod')
+    def test_set_snapshots_path_permission_fail(self, mock_chmod):
+        mock_chmod.side_effect = PermissionError()
+        with TemporaryDirectory() as dirpath:
+            self.assertTrue(tools.validate_snapshots_path(dirpath, self.cfg))

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -8,8 +8,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Tests about the tools module."""
 import os
 import sys
@@ -494,7 +494,7 @@ class TestTools(generic.TestCase):
             'echo start;echo foo;echo foo;echo foo;echo end')
 
 
-class TestEscapeIPv6(generic.TestCase):
+class EscapeIPv6(generic.TestCase):
     def test_escaped(self):
         values_and_expected = (
             ('fd00:0::5', '[fd00:0::5]'),
@@ -542,7 +542,7 @@ class TestEscapeIPv6(generic.TestCase):
                 self.assertEqual(tools.escapeIPv6Address(val), val)
 
 
-class TestToolsEnviron(generic.TestCase):
+class Environ(generic.TestCase):
     """???
     """
 
@@ -620,7 +620,7 @@ class TestToolsEnviron(generic.TestCase):
                 self.assertEqual(test_env.strValue(k), str(i), msg)
 
 
-class TestToolsUniquenessSet(generic.TestCase):
+class UniquenessSet(generic.TestCase):
     # TODO: add test for follow_symlink
     def test_checkUnique(self):
         with TemporaryDirectory() as d:
@@ -750,7 +750,7 @@ class TestToolsUniquenessSet(generic.TestCase):
             self.assertFalse(uniqueness.check(t3))
 
 
-class TestToolsExecuteSubprocess(generic.TestCase):
+class ExecuteSubprocess(generic.TestCase):
     # new method with subprocess
     def test_returncode(self):
         self.assertEqual(tools.Execute(['true']).run(), 0)

--- a/common/tools.py
+++ b/common/tools.py
@@ -369,6 +369,160 @@ def get_native_language_and_completeness(language_code):
 
     return (name, completeness)
 
+# |---------------------------------------|
+# | Snapshot handling                     |
+# |                                       |
+# | Candidates for refactoring and moving |
+# | into better suited moduls/classes     |
+# |---------------------------------------|
+
+
+def validate_snapshots_path(path, cfg, profile_id=None):
+    """Check if the given path is valide for being a snapshot path.
+
+    It is checked if it is a folder, if it is writeable, if the filesystem is
+    supported and several other things.
+
+    Args:
+        path: The path to validate as a snapshot path.
+        cfg: The config instance.
+        profile_id: Related snapshots profile id.
+
+    Returns:
+        (bool): `False` or `True`
+    """
+    if not isinstance(path, pathlib.Path):
+        path = pathlib.Path(path)
+
+    if profile_id is None:
+        profile_id = cfg.currentProfile()
+
+    mode = cfg.snapshotsMode(profile_id)
+
+    if not path.is_dir():
+        cfg.notifyError(_('Invalid option. {path} is not a folder.')
+                        .format(path=path))
+        return False
+
+    # build full path
+    # <path>/backintime/<host>/<user>/<profile_id>
+    host, user, profile = cfg.hostUserProfile(profile_id)
+    full_path = path / 'backintime' / host / user / profile
+
+    # create full_path
+    try:
+        full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
+
+    except PermissionError:
+        cfg.notifyError('\n'.join([
+            _('Creation of following folder failed:'),
+            str(full_path),
+            _(f'Write access may be restricted.')]))
+        return False
+
+    # Test filesystem
+    rc, msg = is_filesystem_valid(
+        full_path, path, mode, cfg.copyLinks())
+    if msg:
+        cfg.notifyError(msg)
+    if rc is False:
+        return False
+
+    # Test write access for the folder
+    rc, msg = is_writeable(full_path)
+    if msg:
+        cfg.notifyError(msg)
+    if rc is False:
+        return False
+
+    return True
+
+
+def is_filesystem_valid(full_path, msg_path, mode, copy_links):
+    """
+    Args:
+        full_path: The path to validate.
+        msg_path: The path used for display in error messages.
+        mode: Snapshot profile mode.
+        copy_links: Snapshot profiles copy links setting.
+
+    Returns:
+        (bool, str): A boolean value indicating success or failure and a
+            msg string.
+
+    """
+    fs = filesystem(full_path if isinstance(full_path, str) else str(full_path))
+
+    msg = None
+
+    # DEV NOTE
+    # notifyError() results in a messagebox
+    # Might be a candidate for a simple error-event-handler
+
+    if fs == 'vfat':
+        msg = _(
+            "Destination filesystem for {path} is formatted with FAT "
+            "which doesn't support hard-links. "
+            "Please use a native Linux filesystem.").format(path=msg_path)
+
+        return False, msg
+
+    elif fs == 'cifs' and not copy_links:
+        msg = _(
+            'Destination filesystem for {path} is an SMB-mounted share. '
+            'Please make sure the remote SMB server supports symlinks or '
+            'activate {copyLinks} in {expertOptions}.') \
+            .format(path=msg_path,
+                    copyLinks=_('Copy links (dereference symbolic links)'),
+                    expertOptions=_('Expert Options'))
+
+    elif fs == 'fuse.sshfs' and mode not in ('ssh', 'ssh_encfs'):
+        msg = _(
+            "Destination filesystem for {path} is an sshfs-mounted share."
+            " Sshfs doesn't support hard-links. "
+            "Please use mode 'SSH' instead.").format(path=msg_path)
+
+        return False, msg
+
+    return True, msg
+
+
+def is_writeable(folder):
+    """Test write access for the folder.
+
+    Args:
+        folder: The folder to check.
+
+    Returns:
+        (bool, str): A boolean value indicating success or failure and a
+            msg string.
+    """
+
+    if not isinstance(folder, pathlib.Path):
+        folder = pathlib.Path(folder)
+
+    check_path = folder / 'check'
+
+    try:
+        check_path.mkdir(
+            # Do not create parent folders
+            parents=False,
+            # Raise error if exists
+            exist_ok=False
+        )
+
+    except PermissionError:
+        msg = '\n'.join([
+            _('File creation failed in this folder:'),
+            str(folder),
+            _('Write access may be restricted.')])
+        return False, msg
+
+    else:
+        check_path.rmdir()
+
+    return True, None
+
 
 # |------------------------------------|
 # | Miscellaneous, not categorized yet |

--- a/common/tools.py
+++ b/common/tools.py
@@ -8,8 +8,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Collection of helper functions not fitting to other modules.
 """
 import os

--- a/common/tools.py
+++ b/common/tools.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
 # SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
 # SPDX-FileCopyrightText: © 2008-2022 Taylor Raack
+# SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/common/tools.py
+++ b/common/tools.py
@@ -499,8 +499,7 @@ def is_writeable(folder):
             msg string.
     """
 
-    if not isinstance(folder, pathlib.Path):
-        folder = pathlib.Path(folder)
+    folder = pathlib.Path(folder)
 
     check_path = folder / 'check'
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -71,6 +71,14 @@ import bcolors
 from exceptions import Timeout, InvalidChar, InvalidCmd, LimitExceeded, PermissionDeniedByPolicy
 import languages
 
+# Workaround:
+# While unittesting and without regular invocation of BIT the GNU gettext
+# class-based API isn't setup yet.
+try:
+    _('Warning')
+except NameError:
+    _ = lambda val: val
+
 DISK_BY_UUID = '/dev/disk/by-uuid'
 
 # |-----------------|
@@ -474,7 +482,7 @@ def is_filesystem_valid(full_path, msg_path, mode, copy_links):
         return False, msg
 
     elif fs.startswith('ntfs'):
-        msg = self.NTFS_FILESYSTEM_WARNING.format(path=value)
+        msg = NTFS_FILESYSTEM_WARNING.format(path=msg_path)
 
     elif fs == 'cifs' and not copy_links:
         msg = _(

--- a/common/tools.py
+++ b/common/tools.py
@@ -27,6 +27,7 @@ import hashlib
 import ipaddress
 from datetime import datetime
 from packaging.version import Version
+from typing import Union
 import logger
 
 # Try to import keyring
@@ -378,44 +379,47 @@ def get_native_language_and_completeness(language_code):
 # |---------------------------------------|
 
 
-def validate_snapshots_path(path, cfg, profile_id=None):
+def validate_snapshots_path(path: Union[str, pathlib.Path],
+                            host_user_profile: tuple[str, str, str],
+                            mode: str,
+                            copy_links: bool,
+                            error_handler: callable) -> bool:
     """Check if the given path is valid for being a snapshot path.
 
     It is checked if it is a folder, if it is writable, if the filesystem is
     supported and several other things.
 
+    Dev note  (buhtz, 2024-09): That code is a good candidate to get moved
+        into a class or module.
+
     Args:
         path: The path to validate as a snapshot path.
-        cfg: The config instance.
-        profile_id: Related snapshots profile id.
+        host_user_profile: I three item list.
+        mode: The profiles mode.
+        copy_links: The copy links value.
+        error_handler: Handle function receiving error messages.
 
-    Returns:
-        (bool): `False` or `True`
+    Returns: Success (`True`) or failure (`False`).
     """
     if not isinstance(path, pathlib.Path):
         path = pathlib.Path(path)
 
-    if profile_id is None:
-        profile_id = cfg.currentProfile()
-
-    mode = cfg.snapshotsMode(profile_id)
-
     if not path.is_dir():
-        cfg.notifyError(_('Invalid option. {path} is not a folder.')
-                        .format(path=path))
+        error_handler(_('Invalid option. {path} is not a folder.')
+                      .format(path=path))
         return False
 
     # build full path
     # <path>/backintime/<host>/<user>/<profile_id>
-    host, user, profile = cfg.hostUserProfile(profile_id)
-    full_path = path / 'backintime' / host / user / profile
+    host_user_profile = pathlib.Path(os.sep.join(host_user_profile))
+    full_path = path / 'backintime' / host_user_profile
 
     # create full_path
     try:
         full_path.mkdir(mode=0o777, parents=True, exist_ok=True)
 
     except PermissionError:
-        cfg.notifyError('\n'.join([
+        error_handler('\n'.join([
             _('Creation of following folder failed:'),
             str(full_path),
             _(f'Write access may be restricted.')]))
@@ -423,16 +427,16 @@ def validate_snapshots_path(path, cfg, profile_id=None):
 
     # Test filesystem
     rc, msg = is_filesystem_valid(
-        full_path, path, mode, cfg.copyLinks())
+        full_path, path, mode, copy_links)
     if msg:
-        cfg.notifyError(msg)
+        error_handler(msg)
     if rc is False:
         return False
 
     # Test write access for the folder
     rc, msg = is_writeable(full_path)
     if msg:
-        cfg.notifyError(msg)
+        error_handler(msg)
     if rc is False:
         return False
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -379,11 +379,12 @@ def get_native_language_and_completeness(language_code):
 # |---------------------------------------|
 
 
-def validate_snapshots_path(path: Union[str, pathlib.Path],
-                            host_user_profile: tuple[str, str, str],
-                            mode: str,
-                            copy_links: bool,
-                            error_handler: callable) -> bool:
+def validate_and_prepare_snapshots_path(
+        path: Union[str, pathlib.Path],
+        host_user_profile: tuple[str, str, str],
+        mode: str,
+        copy_links: bool,
+        error_handler: callable) -> bool:
     """Check if the given path is valid for being a snapshot path.
 
     It is checked if it is a folder, if it is writable, if the filesystem is
@@ -394,15 +395,16 @@ def validate_snapshots_path(path: Union[str, pathlib.Path],
 
     Args:
         path: The path to validate as a snapshot path.
-        host_user_profile: I three item list.
+        host_user_profile: I three item list containing the values for 'host',
+            'user' and 'profile' used as additional components for the
+            snapshots path.
         mode: The profiles mode.
         copy_links: The copy links value.
         error_handler: Handle function receiving error messages.
 
     Returns: Success (`True`) or failure (`False`).
     """
-    if not isinstance(path, pathlib.Path):
-        path = pathlib.Path(path)
+    path = pathlib.Path(path)
 
     if not path.is_dir():
         error_handler(_('Invalid option. {path} is not a folder.')
@@ -411,8 +413,7 @@ def validate_snapshots_path(path: Union[str, pathlib.Path],
 
     # build full path
     # <path>/backintime/<host>/<user>/<profile_id>
-    host_user_profile = pathlib.Path(os.sep.join(host_user_profile))
-    full_path = path / 'backintime' / host_user_profile
+    full_path = pathlib.Path(path, 'backintime', *host_user_profile)
 
     # create full_path
     try:

--- a/common/tools.py
+++ b/common/tools.py
@@ -374,14 +374,14 @@ def get_native_language_and_completeness(language_code):
 # | Snapshot handling                     |
 # |                                       |
 # | Candidates for refactoring and moving |
-# | into better suited moduls/classes     |
+# | into better suited modules/classes    |
 # |---------------------------------------|
 
 
 def validate_snapshots_path(path, cfg, profile_id=None):
-    """Check if the given path is valide for being a snapshot path.
+    """Check if the given path is valid for being a snapshot path.
 
-    It is checked if it is a folder, if it is writeable, if the filesystem is
+    It is checked if it is a folder, if it is writable, if the filesystem is
     supported and several other things.
 
     Args:

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1675,8 +1675,7 @@ class SettingsDialog(QDialog):
 
         snapshots_mountpoint = self.config.get_snapshots_mountpoint(
             tmp_mount=True)
-        ret = self.config.extra_magic_for_set_snapshots_path(
-            snapshots_mountpoint)
+        ret = tools.validate_snapshots_path(snapshots_mountpoint, self.config)
         if not ret:
             return ret
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1679,11 +1679,19 @@ class SettingsDialog(QDialog):
 
         # save snaphots_path
         if self.config.SNAPSHOT_MODES[mode][0] is None:
+            # mode "locale"
             snapshots_path = self.editSnapshotsPath.text()
         else:
+            # other modes
             snapshots_path = self.config.snapshotsPath(mode=mode,
                                                        tmp_mount=True)
 
+        # dev note (buhtz): This does not modify the configs snapshot path
+        # in all cases.
+        # Only in "locale" mode the value is set.
+        # In the three other modes, this method does some mounting tests only.
+        # The path value of SSH/Encfs profiles is set with other methods.
+        # setSshSnapshotsPath(), setEncfsSnapshotsPath()
         ret = self.config.setSnapshotsPath(snapshots_path, mode=mode)
 
         if not ret:

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1578,21 +1578,12 @@ class SettingsDialog(QDialog):
         self.config.setSshCheckPingHost(self.cbSshCheckPing.isChecked())
         self.config.setSshCheckCommands(self.cbSshCheckCommands.isChecked())
 
-        # TODO - consider a single API method to bridge the UI layer
-        # (settings dialog) and backend layer (config)
-        # when setting snapshots path rather than having to call the
-        # mount module from the UI layer
-        #
-        # currently, setting snapshots path requires the path to be mounted.
-        # it seems that it might be nice,
-        # since the config object is more than a data structure, but has
-        # side-effect logic as well, to have the
-        # config.setSnapshotsPath() method take care of everything it needs
-        # to perform its job
-        # (mounting and unmounting the fuse filesystem if necessary).
-        # https://en.wikipedia.org/wiki/Single_responsibility_principle
-
-        if not self.config.SNAPSHOT_MODES[mode][0] is None:
+        # DEV NOTE (Taylor Raack, 2016-01) - consider a single API method to
+        # bridge the UI layer (settings dialog) and backend layer (config) when
+        # setting snapshots path rather than having to call the mount module
+        # from the UI layer
+        # DEV NOTE (buhtz, 2024-09): Work in progress ...
+        if mode != 'local':
             # preMountCheck
             mnt = mount.Mount(cfg=self.config, tmp_mount=True, parent=self)
 
@@ -1678,33 +1669,23 @@ class SettingsDialog(QDialog):
         self.config.setPassword(password_2, mode=mode, pw_id=2)
 
         # save snaphots_path
-        if self.config.SNAPSHOT_MODES[mode][0] is None:
-            # mode "locale"
-            snapshots_path = self.editSnapshotsPath.text()
-        else:
-            # other modes
-            snapshots_path = self.config.snapshotsPath(mode=mode,
-                                                       tmp_mount=True)
+        if mode == 'local':
+            self.config.set_snapshots_path_and_only_that(
+                self.editSnapshotsPath.text())
 
-        # dev note (buhtz): This does not modify the configs snapshot path
-        # in all cases.
-        # Only in "locale" mode the value is set.
-        # In the three other modes, this method does some mounting tests only.
-        # The path value of SSH/Encfs profiles is set with other methods.
-        # setSshSnapshotsPath(), setEncfsSnapshotsPath()
-        ret = self.config.setSnapshotsPath(snapshots_path, mode=mode)
-
+        snapshots_mountpoint = self.config.get_snapshots_mountpoint(
+            tmp_mount=True)
+        ret = self.config.extra_magic_for_set_snapshots_path(
+            snapshots_mountpoint)
         if not ret:
             return ret
 
         # umount
-        if not self.config.SNAPSHOT_MODES[mode][0] is None:
-
+        if mode != 'local':
             try:
                 mnt.umount(hash_id=hash_id)
             except MountException as ex:
                 self.errorHandler(str(ex))
-
                 return False
 
         return True

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1674,7 +1674,13 @@ class SettingsDialog(QDialog):
 
         snapshots_mountpoint = self.config.get_snapshots_mountpoint(
             tmp_mount=True)
-        ret = tools.validate_snapshots_path(snapshots_mountpoint, self.config)
+        ret = tools.validate_snapshots_path(
+            path=snapshots_mountpoint,
+            host_user_profile=self.config.hostUserProfile(),
+            mode=mode,
+            copy_links=self.config.copyLinks(),
+            error_handler=self.config.notifyError)
+
         if not ret:
             return ret
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -8,8 +8,8 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 import os
 import datetime
 import copy

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1670,8 +1670,7 @@ class SettingsDialog(QDialog):
 
         # save snaphots_path
         if mode == 'local':
-            self.config.set_snapshots_path_and_only_that(
-                self.editSnapshotsPath.text())
+            self.config.set_snapshots_path(self.editSnapshotsPath.text())
 
         snapshots_mountpoint = self.config.get_snapshots_mountpoint(
             tmp_mount=True)

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1674,7 +1674,7 @@ class SettingsDialog(QDialog):
 
         snapshots_mountpoint = self.config.get_snapshots_mountpoint(
             tmp_mount=True)
-        ret = tools.validate_snapshots_path(
+        ret = tools.validate_and_prepare_snapshots_path(
             path=snapshots_mountpoint,
             host_user_profile=self.config.hostUserProfile(),
             mode=mode,


### PR DESCRIPTION
Complex refactoring and code movement. :rescue_worker_helmet:  Behavior of BIT shouldn't be modified. :fearful: 

This PR fix refactoring issue #1864 and prepares for a new config management class (PR #1850) and refactoring SettingsDialog code (PR #1865). The problem this PR solves was that the method `Config.setSnapshotsPaths()` has to much logic in it not belonging in that method nor into that class. I moved and "parked" the code in the `tools.py` module.

The current solution give me the ability to easier decouple the code in `SettingsDialog.saveProfile()` in context of PR #1865.

Of course I modified several other things but tried to keep that PR as simple as possible to reduce the risk of introducing bugs.

Fix #1864