### PR TITLE
fix: Copy symlink as symlink in snapshot compare

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Fix: Copy symlink as symlink in snapshot compare (#1902) (Peter Sevens @sevens)
+       Additionally fixes a crash when comparing a snapshot with a symlink pointing to a nonexistent target.
 * ...
 
 Version 1.5.3 (2024-11-13)

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,8 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
-* Fix: Copy symlink as symlink in snapshot compare (#1902) (Peter Sevens @sevens)
-       Additionally fixes a crash when comparing a snapshot with a symlink pointing to a nonexistent target.
+* Fix: Snapshot compare copy symlink as symlink (#1902) (Peter Sevens @sevens)
+* Fix: Crash when comparing a snapshot with a symlink pointing to a nonexistent target (Peter Sevens @sevens)
 * Fix: Crash (KeyError) opening language setup dialog with unknown locale/language
 
 Version 1.5.3 (2024-11-13)

--- a/qt/app.py
+++ b/qt/app.py
@@ -1722,7 +1722,7 @@ class MainWindow(QMainWindow):
         tmp_file = os.path.join(d.name, os.path.basename(full_path))
 
         if os.path.isdir(full_path):
-            shutil.copytree(full_path, tmp_file)
+            shutil.copytree(full_path, tmp_file, symlinks=True)
         else:
             shutil.copy(full_path, d.name)
 


### PR DESCRIPTION
When comparing snapshots, copy symlinks in the snapshots as symlinks, not as
their target.  The old behavior made the comparison not fully compare the actual
snapshot data and, even worse, could fill up your entire disk (when having
circular symlinks, e.g. a symlink to `/`, which copies `/` and eventually
copies the original symlink which points to `/` which ...).

Additionally fixes a crash when the compared snapshot(s) contain a symlink
pointing to a nonexistent target.

Fixes #1902.