### PR TITLE
chore: Fix nonexistent git long option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ the maintenance team upon request.
 
 3. Create and checkout your own feature or bugfix branch with `dev` as baseline branch:
 
-       $ git checkout --branch myfancyfeature dev
+       $ git checkout -b myfancyfeature dev
 
 4. Now you can add your modifications.
 


### PR DESCRIPTION
`git commit` has no `--branch` long option (unfortunately), use `-b` instead.

Checked on:
  * Git versions 2.44.0, 2.46.0 and 2.47.0
  * Quick search on: 'git checkout "--branch"', yielded no result
  * I have a strong preference for long options in code and documentation and my custom `tig` bindings also use `git checkout -b` throughout (it's quite likely I would've used `git checkout --branch` if one existed when I created them over the last many years)
