### PR TITLE
refactor: Move old-args check to Manage Profiles dialog (#1886)

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -1210,19 +1210,7 @@ class Config(configfile.ConfigFileWithProfiles):
 
     def rsyncOptions(self, profile_id = None):
         #?rsync options. Options must be quoted e.g. \-\-exclude-from="/path/to/my exclude file"
-        val = self.profileStrValue('snapshots.rsync_options.value', '', profile_id)
-
-        if '--old-args' in val:
-            logger.warning(
-                'Found rsync flag "--old-args". That flag will be removed '
-                'from the options because it conflicts with '
-                'the flag "-s" (also known as "--secluded-args" or '
-                '"--protected-args") which is used by Back In Time to force '
-                'the "new form of argument protection" in rsync.'
-            )
-            val = val.replace('--old-args', '')
-
-        return val
+        return self.profileStrValue('snapshots.rsync_options.value', '', profile_id)
 
     def setRsyncOptions(self, enabled, value, profile_id = None):
         self.setProfileBoolValue('snapshots.rsync_options.enabled', enabled, profile_id)

--- a/qt/messagebox.py
+++ b/qt/messagebox.py
@@ -52,6 +52,7 @@ def askPasswordDialog(parent, title, prompt, language_code, timeout):
 
     return password
 
+
 def info(text, title=None, widget_to_center_on=None):
     """Show a modal information message box.
 
@@ -62,13 +63,27 @@ def info(text, title=None, widget_to_center_on=None):
         text(str): The information text central to the dialog.
         title(str): Title of the message box dialog.
         widget_to_center_on(QWidget): Center the message box on that widget.
-
-    Returns:
-        Nothing.
     """
     QMessageBox.information(
         widget_to_center_on,
         title if title else ngettext('Information', 'Information', 1),
+        text)
+
+
+def warning(text, title=None, widget_to_center_on=None):
+    """Show a modal warning message box.
+
+    The message box is centered on the primary screen if
+    ``widget_to_center_on`` is not given.
+
+    Args:
+        text(str): The warning message central to the dialog.
+        title(str): Title of the message box dialog.
+        widget_to_center_on(QWidget): Center the message box on that widget.
+    """
+    QMessageBox.warning(
+        widget_to_center_on,
+        title if title else _('Warning'),
         text)
 
 
@@ -125,8 +140,11 @@ def warningYesNoOptions(parent, msg, options = ()):
         }
     )
 
+
 def showInfo(parent, title, msg):
     """Show extended information dialog with framed and scrollable text area.
+
+    Dev info (buhtz, 2024): That function is deprecated. Use `info()` instead.
     """
     dlg = QDialog(parent)
     dlg.setWindowTitle(title)
@@ -144,4 +162,5 @@ def showInfo(parent, title, msg):
 
     vlayout.addWidget(scroll_area)
     vlayout.addWidget(buttonBox)
+
     return dlg.exec()

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -812,6 +812,8 @@ class SettingsDialog(QDialog):
         self.cbRsyncOptions.setToolTip(tooltip)
         hlayout.addWidget(self.cbRsyncOptions)
         self.txtRsyncOptions = QLineEdit(self)
+        self.txtRsyncOptions.editingFinished.connect(
+            self._slot_rsync_options_editing_finished)
         self.txtRsyncOptions.setToolTip(tooltip)
         hlayout.addWidget(self.txtRsyncOptions)
 
@@ -892,6 +894,29 @@ class SettingsDialog(QDialog):
         self.resize(size)
 
         self.finished.connect(self.cleanup)
+
+    def _slot_rsync_options_on_editing_finished(self):
+        """When editing the rsync options is finished warn and remove
+        --old-args option if present.
+        """
+        txt = self.txtRsyncOptions.text()
+
+        if '--old-args' in txt:
+            # No translation for this message because it is a rare case.
+            messagebox.warning(
+                text='Found rsync flag "--old-args". That flag will be removed'
+                ' from the options because it conflicts with the flag "-s" '
+                '(also known as "--secluded-args" or "--protected-args") which'
+                ' is used by Back In Time to force the "new form of argument '
+                'protection" in rsync.',
+                widget_to_center_on=self
+            )
+
+            # Don't leave two-blank spaces between other arguments
+            txt = txt.replace('--old-args ', '')
+            txt = txt.replace(' --old-args', '')
+            txt = txt.replace('--old-args', '')
+            self.txtRsyncOptions.setText(txt)
 
     def _tab_general(self):
         """Create the 'Generals' tab.


### PR DESCRIPTION
Move the "--old-args" check from Config class into the Manage Profiles dialog.

Fix #1886
Related to #1850 