### PR TITLE
doc(FAQ): Entry about why we are not moving away from Microsoft GitHub yet

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1269,7 +1269,7 @@ We also believe that staying with Microsoft GitHub is not a good idea. Microsoft
 GitHub does not offer any exclusive feature for our project that another hoster
 could not also provide. But a migration is a matter of time and resources we
 currently do not have. But it is on our list. And with the current state of
-discussion we seem to target [Cdeberg.org](https://codeberg.org].
+discussion we seem to target [Codeberg.org](https://codeberg.org).
 
 For more details please see
 [this thread on the mailing list](https://mail.python.org/archives/list/bit-dev@python.org/message/O5XZ5SPW6WIFBFKWUBHSOUIBKEUIBPNM/).

--- a/FAQ.md
+++ b/FAQ.md
@@ -55,9 +55,10 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
    * [How to use Synology DSM 6 with BIT over SSH](#how-to-use-synology-dsm-6-with-bit-over-ssh)
    * [How to use Synology DSM 7 with BIT over SSH](#how-to-use-synology-dsm-7-with-bit-over-ssh)
    * [How to use Western Digital MyBook World Edition with BIT over ssh?](#how-to-use-western-digital-mybook-world-edition-with-bit-over-ssh)
-- [Uncategorized questions](#uncategorized-questions)
-   * [Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? I saw that it saves the names for uids and gids, so I assume it can restore correctly even if the ids change. Great! :-) Are there additional benefits?](#which-additional-features-on-top-of-a-gui-does-bit-provide-over-a-self-configured-rsync-backup-i-saw-that-it-saves-the-names-for-uids-and-gids-so-i-assume-it-can-restore-correctly-even-if-the-ids-change-great---are-there-additional-benefits)
+- [Project & more](#project--more)
+   * [Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? Are there additional benefits?](#which-additional-features-on-top-of-a-gui-does-bit-provide-over-a-self-configured-rsync-backup-are-there-additional-benefits)
    * [Support for specific package formats (deb, rpm, Flatpack, AppImage, Snaps, PPA, …)](#support-for-specific-package-formats-deb-rpm-flatpack-appimage-snaps-ppa-)
+   * [Move project to alternative code hoster (e.g. Codeberg, GitLab, …)](#move-project-to-alternative-code-hoster-e-g-codeberg-gitlab-)
 - [Testing & Building](#testing--building)
    * [SSH related tests are skipped](#ssh-related-tests-are-skipped)
    * [Setup SSH Server to run unit tests](#setup-ssh-server-to-run-unit-tests)
@@ -1227,9 +1228,9 @@ documentation about Optware on http://mybookworld.wikidot.com/optware.
    ```
 
 
-# Uncategorized questions
+# Project & more
 
-## Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? I saw that it saves the names for uids and gids, so I assume it can restore correctly even if the ids change. Great! :-) Are there additional benefits?
+## Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? Are there additional benefits?
 
 Actually it's the other way around ;) *Back In Time* stores the user and group name
 which will make it possible to restore permissions correctly even if UID/GID
@@ -1261,6 +1262,17 @@ with much more experience and skills in packaging. We always recommend using
 the official repositories of GNU/Linux distributions and contacting their
 maintainers if _Back In Time_ is unavailable or out dated.
 
+
+## Move project to alternative code hoster (e.g. Codeberg, GitLab, …)
+
+We also believe that stying with Microsoft GitHub is not a good idea. Microsoft
+GitHub does not offer any exclusive feature for our project that another hoster
+could not also provide. But a migration is a matter of time and ressources we
+currently do not have. But it is on our list. And with the current state of
+discussion we seem to target [Cdeberg.org](https://codeberg.org].
+
+For more details please see
+[this thread on the mailing list](https://mail.python.org/archives/list/bit-dev@python.org/message/O5XZ5SPW6WIFBFKWUBHSOUIBKEUIBPNM/).
 
 # Testing & Building
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -58,7 +58,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - [Project & more](#project--more)
    * [Which additional features on top of a GUI does BIT provide over a self-configured rsync backup? Are there additional benefits?](#which-additional-features-on-top-of-a-gui-does-bit-provide-over-a-self-configured-rsync-backup-are-there-additional-benefits)
    * [Support for specific package formats (deb, rpm, Flatpack, AppImage, Snaps, PPA, …)](#support-for-specific-package-formats-deb-rpm-flatpack-appimage-snaps-ppa-)
-   * [Move project to alternative code hoster (e.g. Codeberg, GitLab, …)](#move-project-to-alternative-code-hoster-e-g-codeberg-gitlab-)
+   * [Move project to alternative code hoster (e.g. Codeberg, GitLab, …)](#move-project-to-alternative-code-hoster-eg-codeberg-gitlab-)
 - [Testing & Building](#testing--building)
    * [SSH related tests are skipped](#ssh-related-tests-are-skipped)
    * [Setup SSH Server to run unit tests](#setup-ssh-server-to-run-unit-tests)
@@ -1265,14 +1265,15 @@ maintainers if _Back In Time_ is unavailable or out dated.
 
 ## Move project to alternative code hoster (e.g. Codeberg, GitLab, …)
 
-We also believe that stying with Microsoft GitHub is not a good idea. Microsoft
+We also believe that staying with Microsoft GitHub is not a good idea. Microsoft
 GitHub does not offer any exclusive feature for our project that another hoster
-could not also provide. But a migration is a matter of time and ressources we
+could not also provide. But a migration is a matter of time and resources we
 currently do not have. But it is on our list. And with the current state of
 discussion we seem to target [Cdeberg.org](https://codeberg.org].
 
 For more details please see
 [this thread on the mailing list](https://mail.python.org/archives/list/bit-dev@python.org/message/O5XZ5SPW6WIFBFKWUBHSOUIBKEUIBPNM/).
+
 
 # Testing & Building
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ features. This work is carried out voluntarily during their limited spare time.
 
  * [FAQ - Frequently Asked Questions](FAQ.md)
  * [End user documentation](https://backintime.readthedocs.org/) (not totally up-to-date)
- * [Mailing list
+ * ✉ [Mailing list
    _bit-dev_](https://mail.python.org/mailman3/lists/bit-dev.python.org/) for
    **every topic**, question and idea about _Back In Time_. Despite its name
    it is not restricted to development topics only.
+ * [@backintime@fosstodon.org](https://fosstodon.org/@backintime) in the Fediverse.
  * Use [Issues](https://github.com/bit-team/backintime/issues) to ask
    questions and report bugs.
  * [Source code documentation for developers](https://backintime-dev.readthedocs.org)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ features. This work is carried out voluntarily during their limited spare time.
    _bit-dev_](https://mail.python.org/mailman3/lists/bit-dev.python.org/) for
    **every topic**, question and idea about _Back In Time_. Despite its name
    it is not restricted to development topics only.
- * <a rel="me" href="https://fosstodon.org/@backintime">@backintime@fosstodon.org</a> in the Fediverse on Mastodon.
+ * <a rel="me" href="https://fosstodon.org/@backintime">Fediverse on Mastodon</a>
  * Use [Issues](https://github.com/bit-team/backintime/issues) to ask
    questions and report bugs.
  * [Source code documentation for developers](https://backintime-dev.readthedocs.org)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ features. This work is carried out voluntarily during their limited spare time.
    _bit-dev_](https://mail.python.org/mailman3/lists/bit-dev.python.org/) for
    **every topic**, question and idea about _Back In Time_. Despite its name
    it is not restricted to development topics only.
- * <a rel="me" href="https://fosstodon.org/@backintime">Fediverse on Mastodon</a>
+ * In the Fediverse on Mastodon: [@backintime@fosstodon.org](https://fosstodon.org/@backintime)
  * Use [Issues](https://github.com/bit-team/backintime/issues) to ask
    questions and report bugs.
  * [Source code documentation for developers](https://backintime-dev.readthedocs.org)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ features. This work is carried out voluntarily during their limited spare time.
    _bit-dev_](https://mail.python.org/mailman3/lists/bit-dev.python.org/) for
    **every topic**, question and idea about _Back In Time_. Despite its name
    it is not restricted to development topics only.
- * [@backintime@fosstodon.org](https://fosstodon.org/@backintime) in the Fediverse.
+ * <a rel="me" href="https://fosstodon.org/@backintime">@backintime@fosstodon.org</a> in the Fediverse on Mastodon.
  * Use [Issues](https://github.com/bit-team/backintime/issues) to ask
    questions and report bugs.
  * [Source code documentation for developers](https://backintime-dev.readthedocs.org)

--- a/qt/app.py
+++ b/qt/app.py
@@ -2016,11 +2016,17 @@ class MainWindow(QMainWindow):
     def _open_release_candidate_dialog(self):
         html_contact_list = (
             '<ul>'
+            '<li>{mastodon}</li>'
             '<li>{email}</li>'
             '<li>{mailinglist}</li>'
             '<li>{issue}</li>'
             '<li>{alternative}</li>'
             '</ul>').format(
+                mastodon=_('In the Fediverse at Mastodon: {link_and_label}') \
+                    .format(link_and_label='<a href="https://fosstodon.org'
+                                           '/@backintime">'
+                                           '@backintime@fosstodon.org'
+                                           '</a>'),
                 email=_('Email to {link_and_label}.').format(
                     link_and_label='<a href="mailto:backintime@tuta.io">'
                                    'backintime@tuta.io</a>'),


### PR DESCRIPTION
The topic is why we stay on Microsoft GitHub and not moving to something else, e.g. Codeberg.org.
I am often asked about this so I add an according FAQ entry.

Additionally added the Mastodon account to README.md and into the Release Candidate message dialog. Close #1960 