### PR TITLE
build: PyFakeFS minimal version 5.7

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Back In Time
 
-Version 1.5.3-rc1 - Release Candidate (2024-10-20)
+Version 1.5.3-rc2 - Release Candidate (2024-11-??)
 * Doc: User manual (build with MkDocs) (#1838) (Kosta Vukicevic @stcksmsh)
 * Doc: User-callback topic in user manual (#1659)
 * Feature: Support language Interlingua (Occidental)
@@ -21,6 +21,7 @@ Version 1.5.3-rc1 - Release Candidate (2024-10-20)
 * Refactor!: Remove unused config field "user_callback.no_logging" (#1887)
 * Refactor!: Remove eCryptFS check for home folder (#1855)
 * Dependency: Remove libnotify-bin (notify-send) (#1156)
+* Dependency: PyFakeFS minimal version 5.6 (#1911)
 * Build: Replace "pycodestyle" linter with "flake8" (#1839)
 
 Version 1.5.2 (2024-08-06)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ the packages provided by the official repository of your GNU/Linux distribution.
   - `build-essential`
   - `gzip`
   - `gettext`
-  - `python3-pyfakefs`
+  - `python3-pyfakefs` (>= 5.6)
   - Optional but recommended:
     - `pylint` (>= 3.3.0)
     - `flake8`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ the packages provided by the official repository of your GNU/Linux distribution.
   - `build-essential`
   - `gzip`
   - `gettext`
-  - `python3-pyfakefs` (>= 5.6)
+  - `python3-pyfakefs` (>= 5.7)
   - Optional but recommended:
     - `pylint` (>= 3.3.0)
     - `flake8`

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In time" which is released under GNU
-# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Tests using several linters.
 
@@ -47,6 +47,7 @@ full_test_files = [_base_dir / fp for fp in (
     'ssh_max_arg.py',
     'version.py',
     'test/test_lint.py',
+    'test/test_uniquenessset.py',
 )]
 
 # Not all linters do respect PEP8 (e.g. ruff, PyLint)

--- a/common/test/test_uniquenessset.py
+++ b/common/test/test_uniquenessset.py
@@ -4,29 +4,25 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
-# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Tests about the uniquenessset module."""
+# pylint: disable=wrong-import-position,C0411,import-outside-toplevel
 import os
 import sys
 import unittest
 import packaging.version
+import pyfakefs.fake_filesystem_unittest as pyfakefs_ut
 from pathlib import Path
 from tempfile import TemporaryDirectory
-import pyfakefs.fake_filesystem_unittest as pyfakefs_ut
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from uniquenessset import UniquenessSet
-import logger
+import logger  # noqa: E402,RUF100
+from uniquenessset import UniquenessSet  # noqa: E402,RUF100
 logger.DEBUG = True
 
 
 class General(pyfakefs_ut.TestCase):
     """Behavior of class UniquenessSet.
-
-    Dev note (buhtz, 2024-10):
-    Beginning with Python 3.12 or newer the minimal required PyFakeFS version
-    is 5.6. Otherwise tests using a TemporaryDirectory in a fake file system
-    will fail because of an assert in shutil.rmtree().
     """
 
     def setUp(self):

--- a/common/test/test_uniquenessset.py
+++ b/common/test/test_uniquenessset.py
@@ -51,7 +51,6 @@ class General(pyfakefs_ut.TestCase):
 
         return result
 
-    # relevant only in Python 3.12 or newer
     @unittest.skipIf(sys.version_info[:2] < (3, 12),
                      'Relevant only with Python 3.12 or newer (#1911)')
     def test_001_depency_workaround(self):

--- a/common/test/test_uniquenessset.py
+++ b/common/test/test_uniquenessset.py
@@ -9,6 +9,8 @@
 """Tests about the uniquenessset module."""
 import os
 import sys
+import unittest
+import packaging.version
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import pyfakefs.fake_filesystem_unittest as pyfakefs_ut
@@ -19,7 +21,13 @@ logger.DEBUG = True
 
 
 class General(pyfakefs_ut.TestCase):
-    # TODO: add test for follow_symlink
+    """Behavior of class UniquenessSet.
+
+    Dev note (buhtz, 2024-10):
+    Beginning with Python 3.12 or newer the minimal required PyFakeFS version
+    is 5.6. Otherwise tests using a TemporaryDirectory in a fake file system
+    will fail because of an assert in shutil.rmtree().
+    """
     def setUp(self):
         """Setup a fake filesystem."""
         self.setUpPyfakefs(allow_root_user=False)
@@ -41,6 +49,17 @@ class General(pyfakefs_ut.TestCase):
             result.extend((one, two))
 
         return result
+
+    # relevant only in Python 3.12 or newer
+    @unittest.skipIf(sys.version_info[:2] < (3, 12),
+                     'Relevant only with Python 3.12 or newer (#1911)')
+    def test_001_depency_workaround(self):
+        """Workaround until #1575 is fixed."""
+        import pyfakefs
+        pyfakefs_version = packaging.version.parse(pyfakefs.__version__)
+        min_required_version = packaging.version.parse('5.6.0')
+
+        self.assertTrue(pyfakefs_version >= min_required_version)
 
     def test_ctor_defaults(self):
         """Default values in constructor."""
@@ -181,45 +200,3 @@ class General(pyfakefs_ut.TestCase):
 
             self.assertTrue(sut.check(fpa))
             self.assertTrue(sut.check(fpb))
-
-    # def test_something_with_hardlinks(self):
-    #     """Despite its method name, it does not really test for hardlinks.
-    #     That dest origins from the original code base. I see not much value
-    #     in it. The hardlink behavior in the productive code seems untestable
-    #     to me. the ``checkUnique()`` method internally shortens its path if
-    #     there are hardlinks, otherwise it use md5sum.
-    #     """
-    #     with TemporaryDirectory(prefix='bit.') as temp_name:
-    #         temp_path = Path(temp_name)
-
-    #         fpa = temp_path / 'foo'
-    #         fpb = temp_path / 'bar'
-
-    #         fpa_hardlink = temp_path / 'hl_foo'
-    #         fpb_hardlink = temp_path / 'hl_bar'
-
-    #         fpa.write_text('red')
-    #         fpb.write_text('blue')
-    #         fpa_hardlink.write_text('red')
-    #         fpb_hardlink.write_text('blue')
-
-    #         # fpa_hardlink.hardlink_to(fpa)
-    #         # fpb_hardlink.hardlink_to(fpb)
-
-    #         # os.utime(fpa_hardlink,
-    #         #          times=(fpa.stat().st_atime, fpa.stat().st_mtime))
-    #         # os.utime(fpb_hardlink,
-    #         #          times=(fpb.stat().st_atime, fpb.stat().st_mtime))
-
-    #         # # Be sure that this are hardlinks. (But it does not matter)
-    #         # self.assertEqual(fpa.stat().st_ino, fpa_hardlink.stat().st_ino)
-    #         # self.assertEqual(fpb.stat().st_ino, fpb_hardlink.stat().st_ino)
-
-    #         sut = UniquenessSet(deep_check=True,
-    #                             follow_symlink=False,
-    #                             equal_to='')
-
-    #         self.assertTrue(sut.check(fpa))
-    #         self.assertFalse(sut.check(fpa_hardlink))
-    #         self.assertTrue(sut.check(fpb))
-    #         self.assertFalse(sut.check(fpb_hardlink))

--- a/common/test/test_uniquenessset.py
+++ b/common/test/test_uniquenessset.py
@@ -28,6 +28,7 @@ class General(pyfakefs_ut.TestCase):
     is 5.6. Otherwise tests using a TemporaryDirectory in a fake file system
     will fail because of an assert in shutil.rmtree().
     """
+
     def setUp(self):
         """Setup a fake filesystem."""
         self.setUpPyfakefs(allow_root_user=False)

--- a/common/test/test_uniquenessset.py
+++ b/common/test/test_uniquenessset.py
@@ -54,10 +54,17 @@ class General(pyfakefs_ut.TestCase):
     @unittest.skipIf(sys.version_info[:2] < (3, 12),
                      'Relevant only with Python 3.12 or newer (#1911)')
     def test_001_depency_workaround(self):
-        """Workaround until #1575 is fixed."""
+        """Workaround until #1575 is fixed.
+
+        Python 3.13 needs PyFakeFS at min version 5.7
+        Python 3.12 needs PyFakeFS at min version 5.6
+
+        See: <https://github.com/bit-team/backintime/
+             pull/1916#issuecomment-2438703637>
+        """
         import pyfakefs
         pyfakefs_version = packaging.version.parse(pyfakefs.__version__)
-        min_required_version = packaging.version.parse('5.6.0')
+        min_required_version = packaging.version.parse('5.7.0')
 
         self.assertTrue(pyfakefs_version >= min_required_version)
 


### PR DESCRIPTION
Minimal PyFakeFS version should be 5.6.

Until #1575 is implemented, as a workaround, a unit test does check this dependency if Python 3.12 or newer is used.

Thank you to Fedora maintainer @hannes101 bringing this up. Also to PyFakeFS maintainer @mrbean-bremen, "mock" maintainer @xsuchy and the python mailing list folks supporting the diagnostics.

Related to #1911