### PR TITLE
build: install LICENSES folder

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -17,8 +17,15 @@ path = [
     "VERSION",
     "CHANGES",
     "TRANSLATIONS",
+]
+SPDX-License-Identifier = "CC0-1.0"
+SPDX-FileCopyrightText = "© 2008 Back In Time Team"
+
+
+[[annotations]]
+path = [
     "common/man/C/*",
     "qt/man/C/*",
 ]
-SPDX-License-Identifier = "CC0-1.0"
+SPDX-License-Identifier = "GPL-2.0-or-later"
 SPDX-FileCopyrightText = "© 2008 Back In Time Team"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2024 Back In Time Team
+#
+# SPDX-License-Identifier: CC0-1.0
+#
+# This file is released under Creative Commons Zero 1.0 (CC0-1.0) and part of
+# the program "Back In Time". The program as a whole is released under GNU
+# General Public License v2 or any later version (GPL-2.0-or-later).
+# See LICENSES directory or go to <https://spdx.org/licenses/CC0-1.0.html>
+# and <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+
+# See https://reuse.software/faq/#bulk-license
+version = 1
+
+[[annotations]]
+path = [
+    "AUTHORS",
+    "VERSION",
+    "CHANGES",
+    "TRANSLATIONS",
+    "common/man/C/*",
+    "qt/man/C/*",
+]
+SPDX-License-Identifier = "CC0-1.0"
+SPDX-FileCopyrightText = "© 2008 Back In Time Team"

--- a/common/backintime
+++ b/common/backintime
@@ -1,21 +1,17 @@
 #!/bin/sh
-
-#    Back In Time
-#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2017 Matthias Gerstner
+# SPDX-FileCopyrightText: © 2024 Jürgen Altfeld
+# SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
 #
-#    This program is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation; either version 2 of the License, or
-#    (at your option) any later version.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License along
-#    with this program; if not, write to the Free Software Foundation, Inc.,
-#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 
 # Location of this script
 CUR_PATH="$(dirname $(readlink -m $0))"

--- a/common/backintime-askpass
+++ b/common/backintime-askpass
@@ -1,24 +1,19 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2017 Matthias Gerstner
+# SPDX-FileCopyrightText: © 2024 Jürgen Altfeld
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 
-#    Back In Time
-#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze
-#
-#    This program is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation; either version 2 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License along
-#    with this program; if not, write to the Free Software Foundation, Inc.,
-#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-#fixing gray window error
-#https://launchpad.net/bugs/1493020
+# fixing gray window error
+# https://launchpad.net/bugs/1493020
 export QT_GRAPHICSSYSTEM="native"
 
 CUR_PATH="$(dirname $(readlink -m $0))"

--- a/common/configure
+++ b/common/configure
@@ -7,14 +7,11 @@
 # SPDX-FileCopyrightText: © 2023 Fabio Fantoni
 # SPDX-FileCopyrightText: © 2024 Tejas Guruswamy
 #
-# SPDX-License-Identifier: CC0-1.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This file is released under Creative Commons Zero 1.0 (CC0-1.0) and part of
-# the program "Back In Time". The program as a whole is released under GNU
-# General Public License v2 or any later version (GPL-2.0-or-later).
-# See LICENSES directory or
-# go to <https://spdx.org/licenses/CC0-1.0.html>
-# and <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 #
 # This is the configuration file for the Read the Docs service.
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
@@ -213,11 +210,13 @@ addNewline
 addComment "documentation"
 addInstallDir                        "/share/doc/backintime-common"
 addInstallFile "../AUTHORS"          "/share/doc/backintime-common"
-addInstallFile "../LICENSE"          "/share/doc/backintime-common"
 addInstallFile "../README.md"        "/share/doc/backintime-common"
 addInstallFile "../FAQ.md"           "/share/doc/backintime-common"
 addInstallFile "../TRANSLATIONS"     "/share/doc/backintime-common"
 addInstallFile "../CHANGES"          "/share/doc/backintime-common"
+addInstallFile "../LICENSE"          "/share/doc/backintime-common"
+addInstallDir                        "/share/doc/backintime-common/LICENSES"
+addInstallFiles "../LICENSES/*"      "/share/doc/backintime-common/LICENSES"
 addNewline
 
 addComment "config and user-callback examples"

--- a/common/man/C/backintime-askpass.1
+++ b/common/man/C/backintime-askpass.1
@@ -1,4 +1,4 @@
-.TH backintime-askpass 1 "November 2024" "version 1.6.0-dev.66189870" "USER COMMANDS"
+.TH backintime-askpass 1 "November 2024" "version 1.6.0-dev.a5c44451" "USER COMMANDS"
 .SH NAME
 backintime-askpass \- a simple backup tool for Linux.
 .PP

--- a/common/man/C/backintime-config.1
+++ b/common/man/C/backintime-config.1
@@ -1,4 +1,4 @@
-.TH backintime-config 1 "November 2024" "version 1.6.0-dev.66189870" "USER COMMANDS"
+.TH backintime-config 1 "November 2024" "version 1.6.0-dev.a5c44451" "USER COMMANDS"
 .SH NAME
 config \- BackInTime configuration files.
 .SH SYNOPSIS

--- a/common/man/C/backintime.1
+++ b/common/man/C/backintime.1
@@ -1,4 +1,4 @@
-.TH backintime 1 "November 2024" "version 1.6.0-dev.66189870" "USER COMMANDS"
+.TH backintime 1 "November 2024" "version 1.6.0-dev.a5c44451" "USER COMMANDS"
 .SH NAME
 backintime \- a simple backup tool for Linux.
 .PP

--- a/common/version.py
+++ b/common/version.py
@@ -13,7 +13,7 @@ See Issue #1575 for details about that migration.
 import re
 
 # Version string regularyly used by the application and presented to users.
-__version__ = '1.6.0-dev.66189870'
+__version__ = '1.6.0-dev.a5c44451'
 
 
 def is_release_candidate() -> bool:

--- a/qt/backintime-qt
+++ b/qt/backintime-qt
@@ -1,24 +1,19 @@
 #!/bin/sh
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2017 Matthias Gerstner
+# SPDX-FileCopyrightText: © 2024 Jürgen Altfeld
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 
-#    Back In Time
-#    Copyright (C) 2008-2022 Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze
-#
-#    This program is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation; either version 2 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License along
-#    with this program; if not, write to the Free Software Foundation, Inc.,
-#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
-#fixing gray window error
-#https://launchpad.net/bugs/1493020
+# fixing gray window error
+# https://launchpad.net/bugs/1493020
 export QT_GRAPHICSSYSTEM="native"
 
 CUR_PATH="$(dirname $(readlink -m $0))"

--- a/qt/configure
+++ b/qt/configure
@@ -7,14 +7,11 @@
 # SPDX-FileCopyrightText: © 2023 Fabio Fantoni
 # SPDX-FileCopyrightText: © 2024 Tejas Guruswamy
 #
-# SPDX-License-Identifier: CC0-1.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This file is released under Creative Commons Zero 1.0 (CC0-1.0) and part of
-# the program "Back In Time". The program as a whole is released under GNU
-# General Public License v2 or any later version (GPL-2.0-or-later).
-# See LICENSES directory or
-# go to <https://spdx.org/licenses/CC0-1.0.html>
-# and <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 #
 # This is the configuration file for the Read the Docs service.
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
@@ -223,11 +220,13 @@ addNewline
 addComment "documentation"
 addInstallDir                        "/share/doc/backintime-qt"
 addInstallFile "../AUTHORS"          "/share/doc/backintime-qt"
-addInstallFile "../LICENSE"          "/share/doc/backintime-qt"
 addInstallFile "../README.md"        "/share/doc/backintime-qt"
 addInstallFile "../FAQ.md"        "/share/doc/backintime-qt"
 addInstallFile "../TRANSLATIONS"     "/share/doc/backintime-qt"
 addInstallFile "../CHANGES"          "/share/doc/backintime-qt"
+addInstallFile "../LICENSE"          "/share/doc/backintime-qt"
+addInstallDir                        "/share/doc/backintime-qt/LICENSES"
+addInstallFiles "../LICENSES/*"      "/share/doc/backintime-qt/LICENSES"
 addNewline
 
 addComment ".desktop"

--- a/qt/io.github.bit_team.back_in_time.gui.metainfo.xml
+++ b/qt/io.github.bit_team.back_in_time.gui.metainfo.xml
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
+
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Docu:

--- a/qt/man/C/backintime-qt.1
+++ b/qt/man/C/backintime-qt.1
@@ -1,4 +1,4 @@
-.TH backintime-qt 1 "November 2024" "version 1.6.0-dev.66189870" "USER COMMANDS"
+.TH backintime-qt 1 "November 2024" "version 1.6.0-dev.a5c44451" "USER COMMANDS"
 .SH NAME
 backintime-qt \- a simple backup tool.
 .SH SYNOPSIS

--- a/qt/net.launchpad.backintime.policy
+++ b/qt/net.launchpad.backintime.policy
@@ -1,3 +1,12 @@
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
+
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"

--- a/qt/net.launchpad.backintime.serviceHelper.conf
+++ b/qt/net.launchpad.backintime.serviceHelper.conf
@@ -1,3 +1,13 @@
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
+SPDX-FileCopyrightText: © 2017 Matthias Gerstner
+
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">

--- a/qt/net.launchpad.backintime.serviceHelper.service
+++ b/qt/net.launchpad.backintime.serviceHelper.service
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: © 2016 Germar Reitze
+# SPDX-FileCopyrightText: © 2017 Matthias Gerstner
+# 
+# SPDX-License-Identifier: GPL-2.0-or-later
+# 
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>
 [D-BUS Service]
 Name=net.launchpad.backintime.serviceHelper
 Exec=/usr/bin/python3 -Es /usr/share/backintime/qt/serviceHelper.py


### PR DESCRIPTION
The folder LICENSES now is installed via the make system.

That folder is quit new and appeared while adding SPDX conform meta data (machine readable license and copyright information).