### PR TITLE
fix: Explicit mode argument for Config.get_snapshots_mountpoint() (#1892)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
 
 install:
   - pip install -U pip
-  - pip install pylint ruff pycodestyle pyfakefs keyring
+  - pip install pylint ruff flake8 pyfakefs keyring
   - pip install pyqt6 dbus-python
   # add ssh public / private key pair to ensure user can start ssh session to localhost for tests
   - ssh-keygen -b 2048 -t rsa -f /home/travis/.ssh/id_rsa -N ""

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ Version 1.5.3-dev (development of upcoming release)
 * Refactor: Remove os.system() from class Execute
 * Refactor: Systray notifications send utilize DBUS instead of notify-send (#1156) (Felix Stupp @Zocker1999NET)
 * Dependency: Remove libnotify-bin (notify-send) (#1156)
+* Build: Replace "pycodestyle" linter with "flake8" (#1839)
 
 Version 1.5.2 (2024-08-06)
 * Fix: Ensure crontab with ending newline (#781)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ the packages provided by the official repository of your GNU/Linux distribution.
   - `python3-pyfakefs`
   - Optional but recommended:
     - `pylint` (>= 3.3.0)
-    - `pycodestyle`
+    - `flake8`
     - `ruff` (>= 0.6.0)
     - `codespell`
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ the packages provided by the official repository of your GNU/Linux distribution.
   - Optional but recommended:
     - `pylint` (>= 3.3.0)
     - `pycodestyle`
-    - `ruff` (>= 0.6.6)
+    - `ruff` (>= 0.6.0)
     - `codespell`
  
 * Dependencies to build documentation

--- a/common/config.py
+++ b/common/config.py
@@ -373,13 +373,13 @@ class Config(configfile.ConfigFileWithProfiles):
 
     def get_snapshots_mountpoint(self, profile_id=None, mode=None, tmp_mount=False):
         """Return the profiles snapshot path in form of a mount point."""
-        print(f'Config.get_snapshots_mountpoint() :: {profile_id=} {mode=} {tmp_mount=}')
+        # print(f'Config.get_snapshots_mountpoint() :: {profile_id=} {mode=} {tmp_mount=}')
         if profile_id is None:
             profile_id = self.currentProfile()
 
         if mode is None:
             mode = self.snapshotsMode(profile_id)
-            print(f'\t :: determinied {mode=}')
+            # print(f'\t :: determinied {mode=}')
 
         if mode == 'local':
             return self.get_snapshots_path(profile_id)
@@ -390,7 +390,7 @@ class Config(configfile.ConfigFileWithProfiles):
         if tmp_mount:
             symlink = f'tmp_{symlink}'
 
-        print(f'Config.get_snapshots_mountpoint() :: returning {symlink=}')
+        # print(f'Config.get_snapshots_mountpoint() :: returning {symlink=}')
         return os.path.join(self._LOCAL_MOUNT_ROOT, symlink)
 
     def snapshotsPath(self, profile_id=None, mode=None, tmp_mount=False):
@@ -398,7 +398,7 @@ class Config(configfile.ConfigFileWithProfiles):
 
         That method is a surrogate for `self.get_snapshots_mountpoint()`.
         """
-        print(f'Config.snapshotsPath() :: {profile_id=} {mode=} {tmp_mount=}')
+        # print(f'Config.snapshotsPath() :: {profile_id=} {mode=} {tmp_mount=}')
         return self.get_snapshots_mountpoint(
             profile_id=profile_id,
             mode=mode,
@@ -1689,8 +1689,3 @@ class Config(configfile.ConfigFileWithProfiles):
             cmd = tools.which('nice') + ' -n19 ' + cmd
 
         return cmd
-
-
-if __name__ == '__main__':
-    config = Config()
-    print("snapshots path = %s" % config.snapshotsFullPath())

--- a/common/config.py
+++ b/common/config.py
@@ -371,12 +371,15 @@ class Config(configfile.ConfigFileWithProfiles):
     def host(self):
         return socket.gethostname()
 
-    def get_snapshots_mountpoint(self, profile_id=None, tmp_mount=False):
+    def get_snapshots_mountpoint(self, profile_id=None, mode=None, tmp_mount=False):
         """Return the profiles snapshot path in form of a mount point."""
+        print(f'Config.get_snapshots_mountpoint() :: {profile_id=} {mode=} {tmp_mount=}')
         if profile_id is None:
             profile_id = self.currentProfile()
 
-        mode = self.snapshotsMode(profile_id)
+        if mode is None:
+            mode = self.snapshotsMode(profile_id)
+            print(f'\t :: determinied {mode=}')
 
         if mode == 'local':
             return self.get_snapshots_path(profile_id)
@@ -387,6 +390,7 @@ class Config(configfile.ConfigFileWithProfiles):
         if tmp_mount:
             symlink = f'tmp_{symlink}'
 
+        print(f'Config.get_snapshots_mountpoint() :: returning {symlink=}')
         return os.path.join(self._LOCAL_MOUNT_ROOT, symlink)
 
     def snapshotsPath(self, profile_id=None, mode=None, tmp_mount=False):
@@ -394,8 +398,11 @@ class Config(configfile.ConfigFileWithProfiles):
 
         That method is a surrogate for `self.get_snapshots_mountpoint()`.
         """
+        print(f'Config.snapshotsPath() :: {profile_id=} {mode=} {tmp_mount=}')
         return self.get_snapshots_mountpoint(
-            profile_id=profile_id, tmp_mount=tmp_mount)
+            profile_id=profile_id,
+            mode=mode,
+            tmp_mount=tmp_mount)
 
     def snapshotsFullPath(self, profile_id = None):
         """

--- a/common/config.py
+++ b/common/config.py
@@ -373,13 +373,11 @@ class Config(configfile.ConfigFileWithProfiles):
 
     def get_snapshots_mountpoint(self, profile_id=None, mode=None, tmp_mount=False):
         """Return the profiles snapshot path in form of a mount point."""
-        # print(f'Config.get_snapshots_mountpoint() :: {profile_id=} {mode=} {tmp_mount=}')
         if profile_id is None:
             profile_id = self.currentProfile()
 
         if mode is None:
             mode = self.snapshotsMode(profile_id)
-            # print(f'\t :: determinied {mode=}')
 
         if mode == 'local':
             return self.get_snapshots_path(profile_id)
@@ -390,7 +388,6 @@ class Config(configfile.ConfigFileWithProfiles):
         if tmp_mount:
             symlink = f'tmp_{symlink}'
 
-        # print(f'Config.get_snapshots_mountpoint() :: returning {symlink=}')
         return os.path.join(self._LOCAL_MOUNT_ROOT, symlink)
 
     def snapshotsPath(self, profile_id=None, mode=None, tmp_mount=False):
@@ -398,7 +395,6 @@ class Config(configfile.ConfigFileWithProfiles):
 
         That method is a surrogate for `self.get_snapshots_mountpoint()`.
         """
-        # print(f'Config.snapshotsPath() :: {profile_id=} {mode=} {tmp_mount=}')
         return self.get_snapshots_mountpoint(
             profile_id=profile_id,
             mode=mode,

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -17,6 +17,7 @@ import pathlib
 import subprocess
 import shutil
 from typing import Iterable
+from packaging import version
 
 BASE_REASON = ('Using package {0} is mandatory on TravisCI, on '
                'other systems it runs only if `{0}` is available.')
@@ -126,6 +127,52 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.collected_py_files = cls._collect_py_files()
+
+    def test005_ensure_linter_versions(self):
+        """Workaround to ensure the correct linter versions are used.
+
+        For sure there are better ways to solve this. But migration to a
+        standard python package format need to be done first. See #1575.
+        Until then this test will spare some hours of work, e.g. fixing linter
+        errors (from out-dated linters) that are not relevant anymore in
+        modern lintern versions.
+
+        Another location where linter versions are relevant is CONTRIBUTING.md.
+        """
+
+        if PYLINT_AVAILABLE:
+            version_target = version.parse('3.3.0')
+
+            proc = subprocess.run(
+                ['pylint', '--version'],
+                capture_output=True,
+                text=True,
+                check=True)
+
+            version_string = proc.stdout.split('\n')[0].replace('pylint ', '')
+            version_actual = version.parse(version_string)
+
+            self.assertTrue(
+                version_actual >= version_target,
+                f'PyLint version is {version_actual} but need to '
+                f'be {version_target} or higher.')
+
+        if RUFF_AVAILABLE:
+            version_target = version.parse('0.6.0')
+
+            proc = subprocess.run(
+                ['ruff', '--version'],
+                capture_output=True,
+                text=True,
+                check=True)
+
+            version_string = proc.stdout.split('\n')[0].replace('ruff ', '')
+            version_actual = version.parse(version_string)
+
+            self.assertTrue(
+                version_actual >= version_target,
+                f'Ruff version is {version_actual} but need to '
+                f'be {version_target} or higher.')
 
     @unittest.skipUnless(RUFF_AVAILABLE, BASE_REASON.format('ruff'))
     def test010_ruff_default_ruleset(self):

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -17,11 +17,6 @@ import pathlib
 import subprocess
 import shutil
 from typing import Iterable
-try:
-    import pycodestyle
-    PYCODESTYLE_AVAILABLE = True
-except ImportError:
-    PYCODESTYLE_AVAILABLE = False
 
 BASE_REASON = ('Using package {0} is mandatory on TravisCI, on '
                'other systems it runs only if `{0}` is available.')
@@ -32,11 +27,12 @@ TRAVIS_REASON = ('Running linter tests is mandatory on TravisCI only. On '
 
 PYLINT_AVAILABLE = shutil.which('pylint') is not None
 RUFF_AVAILABLE = shutil.which('ruff') is not None
+FLAKE8_AVAILABLE = shutil.which('flake8') is not None
 
 ANY_LINTER_AVAILABLE = any((
     PYLINT_AVAILABLE,
     RUFF_AVAILABLE,
-    PYCODESTYLE_AVAILABLE,
+    FLAKE8_AVAILABLE,
 ))
 
 # "common" directory
@@ -154,6 +150,9 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             # See: <https://www.reddit.com/r/learnpython/comments/
             #      1buojae/comment/kxu0mp3>
             '--config', 'pylint.max-branches=13',
+            '--config', 'flake8-quotes.inline-quotes = "single"',
+            # one error per line (no context lines)
+            '--output-format=concise',
             '--quiet',
         ]
 
@@ -178,17 +177,33 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # any other errors?
         self.assertEqual(proc.stderr, '')
 
-    @unittest.skipUnless(PYCODESTYLE_AVAILABLE,
-                         BASE_REASON.format('pycodestyle'))
-    def test020_pycodestyle_default_ruleset(self):
-        """PEP8 conformance via pycodestyle"""
+    @unittest.skipUnless(FLAKE8_AVAILABLE, BASE_REASON.format('flake8'))
+    def test020_flake8_default_ruleset(self):
+        """Flake8 in default mode."""
+        cmd = [
+            'flake8',
+            f'--max-line-length={PEP8_MAX_LINE_LENGTH}',
+            '--builtins=_,ngettext',
+            # '--enable-extensions='
+        ]
 
-        style = pycodestyle.StyleGuide(quite=True)
-        result = style.check_files(full_test_files)
+        cmd.extend(full_test_files)
 
-        self.assertEqual(result.total_errors, 0,
-                         f'pycodestyle found {result.total_errors} code '
-                         'style error(s)/warning(s).')
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            universal_newlines=True,
+            capture_output=True
+        )
+
+        error_n = len(proc.stdout.splitlines())
+        if error_n > 0:
+            print(proc.stdout)
+
+        self.assertEqual(0, error_n, f'Flake8 found {error_n} problem(s).')
+
+        # any other errors?
+        self.assertEqual(proc.stderr, '')
 
     @unittest.skipUnless(PYLINT_AVAILABLE, BASE_REASON.format('PyLint'))
     def test030_pylint_default_ruleset(self):

--- a/qt/plugins/notifyplugin.py
+++ b/qt/plugins/notifyplugin.py
@@ -26,7 +26,7 @@ class NotifyPlugin(pluginmanager.Plugin):
     def isGui(self):
         return True
 
-    # pylint: disable-next=too-many-arguments
+    # pylint: disable-next=too-many-arguments,too-many-positional-arguments
     def message(self,
                 profile_id,
                 profile_name,

--- a/qt/plugins/notifyplugin.py
+++ b/qt/plugins/notifyplugin.py
@@ -27,7 +27,7 @@ class NotifyPlugin(pluginmanager.Plugin):
         return True
 
     # pylint: disable-next=too-many-arguments
-    def message(self,  # noqa: PLR0913
+    def message(self,
                 profile_id,
                 profile_name,
                 level,

--- a/qt/plugins/notifyplugin.py
+++ b/qt/plugins/notifyplugin.py
@@ -26,8 +26,8 @@ class NotifyPlugin(pluginmanager.Plugin):
     def isGui(self):
         return True
 
-    # pylint: disable-next=too-many-arguments,too-many-positional-arguments
-    def message(self,
+    # pylint: disable-next=too-many-arguments
+    def message(self,  # noqa: PLR0913
                 profile_id,
                 profile_name,
                 level,

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1255,7 +1255,6 @@ class SettingsDialog(QDialog):
                            t='str')
 
         # local
-        # print(f'SettingsDlg.updateProfile() :: config.snapshotsPath(local) = {p}')  # DEBUG
         self.editSnapshotsPath.setText(
             self.config.snapshotsPath(mode='local'))
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1255,10 +1255,7 @@ class SettingsDialog(QDialog):
                            t='str')
 
         # local
-        print('---- before calling "self.config.snapshotsPath(mode=local)"')
-        p = self.config.snapshotsPath(mode='local')
-        print(f'SettingsDlg.updateProfile() :: config.snapshotsPath(local) = {p}')  # DEBUG
-        print(' -- again -- ')
+        # print(f'SettingsDlg.updateProfile() :: config.snapshotsPath(local) = {p}')  # DEBUG
         self.editSnapshotsPath.setText(
             self.config.snapshotsPath(mode='local'))
 

--- a/qt/settingsdialog.py
+++ b/qt/settingsdialog.py
@@ -1255,6 +1255,10 @@ class SettingsDialog(QDialog):
                            t='str')
 
         # local
+        print('---- before calling "self.config.snapshotsPath(mode=local)"')
+        p = self.config.snapshotsPath(mode='local')
+        print(f'SettingsDlg.updateProfile() :: config.snapshotsPath(local) = {p}')  # DEBUG
+        print(' -- again -- ')
         self.editSnapshotsPath.setText(
             self.config.snapshotsPath(mode='local'))
 
@@ -1673,7 +1677,9 @@ class SettingsDialog(QDialog):
             self.config.set_snapshots_path(self.editSnapshotsPath.text())
 
         snapshots_mountpoint = self.config.get_snapshots_mountpoint(
+            mode=mode,
             tmp_mount=True)
+
         ret = tools.validate_and_prepare_snapshots_path(
             path=snapshots_mountpoint,
             host_user_profile=self.config.hostUserProfile(),

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -15,11 +15,6 @@ import pathlib
 import subprocess
 import shutil
 from typing import Iterable
-try:
-    import pycodestyle
-    PYCODESTYLE_AVAILABLE = True
-except ImportError:
-    PYCODESTYLE_AVAILABLE = False
 
 BASE_REASON = ('Using package {0} is mandatory on TravisCI, on '
                'other systems it runs only if `{0}` is available.')
@@ -30,11 +25,12 @@ TRAVIS_REASON = ('Running linter tests is mandatory on TravisCI only. On '
 
 PYLINT_AVAILABLE = shutil.which('pylint') is not None
 RUFF_AVAILABLE = shutil.which('ruff') is not None
+FLAKE8_AVAILABLE = shutil.which('flake8') is not None
 
 ANY_LINTER_AVAILABLE = any((
     PYLINT_AVAILABLE,
     RUFF_AVAILABLE,
-    PYCODESTYLE_AVAILABLE,
+    FLAKE8_AVAILABLE,
 ))
 
 # "qt" directory
@@ -154,6 +150,8 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
             #      1buojae/comment/kxu0mp3>
             '--config', 'pylint.max-branches=13',
             '--config', 'flake8-quotes.inline-quotes = "single"',
+            # one error per line (no context lines)
+            '--output-format=concise',
             '--quiet',
         ]
 
@@ -178,17 +176,33 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
         # any other errors?
         self.assertEqual(proc.stderr, '')
 
-    @unittest.skipUnless(PYCODESTYLE_AVAILABLE,
-                         BASE_REASON.format('pycodestyle'))
-    def test020_pycodestyle_default_ruleset(self):
-        """PEP8 conformance via pycodestyle"""
+    @unittest.skipUnless(FLAKE8_AVAILABLE, BASE_REASON.format('flake8'))
+    def test020_flake8_default_ruleset(self):
+        """Flake8 in default mode."""
+        cmd = [
+            'flake8',
+            f'--max-line-length={PEP8_MAX_LINE_LENGTH}',
+            '--builtins=_,ngettext',
+            # '--enable-extensions='
+        ]
 
-        style = pycodestyle.StyleGuide(quite=True)
-        result = style.check_files(full_test_files)
+        cmd.extend(full_test_files)
 
-        self.assertEqual(result.total_errors, 0,
-                         f'pycodestyle found {result.total_errors} code '
-                         'style error(s)/warning(s).')
+        proc = subprocess.run(
+            cmd,
+            check=False,
+            universal_newlines=True,
+            capture_output=True
+        )
+
+        error_n = len(proc.stdout.splitlines())
+        if error_n > 0:
+            print(proc.stdout)
+
+        self.assertEqual(0, error_n, f'Flake8 found {error_n} problem(s).')
+
+        # any other errors?
+        self.assertEqual(proc.stderr, '')
 
     @unittest.skipUnless(PYLINT_AVAILABLE, BASE_REASON.format('PyLint'))
     def test030_pylint_default_ruleset(self):

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -15,6 +15,7 @@ import pathlib
 import subprocess
 import shutil
 from typing import Iterable
+from packaging import version
 
 BASE_REASON = ('Using package {0} is mandatory on TravisCI, on '
                'other systems it runs only if `{0}` is available.')
@@ -125,6 +126,52 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.collected_py_files = cls._collect_py_files()
+
+    def test005_ensure_linter_versions(self):
+        """Workaround to ensure the correct linter versions are used.
+
+        For sure there are better ways to solve this. But migration to a
+        standard python package format need to be done first. See #1575.
+        Until then this test will spare some hours of work, e.g. fixing linter
+        errors (from out-dated linters) that are not relevant anymore in
+        modern lintern versions.
+
+        Another location where linter versions are relevant is CONTRIBUTING.md.
+        """
+
+        if PYLINT_AVAILABLE:
+            version_target = version.parse('3.3.0')
+
+            proc = subprocess.run(
+                ['pylint', '--version'],
+                capture_output=True,
+                text=True,
+                check=True)
+
+            version_string = proc.stdout.split('\n')[0].replace('pylint ', '')
+            version_actual = version.parse(version_string)
+
+            self.assertTrue(
+                version_actual >= version_target,
+                f'PyLint version is {version_actual} but need to '
+                f'be {version_target} or higher.')
+
+        if RUFF_AVAILABLE:
+            version_target = version.parse('0.6.0')
+
+            proc = subprocess.run(
+                ['ruff', '--version'],
+                capture_output=True,
+                text=True,
+                check=True)
+
+            version_string = proc.stdout.split('\n')[0].replace('ruff ', '')
+            version_actual = version.parse(version_string)
+
+            self.assertTrue(
+                version_actual >= version_target,
+                f'Ruff version is {version_actual} but need to '
+                f'be {version_target} or higher.')
 
     @unittest.skipUnless(RUFF_AVAILABLE, BASE_REASON.format('ruff'))
     def test010_ruff_default_ruleset(self):


### PR DESCRIPTION
The method `Config.get_snapshots_mountpoint()` (introduced in PR #1867) now use `mode` as argument.

Fix #1892.

Beside of that I modified the linter setup. I replace pycodestyle with flake8. The reason is that pycodestyle refuse (by design/on purpose) to deactivate some of its rules via `# noqa` comments. I also added a new test to check for a minimal version of pylint and ruff. I often ran into "complex" problems using out dated linters on some of my machines. The solution is not elegant but pragmatic. It will warn me if I run the test on one of my machines having out-dated linters.