### PR TITLE
Ensure XML declaration is first line in file

### DIFF
--- a/qt/io.github.bit_team.back_in_time.gui.metainfo.xml
+++ b/qt/io.github.bit_team.back_in_time.gui.metainfo.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
 
@@ -7,7 +8,6 @@ This file is part of the program "Back In Time" which is released under GNU
 General Public License v2 (GPLv2). See LICENSES directory or go to
 <https://spdx.org/licenses/GPL-2.0-or-later.html>
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Docu:
         https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

--- a/qt/net.launchpad.backintime.policy
+++ b/qt/net.launchpad.backintime.policy
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 SPDX-FileCopyrightText: © 2016 Germar Reitze
 
@@ -7,7 +8,6 @@ This file is part of the program "Back In Time" which is released under GNU
 General Public License v2 (GPLv2). See LICENSES directory or go to
 <https://spdx.org/licenses/GPL-2.0-or-later.html>
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">

--- a/qt/net.launchpad.backintime.serviceHelper.conf
+++ b/qt/net.launchpad.backintime.serviceHelper.conf
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 SPDX-FileCopyrightText: © 2016 Germar Reitze
 SPDX-FileCopyrightText: © 2017 Matthias Gerstner
@@ -8,7 +9,6 @@ This file is part of the program "Back In Time" which is released under GNU
 General Public License v2 (GPLv2). See LICENSES directory or go to
 <https://spdx.org/licenses/GPL-2.0-or-later.html>
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 


### PR DESCRIPTION
If the XML declaration is not the first line, then DBus raises the following error:

    dbus.exceptions.DBusException: org.freedesktop.DBus.Error.AccessDenied