### PR TITLE
Fix keyring debug output

### DIFF
--- a/common/tools.py
+++ b/common/tools.py
@@ -1491,7 +1491,7 @@ def keyringSupported():
 
     try:
         for b in backend.get_all_keyring():
-            logger.debug(b)
+            logger.debug(str(b))
     except Exception as e:
         logger.debug("Available backends cannot be listed: " + repr(e))
 


### PR DESCRIPTION
This fixes the following error message in the logs:

```
DEBUG: [common/tools.py:1487 keyringSupported] Available backends cannot be listed: TypeError('can only concatenate str (not "DBusKeyring") to str')
```