### PR TITLE
fix!: Disabled by default auto-remove rules Free inodes and Free space

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Fix: Crash when comparing a snapshot with a symlink pointing to a nonexistent target (Peter Sevens @sevens)
 * Fix: Crash (KeyError) opening language setup dialog with unknown locale/language
 * Changed: Completed license information to conform the REUSE.software and SPDX standards.
+* Breaking Change: Auto-remove rules "Free inodes" and "Free space" disabled by default (#1976)
 
 Version 1.5.3 (2024-11-13)
 * Doc: User manual (build with MkDocs) (#1838) (Kosta Vukicevic @stcksmsh)

--- a/common/config.py
+++ b/common/config.py
@@ -986,7 +986,7 @@ class Config(configfile.ConfigFileWithProfiles):
                 self.profileIntValue('snapshots.min_free_space.unit', self.DISK_UNIT_GB, profile_id))
 
     def minFreeSpaceEnabled(self, profile_id = None):
-        return self.profileBoolValue('snapshots.min_free_space.enabled', True, profile_id)
+        return self.profileBoolValue('snapshots.min_free_space.enabled', False, profile_id)
 
     def minFreeSpaceMib(self, profile_id = None):
         enabled, value, unit = self.minFreeSpace(profile_id)
@@ -1014,7 +1014,7 @@ class Config(configfile.ConfigFileWithProfiles):
     def minFreeInodesEnabled(self, profile_id = None):
         #?Remove snapshots until \fIprofile<N>.snapshots.min_free_inodes.value\fR
         #?free inodes in % is reached.
-        return self.profileBoolValue('snapshots.min_free_inodes.enabled', True, profile_id)
+        return self.profileBoolValue('snapshots.min_free_inodes.enabled', False, profile_id)
 
     def setMinFreeInodes(self, enabled, value, profile_id = None):
         self.setProfileBoolValue('snapshots.min_free_inodes.enabled', enabled, profile_id)

--- a/common/man/C/backintime-config.1
+++ b/common/man/C/backintime-config.1
@@ -381,7 +381,7 @@ Type: bool      Allowed Values: true|false
 .br
 Remove snapshots until \fIprofile<N>.snapshots.min_free_inodes.value\fR free inodes in % is reached.
 .PP
-Default: true
+Default: false
 .RE
 
 .IP "\fIprofile<N>.snapshots.min_free_inodes.value\fR" 6
@@ -399,7 +399,7 @@ Type: bool      Allowed Values: true|false
 .br
 Remove snapshots until \fIprofile<N>.snapshots.min_free_space.value\fR free space is reached.
 .PP
-Default: true
+Default: false
 .RE
 
 .IP "\fIprofile<N>.snapshots.min_free_space.unit\fR" 6

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -29,6 +29,7 @@ TRAVIS_REASON = ('Running linter tests is mandatory on TravisCI only. On '
 PYLINT_AVAILABLE = shutil.which('pylint') is not None
 RUFF_AVAILABLE = shutil.which('ruff') is not None
 FLAKE8_AVAILABLE = shutil.which('flake8') is not None
+REUSE_AVAILABLE = shutil.which('reuse') is not None
 
 ANY_LINTER_AVAILABLE = any((
     PYLINT_AVAILABLE,
@@ -356,3 +357,28 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
 
         # any other errors?
         self.assertEqual(r.stderr, '')
+
+    @unittest.skipUnless(REUSE_AVAILABLE, BASE_REASON.format('REUSE'))
+    def test060_reuse(self):
+        """The reuse linter check license and copyright information in the
+        repository.
+
+        The info need to be complete and available for all files. The
+        info need to be provided as meta data conforming the SPDX standard.
+        """
+        proc = subprocess.run(
+            ['reuse', 'lint', '--lines'],
+            check=False,
+            universal_newlines=True,
+            capture_output=True
+        )
+
+        error_n = len(proc.stdout.splitlines())
+        if error_n > 0:
+            print(proc.stdout)
+
+        self.assertEqual(
+            0, error_n, f'REUSE linter found {error_n} problem(s).')
+
+        # any other errors?
+        self.assertEqual(proc.stderr, '')


### PR DESCRIPTION
For new created profiles the two Auto-remove two rules about free inodes and free space are disabled by default.

Related to #1976