### PR TITLE
fix: Missing crontab not an error anymore

### DIFF
--- a/common/schedule.py
+++ b/common/schedule.py
@@ -61,19 +61,21 @@ def read_crontab():
 
     Returns:
         list: Crontab lines.
-
-    Dev notes (buhtz, 2024-05): Might should raise exception on errors.
     """
-    try:
-        proc = subprocess.run(
-            [CRONTAB_COMMAND, '-l'],
-            check=True,
-            capture_output=True,
-            text=True)
+    proc = subprocess.run(
+        [CRONTAB_COMMAND, '-l'],
+        check=False,
+        capture_output=True,
+        text=True)
 
-    except subprocess.CalledProcessError as err:
-        logger.error(f'Failed to get content via "{CRONTAB_COMMAND}". '
-                     f'Return code of {err.cmd} was {err.returncode}.')
+    # Error?
+    if proc.returncode != 0:
+        # Ignore missing crontabs
+        if not proc.stderr.startswith('no crontab for'):
+            logger.error(f'Failed to get content via "{CRONTAB_COMMAND}". '
+                         f'Return code of {proc.args} was {proc.returncode}. '
+                         f'Stderr: {proc.stderr}')
+
         return []
 
     content = proc.stdout.split('\n')

--- a/common/tools.py
+++ b/common/tools.py
@@ -279,7 +279,7 @@ def set_lc_time_by_language_code(language_code: str):
         locale.setlocale(locale.LC_TIME, code)
 
     except locale.Error:
-        logger.warning(
+        logger.debug(
             f'Determined normalized locale code "{code}" (from language code '
             f'"{language_code}") not available (or invalid). The code will be '
             'ignored. This might lead to unusual display of dates and '


### PR DESCRIPTION
Missing crontab files are not logged as errors anymore. It is a usual situation on fresh systems.

Related #1952