### PR TITLE
refactor!: Remove unused config field ""user_callback.no_logging" (#1887)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,7 @@ Version 1.5.3-dev (development of upcoming release)
 * Refactor: Remove class OrderedSet
 * Refactor: Remove os.system() from class Execute
 * Refactor: Systray notifications send utilize DBUS instead of notify-send (#1156) (Felix Stupp @Zocker1999NET)
+* Refactor!: Remove unused config field "user_callback.no_logging" (#1887)
 * Dependency: Remove libnotify-bin (notify-send) (#1156)
 
 Version 1.5.2 (2024-08-06)

--- a/common/config.py
+++ b/common/config.py
@@ -1292,13 +1292,6 @@ class Config(configfile.ConfigFileWithProfiles):
     def setTakeSnapshotRegardlessOfChanges(self, value, profile_id = None):
         return self.setProfileBoolValue('snapshots.take_snapshot_regardless_of_changes', value, profile_id)
 
-    def userCallbackNoLogging(self, profile_id = None):
-        #?Do not catch std{out|err} from user-callback script.
-        #?The script will only write to current TTY.
-        #?Default is to catch std{out|err} and write it to
-        #?syslog and TTY again.
-        return self.profileBoolValue('user_callback.no_logging', False, profile_id)
-
     def globalFlock(self):
         #?Prevent multiple snapshots (from different profiles or users) to be run at the same time
         return self.boolValue('global.use_flock', False)

--- a/common/plugins/usercallbackplugin.py
+++ b/common/plugins/usercallbackplugin.py
@@ -78,10 +78,7 @@ class UserCallbackPlugin(pluginmanager.Plugin):
 
         logger.debug(f'Call user-callback: {" ".join(cmd)}', self)
 
-        if self.config.userCallbackNoLogging():
-            stdout, stderr = None, None
-        else:
-            stdout, stderr = PIPE, PIPE
+        stdout, stderr = PIPE, PIPE
 
         try:
             callback = Popen(cmd,


### PR DESCRIPTION
Remove config field ""user_callback.no_logging".

Assuming it was never used. Was added in version 1.1.7 (a010fa22e198b664f3342f4bd86798eaf727a16b).

Fix #1887
Related to #1850 