### PR TITLE
feat: Prefix temp snapshot copies with `backintime_`

### DIFF
--- a/common/doc-dev/modules.rst
+++ b/common/doc-dev/modules.rst
@@ -25,6 +25,6 @@ common
    schedule
    snapshotlog
    snapshots
-   sshMaxArg
+   ssh_max_arg
    sshtools
    tools

--- a/common/doc-dev/sshMaxArg.rst
+++ b/common/doc-dev/sshMaxArg.rst
@@ -1,7 +1,0 @@
-sshMaxArg module
-================
-
-.. automodule:: sshMaxArg
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/common/doc-dev/ssh_max_arg.rst
+++ b/common/doc-dev/ssh_max_arg.rst
@@ -1,0 +1,7 @@
+ssh_max_arg module
+==================
+
+.. automodule:: ssh_max_arg
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1718,7 +1718,7 @@ class MainWindow(QMainWindow):
         if sid:
             sid = '_' + sid.sid
 
-        d = TemporaryDirectory(suffix = sid)
+        d = TemporaryDirectory(prefix='backintime_', suffix = sid)
         tmp_file = os.path.join(d.name, os.path.basename(full_path))
 
         if os.path.isdir(full_path):

--- a/qt/app.py
+++ b/qt/app.py
@@ -1703,17 +1703,18 @@ class MainWindow(QMainWindow):
 
         self.openPath(rel_path)
 
-    def tmpCopy(self, full_path, sid = None):
-        """
-        Create a temporary local copy of the file ``full_path`` and add the
-        temp folder to ``self.tmpDirs`` which will remove them on exit.
+    def tmpCopy(self, full_path, sid=None):
+        """Create a temporary local copy a file or directory.
+
+        The name of is of the pattern ``backintime_[tmp_str]_[snapshotID]``.
+        Clean up is done when closing BIT based on ``self.tmpDirs``.
 
         Args:
-            full_path (str):        path to original file
-            sid (snapshots.SID):    snapshot ID used as temp folder suffix
+            full_path (str): Path to original file or directory.
+            sid (snapshots.SID): Snapshot identifier.
 
         Returns:
-            str:                    temporary path to file
+            str: Path to the temporary file or directory.
         """
         if sid:
             sid = '_' + sid.sid


### PR DESCRIPTION
I checked if it was easily possible to add a more specific prefix (e.g. `backintime-snapshot_compare_` for when comparing snapshots) but the function gets used in 3 places (2 through calls to `app.MainWindow.openPath()`), all quite different use cases.  Couldn't find a nice way to pass more specific info to `tmpCopy()` from them (don't know the code well enough to decide on a clean and good way to do this from all places, if it's even desirable at all).

Don't think this warrants a `CHANGES` entry?!  Only case I can think of is if there are people who have e.g. some `/tmp` (and `/var/tmp`) cleanup scripts that assume the current format, but AFAICT it's nigh impossible to reliably determine if an old-format created dir is from BiT or not so that seems unlikely to exist to me.

Tested:
  * Compare 2 snapshots, it created temp dirs like `/tmp/backintime_yvvem486_20241119-165907-278` (last 3 parts being snapshot id)
  * `btnOpenCurrentItemClicked()`:
    * Navigate to file in snapshot that doesn't exist anymore on the local storage/source
    * Click `Alt+Down` (seems to be the only way to trigger this function)
    * Created temp dir: `/tmp/backintime_esh5heni_20241121-112648-601/`
  * `filesViewItemActivated()`:
    * Navigate to file in snapshot that doesn't exist anymore on the local storage/source
    * Double-click on said file
    * Created temp dir: `/tmp/backintime_ge543330_20241121-112648-601/`

There don't seem to be any relevant unittests (same as for #1937).

See also: https://github.com/bit-team/backintime/issues/1902#issuecomment-2491088686 and https://github.com/bit-team/backintime/issues/1902#issuecomment-2491177924