### PR TITLE
chore: Enable full linting on specific files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: © 2008 Back In Time Team
+#
+# SPDX-License-Identifier: CC0 (public domain)
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+#
 # TravisCI (https://travis-ci.org) configuration file
 os: linux
  
@@ -42,7 +50,7 @@ jobs:
 
 install:
   - pip install -U pip
-  - pip install pylint pyfakefs keyring
+  - pip install pylint ruff pycodestyle pyfakefs keyring
   - pip install pyqt6 dbus-python
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: © 2008 Back In Time Team
 #
-# SPDX-License-Identifier: CC0 (public domain)
+# SPDX-License-Identifier: CC0-1.0
 #
-# This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# This file is released under Creative Commons Zero 1.0 (CC0-1.0) and part of
+# the program "Back In Time". The program as a whole is released under GNU
+# General Public License v2 or any later version (GPL-2.0-or-later).
 #
 # TravisCI (https://travis-ci.org) configuration file
 os: linux

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
 #
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
 # General Public License v2 (GPLv2).

--- a/common/daemon.py
+++ b/common/daemon.py
@@ -50,8 +50,9 @@ import logger
 from applicationinstance import ApplicationInstance
 
 
-def fdDup(old, new_fd, mode = 'w'):
-    """Duplicate file descriptor `old` to `new_fd` and closing the latter first.
+def fdDup(old, new_fd, mode='w'):
+    """Duplicate file descriptor `old` to `new_fd` and closing the latter
+    first.
 
     Used to redirect stdin, stdout and stderr from daemonized threads.
 
@@ -68,7 +69,6 @@ def fdDup(old, new_fd, mode = 'w'):
         logger.debug('Failed to redirect {}: {}'.format(old, str(e)))
 
 
-
 class Daemon:
     """A generic daemon class.
 
@@ -79,7 +79,7 @@ class Daemon:
                  stdin='/dev/null',
                  stdout='/dev/stdout',
                  stderr='/dev/null',
-                 umask = 0o022):
+                 umask=0o022):
         self.stdin = stdin
         self.stdout = stdout
         self.stderr = stderr

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -187,7 +187,6 @@ def collect_diagnostics():
     return result
 
 
-
 def _get_qt_information():
     """Collect Version and Theme information from Qt.
 
@@ -334,7 +333,8 @@ def _get_rsync_info():
             if isinstance(info[key], list):
                 info[key] = ', '.join(info[key])
             elif isinstance(info[key], dict):
-                info[key] = '; '.join(f'{k}: {v}' for k, v in info[key].items())
+                info[key] = '; '.join(
+                    f'{k}: {v}' for k, v in info[key].items())
 
     return info
 

--- a/common/doc-dev/conf.py
+++ b/common/doc-dev/conf.py
@@ -35,8 +35,8 @@ copyright = '2016, Germar Reitze'
 author = 'Germar Reitze'
 
 # Don't edit this variable. It is updated automatically by "updateversion.sh".
-import backintime
-version = backintime.__version__
+import version as version_module
+version = version_module.__version__
 # The full version, including alpha/beta/rc tags.
 release = version  # '1.3.3-dev'
 

--- a/common/languages.py
+++ b/common/languages.py
@@ -1,4 +1,5 @@
-# Generated at Tue Aug  6 10:08:08 2024 with help of package "babel" and "polib".
+# Generated at Tue Aug  6 10:08:08 2024 with help
+# of package "babel" and "polib".
 # https://babel.pocoo.org
 # https://github.com/python-babel/babel
 

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -51,7 +51,7 @@ def _determine_crontab_command() -> str:
     raise RuntimeError(msg)
 
 
-crontab_command = _determine_crontab_command()
+CRONTAB_COMMAND = _determine_crontab_command()
 
 
 def read_crontab():
@@ -66,13 +66,13 @@ def read_crontab():
     """
     try:
         proc = subprocess.run(
-            [crontab_command, '-l'],
+            [CRONTAB_COMMAND, '-l'],
             check=True,
             capture_output=True,
             text=True)
 
     except subprocess.CalledProcessError as err:
-        logger.error(f'Failed to get content from "{crontab_command}". '
+        logger.error(f'Failed to get content via "{CRONTAB_COMMAND}". '
                      f'Return code of {err.cmd} was {err.returncode}.')
         return []
 
@@ -118,7 +118,7 @@ def write_crontab(lines):
 
         try:
             subprocess.run(
-                [crontab_command, '-'],
+                [CRONTAB_COMMAND, '-'],
                 stdin=echo.stdout,
                 check=True,
                 capture_output=True,
@@ -127,7 +127,7 @@ def write_crontab(lines):
 
         except subprocess.CalledProcessError as err:
             logger.error(
-                f'Failed to write crontab lines with "{crontab_command}". '
+                f'Failed to write crontab lines with "{CRONTAB_COMMAND}". '
                 f'Return code was {err.returncode}. '
                 f'Error was:\n{err.stderr}')
             return False

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -35,7 +35,11 @@ def _determine_crontab_command() -> str:
     """
     to_check_commands = ['crontab', 'fcrontab']
     for cmd in to_check_commands:
-        proc = subprocess.run(['which', cmd], stdout=subprocess.PIPE)
+        proc = subprocess.run(
+            ['which', cmd],
+            stdout=subprocess.PIPE,
+            check=False
+        )
         if proc.returncode == 0:
             return cmd
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1,20 +1,14 @@
-# Back In Time
-# Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey,
-# Germar Reitze, Taylor Raack
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Taylor Raack
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# This file is part of the program "Back In time" which is released under GNU
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 import os
 from pathlib import Path
 import stat
@@ -2301,8 +2295,7 @@ class Snapshots:
                 or ``1`` if ``item`` is a file.
 
         Returns:
-            (tuple): Two item tuple of ``(OrderedSet('include1 options'),
-                OrderedSet('include2 options'))``.
+            (tuple): Two item tuple with two lists.
         """
         # Include items..
         # ...before the exclude items and...

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -1,22 +1,104 @@
+# SPDX-FileCopyrightText: © 2023 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""Tests using several linters.
+
+Instead of failing tests are skipped on machines where the linters are not
+available. As an exception only on TravisCI tests are forced to run and will
+fail if linters not available.
+"""
 import unittest
 import os
 import pathlib
 import subprocess
 import shutil
 from typing import Iterable
+try:
+    import pycodestyle
+    PYCODESTYLE_AVAILABLE = True
+except ImportError:
+    PYCODESTYLE_AVAILABLE = False
+
+BASE_REASON = ('Using package {0} is mandatory on TravisCI, on '
+               'other systems it runs only if `{0}` is available.')
 
 ON_TRAVIS = os.environ.get('TRAVIS', '') == 'true'
-PYLINT_AVIALBE = not shutil.which('pylint') is None
-PYLINT_REASON = ('Using PyLint is mandatory on TravisCI, on other systems'
-                 'it runs only if `pylint` is available.')
+TRAVIS_REASON = ('Running linter tests is mandatory on TravisCI only. On '
+                 'other machines they will run only if linters available.')
+
+PYLINT_AVAILABLE = shutil.which('pylint') is not None
+RUFF_AVAILABLE = shutil.which('ruff') is not None
+
+ANY_LINTER_AVAILABLE = any((
+    PYLINT_AVAILABLE,
+    RUFF_AVAILABLE,
+    PYCODESTYLE_AVAILABLE,
+))
+
+# Files in this lists will get the full battery of linters and rule sets.
+full_test_files = [pathlib.Path(fp) for fp in (
+    'bitbase.py',
+    'schedule.py',
+    'version.py',
+    'test/test_lint.py',
+)]
+
+# Not all linters do respect PEP8
+PEP8_MAX_LINE_LENGTH = 79
 
 
+def create_pylint_cmd(include_error_codes=None):
+    """Create the pylint base command for later use with subprocess.run().
+
+    Args:
+        include_error_codes: List of exclusive rules to check for. If empty all
+            default rules are checked.
+    """
+
+    cmd = [
+        'pylint',
+        # Make sure BIT modules can be imported (to detect "no-member")
+        '--init-hook=import sys;'
+        'sys.path.insert(0, "./../qt");'
+        'sys.path.insert(0, "./../common");',
+        # Storing results in a pickle file is unnecessary
+        '--persistent=n',
+        # autodetec number of parallel jobs
+        '--jobs=0',
+        # Disable scoring  ("Your code has been rated at xx/10")
+        '--score=n',
+        # prevent false-positive no-module-member errors
+        '--extension-pkg-allow-list=PyQt6,PyQt6.QtCore',
+        # Because of globally installed GNU gettext functions
+        '--additional-builtins=_,ngettext',
+        # PEP8 conform line length (see PyLint Issue #3078)
+        '--max-line-length=79',
+        # Whitelist variable names
+        '--good-names=idx,fp',
+        # '--reports=yes',
+    ]
+
+    if include_error_codes:
+        # Deactivate all checks by default
+        cmd.append('--disable=all')
+        # Inlcude specific codes only
+        cmd.append('--enable=' + ','.join(include_error_codes))
+
+    return cmd
+
+
+@unittest.skipUnless(ON_TRAVIS or ANY_LINTER_AVAILABLE, TRAVIS_REASON)
 class MirrorMirrorOnTheWall(unittest.TestCase):
     """Check all py-files in the package (incl. test files) for lints,
     potential bugs and if they are compliant to the coding styles (e.g. PEP8).
     """
 
-    def _collect_py_files(self) -> Iterable[pathlib.Path]:
+    @classmethod
+    def _collect_py_files(cls) -> Iterable[pathlib.Path]:
         """All py-files related to that distribution package.
 
         Dev note (2023-11): Use package metadata after migration to
@@ -37,42 +119,105 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         path = path.parent
 
         # Find recursive all py-files.
-        return path.rglob('**/*.py')
+        py_files = path.rglob('**/*.py')
 
-    @unittest.skipUnless(ON_TRAVIS or PYLINT_AVIALBE, PYLINT_REASON)
-    def test_with_pylint(self):
-        """Use Pylint to check for specific error codes.
+        # Exclude full test files
+        return filter(lambda fp: fp not in full_test_files, py_files)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.collected_py_files = cls._collect_py_files()
+
+    @unittest.skipUnless(RUFF_AVAILABLE, BASE_REASON.format('ruff'))
+    def test010_ruff_default_ruleset(self):
+        """Ruff in default mode."""
+
+        # ATTENTIION: Some settings are found in pyproject.toml
+        cmd = [
+            'ruff',
+            'check',
+            # Additionally activate subset of PyLint (PL)
+            # and PyCodestyle (E, W) rules
+            '--extend-select=PL,E,W',
+            # Ignore: redefined-loop-name
+            '--ignore=PLW2901',
+            '--line-length', str(PEP8_MAX_LINE_LENGTH),
+            # Because of globally installed GNU gettext functions
+            '--config', 'builtins=["_", "ngettext"]',
+            # Ruff counting branches different from PyLint.
+            # See: <https://www.reddit.com/r/learnpython/comments/
+            #      1buojae/comment/kxu0mp3>
+            '--config', 'pylint.max-branches=13',
+            '--quiet',
+        ]
+
+        cmd.extend(full_test_files)
+
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            universal_newlines=True,
+            capture_output=True
+        )
+
+        # No errors other then linter rules
+        self.assertIn(proc.returncode, [0, 1], proc.stderr)
+
+        error_n = len(proc.stdout.splitlines())
+        if error_n > 0:
+            print(proc.stdout)
+
+        self.assertEqual(0, error_n, f'Ruff found {error_n} problem(s).')
+
+        # any other errors?
+        self.assertEqual(proc.stderr, '')
+
+    @unittest.skipUnless(PYCODESTYLE_AVAILABLE,
+                         BASE_REASON.format('pycodestyle'))
+    def test020_pycodestyle(self):
+        """PEP8 conformance via pycodestyle"""
+
+        style = pycodestyle.StyleGuide(quite=True)
+        result = style.check_files(full_test_files)
+
+        self.assertEqual(result.total_errors, 0,
+                         f'pycodestyle found {result.total_errors} code '
+                         'style error(s)/warning(s).')
+
+    @unittest.skipUnless(PYLINT_AVAILABLE, BASE_REASON.format('PyLint'))
+    def test030_pylint_default_ruleset(self):
+        """Use Pylint with all default rules to check specific files.
+        """
+
+        cmd = create_pylint_cmd()
+
+        # Add py-files
+        cmd.extend(full_test_files)
+
+        r = subprocess.run(
+            cmd,
+            check=False,
+            universal_newlines=True,
+            capture_output=True)
+
+        # Count lines except module headings
+        error_n = len(list(filter(lambda line: not line.startswith('*****'),
+                                  r.stdout.splitlines())))
+        print(r.stdout)
+
+        self.assertEqual(0, error_n, f'PyLint found {error_n} problems.')
+
+        # any other errors?
+        self.assertEqual(r.stderr, '')
+
+    @unittest.skipUnless(PYLINT_AVAILABLE, BASE_REASON.format('PyLint'))
+    def test050_pylint_exclusive_ruleset(self):
+        """Use Pylint to check for specific rules only.
 
         Some facts about PyLint
          - It is one of the slowest available linters.
          - It is able to catch lints other linters miss.
         """
-
-        # Pylint base command
-        cmd = [
-            'pylint',
-            # Make sure BIT modules can be imported (to detect "no-member")
-            '--init-hook=import sys;'
-            'sys.path.insert(0, "./../qt");'
-            'sys.path.insert(0, "./../common");',
-            # Storing results in a pickle file is unnecessary
-            '--persistent=n',
-            # autodetec number of parallel jobs
-            '--jobs=0',
-            # Disable scoring  ("Your code has been rated at xx/10")
-            '--score=n',
-            # Deactivate all checks by default
-            '--disable=all',
-            # prevent false-positive no-module-member errors
-            '--extension-pkg-allow-list=PyQt6,PyQt6.QtCore',
-            # Because of globally installed GNU gettext functions
-            '--additional-builtins=_,ngettext',
-            # PEP8 conform line length (see PyLint Issue #3078)
-            '--max-line-length=79',
-            # Whitelist variable names
-            '--good-names=idx,fp',
-            # '--reports=yes',
-        ]
 
         # Explicit activate checks
         err_codes = [
@@ -109,14 +254,14 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             'R0801',  # duplicate-code
 
             # Enable asap. This list is a selection of existing (not all!)
-            # problems currently existing in the BIT code base. Quite easy to fix
-            # because their count is low.
+            # problems currently existing in the BIT code base. Quite easy to
+            # fix because their count is low.
             # 'W0237',  # arguments-renamed
             # 'W0221',  # arguments-differ
             # 'W0603',  # global-statement
         ]
 
-        cmd.append('--enable=' + ','.join(err_codes))
+        cmd = create_pylint_cmd(err_codes)
 
         # Add py-files
         cmd.extend(self._collect_py_files())

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -47,7 +47,7 @@ full_test_files = [pathlib.Path(fp) for fp in (
     'test/test_lint.py',
 )]
 
-# Not all linters do respect PEP8
+# Not all linters do respect PEP8 (e.g. ruff, PyLint)
 PEP8_MAX_LINE_LENGTH = 79
 
 
@@ -76,7 +76,7 @@ def create_pylint_cmd(include_error_codes=None):
         # Because of globally installed GNU gettext functions
         '--additional-builtins=_,ngettext',
         # PEP8 conform line length (see PyLint Issue #3078)
-        '--max-line-length=79',
+        f'--max-line-length={PEP8_MAX_LINE_LENGTH}',
         # Whitelist variable names
         '--good-names=idx,fp',
         # '--reports=yes',

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# This file is part of the program "Back In time" which is released under GNU
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Tests using several linters.
 
-Instead of failing tests are skipped on machines where the linters are not
-available. As an exception only on TravisCI tests are forced to run and will
-fail if linters not available.
+Linter tests are skipped on machines where the linters are not available. As an
+exception only on TravisCI tests are forced to run and will fail if linters not
+available.
 """
 import unittest
 import os

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -119,7 +119,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         path = path.parent
 
         # Find recursive all py-files.
-        py_files = path.rglob('**/*.py')
+        py_files = path.rglob('*.py')
 
         # Exclude full test files
         return filter(lambda fp: fp not in full_test_files, py_files)

--- a/common/version.py
+++ b/common/version.py
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
 """Centralize management about the version.
 
 That file is a workaround until the project migrated to a Python build-system.

--- a/qt/aboutdlg.py
+++ b/qt/aboutdlg.py
@@ -1,21 +1,14 @@
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
 """The About dialog."""
-# Back In Time
-# Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey,
-# Germar Reitze
-#
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 import re
 import pathlib
 from PyQt6.QtWidgets import (QLabel,
@@ -25,8 +18,8 @@ from PyQt6.QtWidgets import (QLabel,
                              QDialogButtonBox)
 from PyQt6.QtCore import Qt, QSize
 import tools
-import messagebox
 import backintime
+import messagebox
 
 
 class AboutDlg(QDialog):

--- a/qt/combobox.py
+++ b/qt/combobox.py
@@ -5,6 +5,7 @@
 # This file is part of the program "Back In Time" which is released under GNU
 # General Public License v2 (GPLv2).
 # See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""Module with an improved combo box widget."""
 from PyQt6.QtWidgets import QComboBox, QWidget
 
 
@@ -44,6 +45,7 @@ class BitComboBox(QComboBox):
 
     @property
     def current_data(self):
+        """Data linked to the current selected entry."""
         return self.itemData(self.currentIndex())
 
     def select_by_data(self, data):

--- a/qt/encfsmsgbox.py
+++ b/qt/encfsmsgbox.py
@@ -42,14 +42,14 @@ class EncfsCreateWarning(_EncfsWarningBase):
         text = _('Support for EncFS will be discontinued in the '
                  'foreseeable future. It is not recommended to use that '
                  'mode for a profile furthermore.')
+        whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
+            + _('whitepaper') + '</a>'
         informative_text = _(
             'A decision on a replacement for continued support of encrypted '
             'backups is still pending, depending on project resources and '
             'contributor availability. More details are available in this '
             '{whitepaper}.'
-        ).format(whitepaper='<a href="{}">{}</a>'.format(
-            URL_ENCRYPT_TRANSITION,
-            _('whitepaper')))
+        ).format(whitepaper=whitepaper)
 
         super().__init__(parent, text, informative_text)
 
@@ -71,6 +71,8 @@ class EncfsExistsWarning(_EncfsWarningBase):
             + ''.join(f'<li>{profile}</li>' for profile in profiles) \
             + '</ul>'
 
+        whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
+            + _('whitepaper') + '</a>'
         info_paragraphs = (
             _('The following profile(s) use encryption with EncFS:'),
             profiles,
@@ -79,9 +81,7 @@ class EncfsExistsWarning(_EncfsWarningBase):
               'contributor availability. Users are invited to join this '
               'discussion. Updated details on the next steps are '
               'available in this {whitepaper}.').format(
-                  whitepaper='<a href="{}">{}</a>'.format(
-                      URL_ENCRYPT_TRANSITION,
-                      _('whitepaper'))),
+                  whitepaper=whitepaper),
             _('This message will not be shown again. This dialog is '
               'available at any time via the help menu.'),
             _('Your Back In Time Team')

--- a/qt/languagedialog.py
+++ b/qt/languagedialog.py
@@ -1,5 +1,11 @@
-"""Dialog window to choose GUI display language.
-"""
+# SPDX-FileCopyrightText: © 2023 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""Dialog window to choose GUI display language."""
 from PyQt6.QtCore import Qt, QSize, QTimer
 from PyQt6.QtGui import QCursor
 from PyQt6.QtWidgets import (QApplication,
@@ -15,8 +21,10 @@ from PyQt6.QtWidgets import (QApplication,
                              QToolTip,
                              )
 import tools
-import qttools
 import languages
+import qttools
+
+LOW_RESOLUTION_WIDTH = 1024
 
 
 class LanguageDialog(QDialog):
@@ -24,6 +32,7 @@ class LanguageDialog(QDialog):
     def __init__(self, used_language_code: str, configured_language_code: str):
         super().__init__()
 
+        self.language_code = None
         self.used_language_code = used_language_code
         self.configured_language_code = configured_language_code
 
@@ -96,9 +105,11 @@ class LanguageDialog(QDialog):
             # ...combine source and translated version.
             label = f'{label}\n{translated_label}'
 
-        tooltip = _('Use operating systems language.')
-        code = None
-        r = self._create_radio_button(code, label, tooltip)
+        r = self._create_radio_button(
+            lang_code=None,
+            label=label,
+            tooltip=_('Use operating systems language.')
+        )
         grid.addWidget(r, 1, 1)
 
         # Sort by language code but keep English on top
@@ -111,7 +122,7 @@ class LanguageDialog(QDialog):
         number_of_columns = 3
 
         # Low-resolution screens (XGA or less)
-        if QApplication.primaryScreen().size().width() <= 1024:
+        if QApplication.primaryScreen().size().width() <= LOW_RESOLUTION_WIDTH:
             # Use one columns less
             number_of_columns -= 1
 
@@ -177,7 +188,7 @@ class ApproachTranslatorDialog(QDialog):
     translation of Back In Time.
     """
 
-    # ToDo (2023-08): Move to packages meta-data (pyproject.toml).
+    # (2023-08): Move to packages meta-data (pyproject.toml).
     _URL_PLATFORM = 'https://translate.codeberg.org/engage/backintime'
     _URL_PROJECT = 'https://github.com/bit-team/backintime'
 

--- a/qt/qttools_path.py
+++ b/qt/qttools_path.py
@@ -1,21 +1,13 @@
-#    Back In Time
-#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar
-#    Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
 #
-#    This program is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation; either version 2 of the License, or
-#    (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License along
-#    with this program; if not, write to the Free Software Foundation, Inc.,
-#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
 """Helper functions extracted from qt/qttools.py file.
 
 Extraction happened of problems with import dependencies. The whole path
@@ -26,7 +18,9 @@ the future.
 import os
 import sys
 
+
 def backintimePath(*path):
+    """Return the path of the backintime project folder."""
     return os.path.abspath(os.path.join(__file__, os.pardir, os.pardir, *path))
 
 

--- a/qt/schedulewidget.py
+++ b/qt/schedulewidget.py
@@ -10,6 +10,7 @@
 # This file is part of the program "Back In Time" which is released under GNU
 # General Public License v2 (GPLv2).
 # See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""The widget to setup scheduling backup jobs."""
 import datetime
 from PyQt6.QtWidgets import (QHBoxLayout,
                              QFormLayout,
@@ -35,7 +36,7 @@ class ScheduleWidget(QGroupBox):
 
         main_layout = QFormLayout(self)
 
-        def _create_form_entry(label: str, widget: QWidget=None) -> int:
+        def _create_form_entry(label: str, widget: QWidget = None) -> int:
             """Helper to create a row with a label and widget in the form
             layout.
 
@@ -205,7 +206,7 @@ class ScheduleWidget(QGroupBox):
 
         return combobox.BitComboBox(self, repeatedly_units)
 
-    def _slot_schedule_mode_changed(self, idx):
+    def _slot_schedule_mode_changed(self, _idx):
         """Handle value changed events for schedule mode combobox."""
         self._set_child_visibilities(self._combo_schedule_mode.current_data)
 
@@ -277,7 +278,6 @@ class ScheduleWidget(QGroupBox):
         """
 
         if self._combo_schedule_mode.current_data == cfg.CUSTOM_HOUR:
-            # TODO
             # Dev note (buhtz, 2024-05): IMHO checkCronPattern() is not needed
             # because the "crontab" command itself will validate this. See
             # schedule.write_crontab().

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -1,22 +1,103 @@
+# SPDX-FileCopyrightText: © 2023 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""Tests using several linters.
+
+See file common/test/test_lint.py for details.
+"""
 import unittest
 import os
 import pathlib
 import subprocess
 import shutil
 from typing import Iterable
+try:
+    import pycodestyle
+    PYCODESTYLE_AVAILABLE = True
+except ImportError:
+    PYCODESTYLE_AVAILABLE = False
+
+BASE_REASON = ('Using package {0} is mandatory on TravisCI, on '
+               'other systems it runs only if `{0}` is available.')
 
 ON_TRAVIS = os.environ.get('TRAVIS', '') == 'true'
-PYLINT_AVIALBE = not shutil.which('pylint') is None
-PYLINT_REASON = ('Using PyLint is mandatory on TravisCI, on other systems'
-                 'it runs only if `pylint` is available.')
+TRAVIS_REASON = ('Running linter tests is mandatory on TravisCI only. On '
+                 'other machines they will run only if linters available.')
+
+PYLINT_AVAILABLE = shutil.which('pylint') is not None
+RUFF_AVAILABLE = shutil.which('ruff') is not None
+
+ANY_LINTER_AVAILABLE = any((
+    PYLINT_AVAILABLE,
+    RUFF_AVAILABLE,
+    PYCODESTYLE_AVAILABLE,
+))
+
+# Files in this lists will get the full battery of linters and rule sets.
+full_test_files = [pathlib.Path(fp) for fp in (
+    'aboutdlg.py',
+    'combobox.py',
+    'encfsmsgbox.py',
+    'languagedialog.py',
+    'test/test_lint.py',
+)]
+
+# Not all linters do respect PEP8
+PEP8_MAX_LINE_LENGTH = 79
 
 
+def create_pylint_cmd(include_error_codes=None):
+    """Create the pylint base command for later use with subprocess.run().
+
+    Args:
+        include_error_codes: List of exclusive rules to check for. If empty all
+            default rules are checked.
+    """
+
+    cmd = [
+        'pylint',
+        # Make sure BIT modules can be imported (to detect "no-member")
+        '--init-hook=import sys;'
+        'sys.path.insert(0, "./../qt");'
+        'sys.path.insert(0, "./../common");',
+        # Storing results in a pickle file is unnecessary
+        '--persistent=n',
+        # autodetec number of parallel jobs
+        '--jobs=0',
+        # Disable scoring  ("Your code has been rated at xx/10")
+        '--score=n',
+        # prevent false-positive no-module-member errors
+        '--extension-pkg-allow-list=PyQt6,PyQt6.QtCore',
+        # Because of globally installed GNU gettext functions
+        '--additional-builtins=_,ngettext',
+        # PEP8 conform line length (see PyLint Issue #3078)
+        '--max-line-length=79',
+        # Whitelist variable names
+        '--good-names=idx,fp',
+        # '--reports=yes',
+    ]
+
+    if include_error_codes:
+        # Deactivate all checks by default
+        cmd.append('--disable=all')
+        # Inlcude specific codes only
+        cmd.append('--enable=' + ','.join(include_error_codes))
+
+    return cmd
+
+
+@unittest.skipUnless(ON_TRAVIS or ANY_LINTER_AVAILABLE, TRAVIS_REASON)
 class MirrorMirrorOnTheWall(unittest.TestCase):
-    """Check all py-files in the package (incl. test files) for lints and
+    """Check all py-files in the package (incl. test files) for lints,
     potential bugs and if they are compliant to the coding styles (e.g. PEP8).
     """
 
-    def _collect_py_files(self) -> Iterable[pathlib.Path]:
+    @classmethod
+    def _collect_py_files(cls) -> Iterable[pathlib.Path]:
         """All py-files related to that distribution package.
 
         Dev note (2023-11): Use package metadata after migration to
@@ -30,49 +111,113 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
 
         if not path.name.startswith('test'):
             raise RuntimeError('Something went wrong. The test should run '
-                               'inside the test folder but current folder '
+                               'inside the test folder but the current folder '
                                f'is {path}.')
 
         # Workaround
         path = path.parent
 
         # Find recursive all py-files.
-        return path.rglob('**/*.py')
+        py_files = path.rglob('**/*.py')
 
-    @unittest.skipUnless(ON_TRAVIS or PYLINT_AVIALBE, PYLINT_REASON)
-    def test_with_pylint(self):
-        """Use Pylint to check for specific error codes.
+        # Exclude full test files
+        return filter(lambda fp: fp not in full_test_files, py_files)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.collected_py_files = cls._collect_py_files()
+
+    @unittest.skipUnless(RUFF_AVAILABLE, BASE_REASON.format('ruff'))
+    def test010_ruff_default_ruleset(self):
+        """Ruff in default mode."""
+
+        # ATTENTIION: Some settings are found in pyproject.toml
+        cmd = [
+            'ruff',
+            'check',
+            # Additionally activate subset of PyLint (PL)
+            # and PyCodestyle (E, W) rules
+            '--extend-select=PL,E,W',
+            # Ignore: redefined-loop-name
+            '--ignore=PLW2901',
+            '--line-length', str(PEP8_MAX_LINE_LENGTH),
+            # Because of globally installed GNU gettext functions
+            '--config', 'builtins=["_", "ngettext"]',
+            # Ruff counting branches different from PyLint.
+            # See: <https://www.reddit.com/r/learnpython/comments/
+            #      1buojae/comment/kxu0mp3>
+            '--config', 'pylint.max-branches=13',
+            '--config', 'flake8-quotes.inline-quotes = "single"',
+            '--quiet',
+        ]
+
+        cmd.extend(full_test_files)
+
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            universal_newlines=True,
+            capture_output=True
+        )
+
+        # No errors other then linter rules
+        self.assertIn(proc.returncode, [0, 1], proc.stderr)
+
+        error_n = len(proc.stdout.splitlines())
+        if error_n > 0:
+            print(proc.stdout)
+
+        self.assertEqual(0, error_n, f'Ruff found {error_n} problem(s).')
+
+        # any other errors?
+        self.assertEqual(proc.stderr, '')
+
+    @unittest.skipUnless(PYCODESTYLE_AVAILABLE,
+                         BASE_REASON.format('pycodestyle'))
+    def test020_pycodestyle(self):
+        """PEP8 conformance via pycodestyle"""
+
+        style = pycodestyle.StyleGuide(quite=True)
+        result = style.check_files(full_test_files)
+
+        self.assertEqual(result.total_errors, 0,
+                         f'pycodestyle found {result.total_errors} code '
+                         'style error(s)/warning(s).')
+
+    @unittest.skipUnless(PYLINT_AVAILABLE, BASE_REASON.format('PyLint'))
+    def test030_pylint_default_ruleset(self):
+        """Use Pylint with all default rules to check specific files.
+        """
+
+        cmd = create_pylint_cmd()
+
+        # Add py-files
+        cmd.extend(full_test_files)
+
+        r = subprocess.run(
+            cmd,
+            check=False,
+            universal_newlines=True,
+            capture_output=True)
+
+        # Count lines except module headings
+        error_n = len(list(filter(lambda line: not line.startswith('*****'),
+                                  r.stdout.splitlines())))
+        print(r.stdout)
+
+        self.assertEqual(0, error_n, f'PyLint found {error_n} problems.')
+
+        # any other errors?
+        self.assertEqual(r.stderr, '')
+
+    @unittest.skipUnless(PYLINT_AVAILABLE, BASE_REASON.format('PyLint'))
+    def test050_pylint_exclusive_ruleset(self):
+        """Use Pylint to check for specific rules only.
 
         Some facts about PyLint
          - It is one of the slowest available linters.
-         - It is able to catch lints none of the other linters
+         - It is able to catch lints other linters miss.
         """
-
-        # Pylint base command
-        cmd = [
-            'pylint',
-            # Make sure BIT modules can be imported (to detect "no-member")
-            '--init-hook=import sys;'
-            'sys.path.insert(0, "./../qt");'
-            'sys.path.insert(0, "./../common");',
-            # Storing results in a pickle file is unnecessary
-            '--persistent=n',
-            # autodetec number of parallel jobs
-            '--jobs=0',
-            # Disable scoring  ("Your code has been rated at xx/10")
-            '--score=n',
-            # Deactivate all checks by default
-            '--disable=all',
-            # prevent false-positive no-module-member errors
-            '--extension-pkg-allow-list=PyQt6,PyQt6.QtCore',
-            # Because of globally installed GNU gettext functions
-            '--additional-builtins=_,ngettext',
-            # PEP8 conform line length (see PyLint Issue #3078)
-            '--max-line-length=79',
-            # Whitelist variable names
-            '--good-names=idx,fp',
-            # '--reports=yes',
-        ]
 
         # Explicit activate checks
         err_codes = [
@@ -116,9 +261,9 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # 'W0707',  # raise-missing-from
         ]
 
-        cmd.append('--enable=' + ','.join(err_codes))
+        cmd = create_pylint_cmd(err_codes)
 
-        # Add py files
+        # Add py-files
         cmd.extend(self._collect_py_files())
 
         r = subprocess.run(
@@ -133,3 +278,6 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         print(r.stdout)
 
         self.assertEqual(0, error_n, f'PyLint found {error_n} problems.')
+
+        # any other errors?
+        self.assertEqual(r.stderr, '')

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -42,7 +42,6 @@ full_test_files = [pathlib.Path(fp) for fp in (
     'aboutdlg.py',
     'combobox.py',
     'encfsmsgbox.py',
-    'languagedialog.py',
     'test/test_lint.py',
 )]
 

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -45,7 +45,7 @@ full_test_files = [pathlib.Path(fp) for fp in (
     'test/test_lint.py',
 )]
 
-# Not all linters do respect PEP8
+# Not all linters do respect PEP8 (e.g. ruff, PyLint)
 PEP8_MAX_LINE_LENGTH = 79
 
 
@@ -74,7 +74,7 @@ def create_pylint_cmd(include_error_codes=None):
         # Because of globally installed GNU gettext functions
         '--additional-builtins=_,ngettext',
         # PEP8 conform line length (see PyLint Issue #3078)
-        '--max-line-length=79',
+        f'--max-line-length={PEP8_MAX_LINE_LENGTH}',
         # Whitelist variable names
         '--good-names=idx,fp',
         # '--reports=yes',

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2).
-# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+# This file is part of the program "Back In time" which is released under GNU
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Tests using several linters.
 
 See file common/test/test_lint.py for details.

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -117,7 +117,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         path = path.parent
 
         # Find recursive all py-files.
-        py_files = path.rglob('**/*.py')
+        py_files = path.rglob('*.py')
 
         # Exclude full test files
         return filter(lambda fp: fp not in full_test_files, py_files)

--- a/update_language_files.py
+++ b/update_language_files.py
@@ -359,7 +359,7 @@ def create_languages_file():
 
         date_now = datetime.datetime.now().strftime('%c')
         handle.write(
-            f'# Generated at {date_now} with help of package "babel" '
+            f'# Generated at {date_now} with help\n# of package "babel" '
             'and "polib".\n')
         handle.write('# https://babel.pocoo.org\n')
         handle.write('# https://github.com/python-babel/babel\n')

--- a/update_language_files.py
+++ b/update_language_files.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2023 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In time" which is released under GNU
+# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """This helper script does manage transferring translations to and from the
 translation platform (currently Weblate).
 """


### PR DESCRIPTION
Introduce full linting without any exceptions for a specific (and small) list of files. This increase the pressure on our code quality.

- The two files `common/test/test_lint.py` and `qt/test/test_lint.py` now have a module variable `full_test_files` containing a list of py file names that will get the full linter test battery.
- All other source files are only receiving the PyLint run with an exclusive and minimal list of rules only (`test050_pylint_exclusive_ruleset()`).
- Full linting means that (minimum) the default rule set of each linter is used without excluding any rules.
- Beside previously used PyLint now a chain of linters is used. The unit test method names have numbers to fix the execution order of the linters. 1) `ruff` very fast 2) `pycodestyle` quit fast 3) `pylint` slow but pedantic.
- The reason for having a chain of linters is they do have exceptional rules and capabilities.
- Much files are modified in this PR. I tried to fix some linter errors in them. I wasn't successful on all of them.

I do use a similar setup on two of my own smaller projects.
The motivation behind it was that I will introduce some new files (from splitting existing files) in the next weeks and I want to have them standard conform from the start.