### PR TITLE
feat: Introduce state file and migrate several config fields

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Changed: Move several fields from config file to new state file at $XDG_STATE_HOME/backintime.json
+* Fix: The width of the fourth column in files view is now saved.
 * Fix: Snapshot compare copy symlink as symlink (#1902) (Peter Sevens @sevens)
 * Fix: Crash when comparing a snapshot with a symlink pointing to a nonexistent target (Peter Sevens @sevens)
 * Fix: Crash (KeyError) opening language setup dialog with unknown locale/language

--- a/CHANGES
+++ b/CHANGES
@@ -1,8 +1,8 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
-* Changed: Introduce state file ($XDG_STATE_HOME/backintime.json) and move several config fields into it
-* Fix: The width of the fourth column in files view is now saved.
+* Changed: Move several values from config file into new introduce state file ($XDG_STATE_HOME/backintime.json)
+* Fix: The width of the fourth column in files view is now saved
 * Fix: Snapshot compare copy symlink as symlink (#1902) (Peter Sevens @sevens)
 * Fix: Crash when comparing a snapshot with a symlink pointing to a nonexistent target (Peter Sevens @sevens)
 * Fix: Crash (KeyError) opening language setup dialog with unknown locale/language

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
-* Changed: Move several fields from config file to new state file at $XDG_STATE_HOME/backintime.json
+* Changed: Introduce state file ($XDG_STATE_HOME/backintime.json) and move several config fields into it
 * Fix: The width of the fourth column in files view is now saved.
 * Fix: Snapshot compare copy symlink as symlink (#1902) (Peter Sevens @sevens)
 * Fix: Crash when comparing a snapshot with a symlink pointing to a nonexistent target (Peter Sevens @sevens)

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -730,6 +730,9 @@ def getConfig(args, check=True):
 def _get_state_data_from_config(cfg: config.Config) -> dict:
     """Get data related to application state from the config instance.
 
+    It migrates state data from the config file to an instantance of
+    `StateData` which later is saved in a separate file.
+
     This function is a temporary workaround. See PR #1850.
 
     Args:

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -788,6 +788,8 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
     # bug. Three columns are tracked but the widget has four columns. The "Typ"
     # column is treated as "Date" and the width of the real "Date" column (4th)
     # was never stored.
+    # The new state file will load and store width values for all existing
+    # columns.
     # qt.main_window.files_view.name_width
     # qt.main_window.files_view.size_width
     # qt.main_window.files_view.date_width
@@ -859,7 +861,7 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
 def load_state_data(args: argparse.Namespace) -> None:
     """Initiate the `State` instance.
 
-    The state file is loaded and its date stored in `State`. The later is a
+    The state file is loaded and its data stored in `State`. The later is a
     singleton and can be used everywhere.
 
     Dev note (buhtz, 2024-12): The args argument is a workaround and will be
@@ -877,17 +879,20 @@ def load_state_data(args: argparse.Namespace) -> None:
         state_data = StateData(json.loads(fp.read_text(encoding='utf-8')))
 
     except FileNotFoundError:
-        logger.debug('State file not found. Using config file.')
+        logger.debug('State file not found. Using config file and migrate it'
+                     'into a state file.')
         fp.parent.mkdir(parents=True, exist_ok=True)
-        # extract data from the config file (for later migration)
+        # extract data from the config file (for migration)
         state_data = _get_state_data_from_config(getConfig(args))
 
     except json.decoder.JSONDecodeError as exc:
         logger.warning(f'Unable to read and decode state file "{fp}". '
                        'Ignnoring it.')
         logger.debug(f'{exc=}')
+        # Empty state data with default values
         state_data = StateData()
 
+    # Register close callback. This will save the state file when the BIT ends.
     atexit.register(state_data.save)
 
 
@@ -917,6 +922,7 @@ class printLicense(argparse.Action):
     """
     Print custom license
     """
+
     def __init__(self, *args, **kwargs):
         super(printLicense, self).__init__(*args, **kwargs)
 

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -755,6 +755,7 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         },
     }
 
+
     # internal.manual_starts_countdown
     data['manual_starts_countdown'] = cfg.manual_starts_countdown()
 
@@ -771,6 +772,8 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     # qt.show_hidden_files
     data['gui']['mainwindow']['show_hidden'] \
         = cfg.boolValue('qt.show_hidden_files', False)
+
+    # ---- XXXX ----
 
     # Coordinates and dimensions
     process_data = (

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -755,9 +755,9 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         },
     }
 
-
     # internal.manual_starts_countdown
-    data['manual_starts_countdown'] = cfg.manual_starts_countdown()
+    data['manual_starts_countdown'] \
+        = cfg.intValue('internal.manual_starts_countdown', 10)
 
     # internal.msg_rc
     val = cfg.strValue('internal.msg_rc', None)
@@ -773,7 +773,6 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     data['gui']['mainwindow']['show_hidden'] \
         = cfg.boolValue('qt.show_hidden_files', False)
 
-    # ---- XXXX ----
 
     # Coordinates and dimensions
     process_data = (
@@ -787,7 +786,9 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
             cfg.intValue(f'{org_prefix}{xyhw[1]}', None),
         )
         if all(val):
-            data['gui'][widgetname]['coord' if 'x' in xyhw else 'dim'] = val
+            data['gui'][widgetname]['coords' if 'x' in xyhw else 'dims'] = val
+
+    # ---- XXXX ----
 
     # files view
     widths = (

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -727,6 +727,20 @@ def getConfig(args, check=True):
     return cfg
 
 
+_STATE_DATA_EMPTY_STRUCT = {
+    'gui': {
+        'mainwindow': {
+            'files_view': {},
+        },
+        'manage_profiles': {},
+        'logview': {},
+    },
+    'message': {
+        'encfs': {}
+    },
+}
+
+
 def _get_state_data_from_config(cfg: config.Config) -> dict:
     """Get data related to application state from the config instance.
 
@@ -742,18 +756,7 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         dict: The state data.
         """
 
-    data = {
-        'gui': {
-            'mainwindow': {
-                'files_view': {},
-            },
-            'manage_profiles': {},
-            'logview': {},
-        },
-        'message': {
-            'encfs': {}
-        },
-    }
+    data = _STATE_DATA_EMPTY_STRUCT
 
     # internal.manual_starts_countdown
     data['manual_starts_countdown'] \
@@ -773,7 +776,6 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     data['gui']['mainwindow']['show_hidden'] \
         = cfg.boolValue('qt.show_hidden_files', False)
 
-
     # Coordinates and dimensions
     process_data = (
         ('qt.main_window.', ('x', 'y'), 'mainwindow'),
@@ -788,19 +790,14 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         if all(val):
             data['gui'][widgetname]['coords' if 'x' in xyhw else 'dims'] = val
 
-    # ---- XXXX ----
-
     # files view
-    widths = (
-        # first column "name"
-        cfg.intValue('qt.main_window.files_view.name_width', None),
-        # second column "size"
-        cfg.intValue('qt.main_window.files_view.size_width', None),
-        # third column "date"
-        cfg.intValue('qt.main_window.files_view.date_width', None)
-    )
-    if all(widths):
-        data['gui']['mainwindow']['files_view']['column_widths'] = widths
+    # Dev note (buhtz, 2024-12): Ignore the column width values because of a
+    # bug. Three columsn are tracked but the widget has four columsn. The "Typ"
+    # column is treated as "Date" and the width of the real "Date" column (4th)
+    # was never stored.
+    # qt.main_window.files_view.name_width
+    # qt.main_window.files_view.size_width
+    # qt.main_window.files_view.date_width
 
     col = cfg.intValue('qt.main_window.files_view.sort.column', 0)
     order = cfg.boolValue('qt.main_window.files_view.sort.ascending', True)
@@ -815,6 +812,8 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         )
         if all(widths):
             data['gui']['mainwindow'][f'splitter_{prefix}_widths'] = widths
+
+    # ---- XXXX ----
 
     # each profile
     for profile_id in cfg.profiles():
@@ -874,6 +873,12 @@ def load_state_data(args: argparse.Namespace) -> None:
         # extract data from the config file (for later migration)
         cfg = getConfig(args)
         data_dict = _get_state_data_from_config(cfg)
+
+    except json.decoder.JSONDecodeError as exc:
+        logger.warning(f'Unable to read and decode state file "{fp}". '
+                       'Ignnoring it.')
+        logger.debug(f'{exc=}')
+        data_dict = _STATE_DATA_EMPTY_STRUCT
 
     st = StateData(data_dict)
 

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -21,7 +21,6 @@ import tools
 # Workaround for situations where startApp() is not invoked.
 # E.g. when using --diagnostics and other argparse.Action
 tools.initiate_translation(None)
-
 import config
 import logger
 import snapshots
@@ -30,6 +29,7 @@ import mount
 import password
 import encfstools
 import cli
+import state
 from diagnostics import collect_diagnostics, collect_minimal_diagnostics
 from exceptions import MountException
 from applicationinstance import ApplicationInstance
@@ -41,7 +41,8 @@ RETURN_NO_CFG = 2
 
 parsers = {}
 
-def takeSnapshotAsync(cfg, checksum = False):
+
+def takeSnapshotAsync(cfg, checksum=False):
     """
     Fork a new backintime process with 'backup' command which will
     take a new snapshot in background.
@@ -75,7 +76,8 @@ def takeSnapshotAsync(cfg, checksum = False):
             pass
     subprocess.Popen(cmd, env = env)
 
-def takeSnapshot(cfg, force = True):
+
+def takeSnapshot(cfg, force=True):
     """
     Take a new snapshot.
 
@@ -90,6 +92,7 @@ def takeSnapshot(cfg, force = True):
     tools.envLoad(cfg.cronEnvFile())
     ret = snapshots.Snapshots(cfg).backup(force)
     return ret
+
 
 def _mount(cfg):
     """
@@ -106,6 +109,7 @@ def _mount(cfg):
     else:
         cfg.setCurrentHashId(hash_id)
 
+
 def _umount(cfg):
     """
     Unmount external filesystems.
@@ -118,7 +122,8 @@ def _umount(cfg):
     except MountException as ex:
         logger.error(str(ex))
 
-def createParsers(app_name = 'backintime'):
+
+def createParsers(app_name='backintime'):
     """
     Define parsers for commandline arguments.
 
@@ -521,6 +526,9 @@ def startApp(app_name='backintime'):
             f"{config.Config.APP_NAME}. This will cause some trouble. "
             f"Please use either 'sudo -i {app_name}' or 'pkexec {app_name}'.")
 
+    # State data
+    init_state_data(args)
+
     # Call commands
     if 'func' in dir(args):
         args.func(args)
@@ -615,6 +623,7 @@ def argParse(args):
 
     return args
 
+
 def printHeader():
     """
     Print application name, version and legal notes.
@@ -627,6 +636,7 @@ def printHeader():
     print('This is free software, and you are welcome to redistribute it')
     print("under certain conditions; type `backintime --license' for details.")
     print('')
+
 
 class PseudoAliasAction(argparse.Action):
     """
@@ -654,6 +664,7 @@ class PseudoAliasAction(argparse.Action):
         setattr(namespace, 'replace', replace)
         setattr(namespace, 'alias', alias)
 
+
 def aliasParser(args):
     """
     Call commands which where given with leading -- for backwards
@@ -671,7 +682,8 @@ def aliasParser(args):
     if 'func' in dir(newArgs):
         newArgs.func(newArgs)
 
-def getConfig(args, check = True):
+
+def getConfig(args, check=True):
     """
     Load config and change to profile selected on commandline.
 
@@ -715,6 +727,93 @@ def getConfig(args, check = True):
     return cfg
 
 
+def _get_state_data_from_config(cfg: config.Config) -> dict:
+    """Get data related to application state from the config instance.
+
+    This function is a temporary workaround. See PR #1850.
+
+    Args:
+       cfg: The config instance.
+
+    Returns:
+        dict: The state data.
+
+    State relatd parameters:
+        internal.msg_rc=1.5.3-rc1
+        internal.msg_shown_encfs=true
+        profile1.qt.last_path=/home/user/Downloads
+        profile1.qt.places.SortColumn=1
+        profile1.qt.places.SortOrder=SortOrder.AscendingOrder
+        profile1.qt.settingsdialog.exclude.SortColumn=1
+        profile1.qt.settingsdialog.exclude.SortOrder=0
+        profile1.qt.settingsdialog.include.SortColumn=1
+        profile1.qt.settingsdialog.include.SortOrder=0
+        qt.last_path=/home/user/Downloads
+        qt.logview.height=676
+        qt.logview.width=949
+        qt.main_window.files_view.date_width=100
+        qt.main_window.files_view.name_width=822
+        qt.main_window.files_view.size_width=100
+        qt.main_window.files_view.sort.ascending=true
+        qt.main_window.files_view.sort.column=0
+        qt.main_window.height=802
+        qt.main_window.main_splitter_left_w=233
+        qt.main_window.main_splitter_right_w=1119
+        qt.main_window.second_splitter_left_w=243
+        qt.main_window.second_splitter_right_w=857
+        qt.main_window.width=1356
+        qt.main_window.x=230
+        qt.main_window.y=110
+        """
+
+    data = {
+        'gui': {
+            'mainwindow': {}
+        }
+    }
+
+    # internal.manual_starts_countdown
+    data['manual_starts_countdown'] = cfg.manual_starts_countdown()
+
+    # self.config.boolValue('qt.show_hidden_files', False)
+    data['gui']['mainwindow']['show_hidden'] \
+        = cfg.boolValue('qt.show_hidden_files', False)
+
+    return data
+
+
+def init_state_data(args: argparse.Namespace) -> None:
+    """Initiate the `State` instance.
+
+    The state file is loaded and its date stored in `State`. The later is a
+    singleton and can be used everywhere.
+
+    Dev note (buhtz, 2024-12): The args argument is a workaround and will be
+    removed. Related to PR #1850.
+
+    Args:
+       args: Arguments given from command line.
+    """
+    xdg_state = os.environ.get('XDG_STATE_HOME',
+                               pathlib.Path.home() / '.local' / 'state')
+    fp = xdg_state / 'backintime.json'
+
+    logger.debug(f'Reading state file "{fp}".')
+
+    try:
+        # load file
+        data_dict = json.loads(fp.read_text(encoding='utf-8'))
+
+    except FileNotFoundError:
+        logger.debug('State file not found. Using config file.')
+        # extract data from the config file (for later migration)
+        cfg = getConfig(args)
+        data_dict = _get_state_data_from_config(cfg)
+
+    st = state.State(data_dict)
+    print(st)
+
+
 def setQuiet(args):
     """
     Redirect :py:data:`sys.stdout` to ``/dev/null`` if ``--quiet`` was set on
@@ -736,6 +835,7 @@ def setQuiet(args):
         atexit.register(force_stdout.close)
     return force_stdout
 
+
 class printLicense(argparse.Action):
     """
     Print custom license
@@ -747,6 +847,7 @@ class printLicense(argparse.Action):
         license_path = pathlib.Path(tools.docPath()) / 'LICENSE'
         print(license_path.read_text('utf-8'))
         sys.exit(RETURN_OK)
+
 
 class printDiagnostics(argparse.Action):
     """
@@ -766,7 +867,8 @@ class printDiagnostics(argparse.Action):
 
         sys.exit(RETURN_OK)
 
-def backup(args, force = True):
+
+def backup(args, force=True):
     """
     Command for force taking a new snapshot.
 
@@ -785,6 +887,7 @@ def backup(args, force = True):
     ret = takeSnapshot(cfg, force)
     sys.exit(int(ret))
 
+
 def backupJob(args):
     """
     Command for taking a new snapshot in background. Mainly used for cronjobs.
@@ -799,6 +902,7 @@ def backupJob(args):
         SystemExit:     0
     """
     cli.BackupJobDaemon(backup, args).start()
+
 
 def shutdown(args):
     """
@@ -819,12 +923,14 @@ def shutdown(args):
     cfg = getConfig(args)
 
     sd = tools.ShutDown()
+
     if not sd.canShutdown():
         logger.warning('Shutdown is not supported.')
         sys.exit(RETURN_ERR)
 
     instance = ApplicationInstance(cfg.takeSnapshotInstanceFile(), False)
     profile = '='.join((cfg.currentProfile(), cfg.profileName()))
+
     if not instance.busy():
         logger.info('There is no active snapshot for profile %s. Skip shutdown.'
                     %profile)
@@ -833,16 +939,21 @@ def shutdown(args):
     print('Shutdown is waiting for the snapshot in profile %s to end.\nPress CTRL+C to interrupt shutdown.\n'
           %profile)
     sd.activate_shutdown = True
+
     try:
         while instance.busy():
             logger.debug('Snapshot is still active. Wait for shutdown.')
             sleep(5)
+
     except KeyboardInterrupt:
         print('Shutdown interrupted.')
+
     else:
         logger.info('Shutdown now.')
         sd.shutdown()
+
     sys.exit(RETURN_OK)
+
 
 def snapshotsPath(args):
     """
@@ -865,6 +976,7 @@ def snapshotsPath(args):
         msg = 'SnapshotsPath: {}'
     print(msg.format(cfg.snapshotsFullPath()), file=force_stdout)
     sys.exit(RETURN_OK)
+
 
 def snapshotsList(args):
     """
@@ -896,6 +1008,7 @@ def snapshotsList(args):
         _umount(cfg)
     sys.exit(RETURN_OK)
 
+
 def snapshotsListPath(args):
     """
     Command for printing a list of all snapshots paths in current profile.
@@ -926,6 +1039,7 @@ def snapshotsListPath(args):
         _umount(cfg)
     sys.exit(RETURN_OK)
 
+
 def lastSnapshot(args):
     """
     Command for printing the very last snapshot in current profile.
@@ -951,6 +1065,7 @@ def lastSnapshot(args):
         logger.error("There are no snapshots in '%s'" % cfg.profileName())
     _umount(cfg)
     sys.exit(RETURN_OK)
+
 
 def lastSnapshotPath(args):
     """
@@ -980,6 +1095,7 @@ def lastSnapshotPath(args):
         _umount(cfg)
     sys.exit(RETURN_OK)
 
+
 def unmount(args):
     """
     Command for unmounting all filesystems.
@@ -996,6 +1112,7 @@ def unmount(args):
     _mount(cfg)
     _umount(cfg)
     sys.exit(RETURN_OK)
+
 
 def benchmarkCipher(args):
     """
@@ -1019,6 +1136,7 @@ def benchmarkCipher(args):
     else:
         logger.error("SSH is not configured for profile '%s'!" % cfg.profileName())
         sys.exit(RETURN_ERR)
+
 
 def pwCache(args):
     """
@@ -1049,6 +1167,7 @@ def pwCache(args):
     else:
         daemon.run()
     sys.exit(ret)
+
 
 def decode(args):
     """
@@ -1084,7 +1203,8 @@ def decode(args):
     _umount(cfg)
     sys.exit(RETURN_OK)
 
-def remove(args, force = False):
+
+def remove(args, force=False):
     """
     Command for removing snapshots.
 
@@ -1104,6 +1224,7 @@ def remove(args, force = False):
     _umount(cfg)
     sys.exit(RETURN_OK)
 
+
 def removeAndDoNotAskAgain(args):
     """
     Command for removing snapshots without asking before remove
@@ -1117,6 +1238,7 @@ def removeAndDoNotAskAgain(args):
         SystemExit:     0
     """
     remove(args, True)
+
 
 def smartRemove(args):
     """
@@ -1151,6 +1273,7 @@ def smartRemove(args):
         logger.error('Smart Removal is not configured.')
         sys.exit(RETURN_NO_CFG)
 
+
 def restore(args):
     """
     Command for restoring files from snapshots.
@@ -1180,6 +1303,7 @@ def restore(args):
     _umount(cfg)
     sys.exit(RETURN_OK)
 
+
 def checkConfig(args):
     """
     Command for checking the config file.
@@ -1206,6 +1330,7 @@ def checkConfig(args):
                  'profile': cfg.profileName()},
               file = force_stdout)
         sys.exit(RETURN_ERR)
+
 
 if __name__ == '__main__':
     startApp()

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -741,13 +741,7 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     State relatd parameters:
         internal.msg_rc=1.5.3-rc1
         internal.msg_shown_encfs=true
-        profile1.qt.places.SortColumn=1
-        profile1.qt.places.SortOrder=SortOrder.AscendingOrder
-        profile1.qt.settingsdialog.exclude.SortColumn=1
-        profile1.qt.settingsdialog.exclude.SortOrder=0
-        profile1.qt.settingsdialog.include.SortColumn=1
-        profile1.qt.settingsdialog.include.SortOrder=0
-        qt.logview.height=676
+           qt.logview.height=676
         qt.logview.width=949
         qt.main_window.files_view.date_width=100
         qt.main_window.files_view.name_width=822
@@ -762,14 +756,12 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         qt.main_window.width=1356
         qt.main_window.x=230
         qt.main_window.y=110
-
-        qt.last_path=/home/user/Downloads
-        profile1.qt.last_path=/home/user/Downloads
         """
 
     data = {
         'gui': {
-            'mainwindow': {}
+            'mainwindow': {},
+            'manage_profiles': {},
         }
     }
 
@@ -785,9 +777,39 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
 
         # qt.last_path
         if cfg.hasProfileKey('qt.last_path', profile_id):
-            val = cfg.profileStrValue('qt.last_path')
+            val = cfg.profileStrValue('qt.last_path', profile_id)
             data['gui']['mainwindow'] \
                 .setdefault(profile_id, {})['last_path'] = val
+
+        # profile1.qt.places.SortColumn
+        # profile1.qt.places.SortOrder=SortOrder.AscendingOrder
+        if cfg.hasProfileKey('qt.places.SortColumn', profile_id):
+            val = cfg.profileIntValue('qt.places.SortColumn', profile_id)
+            data['gui']['mainwindow'].setdefault(profile_id, {})['places_sort_col'] = val
+            val = cfg.profileIntValue('qt.places.SortOrder', profile_id)
+            data['gui']['mainwindow'].setdefault(profile_id, {})['places_sort_order'] = val
+
+        # profile1.qt.settingsdialog.exclude.SortColumn=1
+        # profile1.qt.settingsdialog.exclude.SortOrder=0
+        if cfg.hasProfileKey('qt.settingsdialog.exclude.SortColumn',
+                             profile_id):
+            val = cfg.profileIntValue(
+                'qt.settingsdialog.exclude.SortColumn', profile_id)
+            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_col_excl'] = val
+            val = cfg.profileIntValue(
+                'qt.settingsdialog.exclude.SortOrder',profile_id)
+            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_order_excl'] = val
+
+        # profile1.qt.settingsdialog.include.SortColumn=1
+        # profile1.qt.settingsdialog.include.SortOrder=0
+        if cfg.hasProfileKey('qt.settingsdialog.include.SortColumn',
+                             profile_id):
+            val = cfg.profileIntValue(
+                'qt.settingsdialog.include.SortColumn', profile_id)
+            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_col_incl'] = val
+            val = cfg.profileIntValue(
+                'qt.settingsdialog.include.SortOrder',profile_id)
+            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_order_incl'] = val
 
     return data
 

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -741,14 +741,12 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     State relatd parameters:
         internal.msg_rc=1.5.3-rc1
         internal.msg_shown_encfs=true
-        profile1.qt.last_path=/home/user/Downloads
         profile1.qt.places.SortColumn=1
         profile1.qt.places.SortOrder=SortOrder.AscendingOrder
         profile1.qt.settingsdialog.exclude.SortColumn=1
         profile1.qt.settingsdialog.exclude.SortOrder=0
         profile1.qt.settingsdialog.include.SortColumn=1
         profile1.qt.settingsdialog.include.SortOrder=0
-        qt.last_path=/home/user/Downloads
         qt.logview.height=676
         qt.logview.width=949
         qt.main_window.files_view.date_width=100
@@ -764,6 +762,9 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         qt.main_window.width=1356
         qt.main_window.x=230
         qt.main_window.y=110
+
+        qt.last_path=/home/user/Downloads
+        profile1.qt.last_path=/home/user/Downloads
         """
 
     data = {
@@ -778,6 +779,15 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     # self.config.boolValue('qt.show_hidden_files', False)
     data['gui']['mainwindow']['show_hidden'] \
         = cfg.boolValue('qt.show_hidden_files', False)
+
+    # each profile
+    for profile_id in cfg.profiles():
+
+        # qt.last_path
+        if cfg.hasProfileKey('qt.last_path', profile_id):
+            val = cfg.profileStrValue('qt.last_path')
+            data['gui']['mainwindow'] \
+                .setdefault(profile_id, {})['last_path'] = val
 
     return data
 

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -817,40 +817,40 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
 
         # profile specific encfs warning
         val = cfg.profileBoolValue('msg_shown_encfs', None, profile_id)
-        if val:
+        if val is not None:
             profile_state.msg_encfs = val
 
         # qt.last_path
         if cfg.hasProfileKey('qt.last_path', profile_id):
             profile_state.last_path \
-                = cfg.profileStrValue('qt.last_path', profile_id)
+                = cfg.profileStrValue('qt.last_path', None, profile_id)
 
-        # Columns sorting order
-        if cfg.hasProfileKey('qt.places.SortColumn', profile_id):
-            sorting = (
-                cfg.profileIntValue('qt.places.SortColumn', profile_id),
-                cfg.profileIntValue('qt.places.SortOrder', profile_id)
-            )
+        # Places: sorting
+        sorting = (
+            cfg.profileIntValue('qt.places.SortColumn', None, profile_id),
+            cfg.profileIntValue('qt.places.SortOrder', None, profile_id)
+        )
+        if all(sorting):
             profile_state.places_sorting = sorting
 
-        if cfg.hasProfileKey('qt.settingsdialog.exclude.SortColumn',
-                             profile_id):
-            sorting = (
-                cfg.profileIntValue(
-                    'qt.settingsdialog.exclude.SortColumn', profile_id),
-                cfg.profileIntValue(
-                    'qt.settingsdialog.exclude.SortOrder', profile_id)
-            )
+        # Manage profiles - Exclude tab: sorting
+        sorting = (
+            cfg.profileIntValue(
+                'qt.settingsdialog.exclude.SortColumn', None, profile_id),
+            cfg.profileIntValue(
+                'qt.settingsdialog.exclude.SortOrder', None, profile_id)
+        )
+        if all(sorting):
             profile_state.exclude_sorting = sorting
 
-        if cfg.hasProfileKey('qt.settingsdialog.include.SortColumn',
-                             profile_id):
-            sorting = (
-                cfg.profileIntValue(
-                    'qt.settingsdialog.include.SortColumn', profile_id),
-                cfg.profileIntValue(
-                    'qt.settingsdialog.include.SortOrder', profile_id)
-            )
+        # Manage profiles - Include tab: sorting
+        sorting = (
+            cfg.profileIntValue(
+                'qt.settingsdialog.include.SortColumn', None, profile_id),
+            cfg.profileIntValue(
+                'qt.settingsdialog.include.SortOrder', None, profile_id)
+        )
+        if all(sorting):
             profile_state.include_sorting = sorting
 
     return data

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -730,7 +730,7 @@ def getConfig(args, check=True):
 def _get_state_data_from_config(cfg: config.Config) -> StateData:
     """Get data related to application state from the config instance.
 
-    It migrates state data from the config file to an instantance of
+    It migrates state data from the config file to an instance of
     `StateData` which later is saved in a separate file.
 
     This function is a temporary workaround. See PR #1850.
@@ -863,7 +863,8 @@ def load_state_data(args: argparse.Namespace) -> None:
     singleton and can be used everywhere.
 
     Dev note (buhtz, 2024-12): The args argument is a workaround and will be
-    removed. Related to PR #1850.
+    removed. Currently it is needed to know where to load the config file
+    from. Related to PR #1850.
 
     Args:
        args: Arguments given from command line.

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -737,79 +737,108 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
 
     Returns:
         dict: The state data.
-
-    State relatd parameters:
-        internal.msg_rc=1.5.3-rc1
-        internal.msg_shown_encfs=true
-           qt.logview.height=676
-        qt.logview.width=949
-        qt.main_window.files_view.date_width=100
-        qt.main_window.files_view.name_width=822
-        qt.main_window.files_view.size_width=100
-        qt.main_window.files_view.sort.ascending=true
-        qt.main_window.files_view.sort.column=0
-        qt.main_window.height=802
-        qt.main_window.main_splitter_left_w=233
-        qt.main_window.main_splitter_right_w=1119
-        qt.main_window.second_splitter_left_w=243
-        qt.main_window.second_splitter_right_w=857
-        qt.main_window.width=1356
-        qt.main_window.x=230
-        qt.main_window.y=110
         """
 
     data = {
         'gui': {
-            'mainwindow': {},
+            'mainwindow': {
+                'files_view': {},
+            },
             'manage_profiles': {},
-        }
+            'logview': {},
+        },
+        'message': {
+            'encfs': {}
+        },
     }
 
     # internal.manual_starts_countdown
     data['manual_starts_countdown'] = cfg.manual_starts_countdown()
 
-    # self.config.boolValue('qt.show_hidden_files', False)
+    # internal.msg_rc
+    val = cfg.strValue('internal.msg_rc', None)
+    if val:
+        data['message']['release_candidate'] = val
+
+    # internal.msg_shown_encfs
+    val = cfg.boolValue('internal.msg_shown_encfs', None)
+    if val:
+        data['message']['encfs']['global'] = val
+
+    # qt.show_hidden_files
     data['gui']['mainwindow']['show_hidden'] \
         = cfg.boolValue('qt.show_hidden_files', False)
+
+    # Coordinates and dimensions
+    process_data = (
+        ('qt.main_window.', ('x', 'y'), 'mainwindow'),
+        ('qt.main_window.', ('width', 'height'), 'mainwindow'),
+        ('qt.logview.', ('width', 'height'), 'logview'),
+    )
+    for org_prefix, xyhw, widgetname in process_data:
+        val = (
+            cfg.intValue(f'{org_prefix}{xyhw[0]}', None),
+            cfg.intValue(f'{org_prefix}{xyhw[1]}', None),
+        )
+        if all(val):
+            data['gui'][widgetname]['coord' if 'x' in xyhw else 'dim'] = val
+
+    # files view
+    widths = (
+        # first column "name"
+        cfg.intValue('qt.main_window.files_view.name_width', None),
+        # second column "size"
+        cfg.intValue('qt.main_window.files_view.size_width', None),
+        # third column "date"
+        cfg.intValue('qt.main_window.files_view.date_width', None)
+    )
+    if all(widths):
+        data['gui']['mainwindow']['files_view']['column_widths'] = widths
+
+    col = cfg.intValue('qt.main_window.files_view.sort.column', 0)
+    order = cfg.boolValue('qt.main_window.files_view.sort.ascending', True)
+    data['gui']['mainwindow']['files_view']['sort_column'] = col
+    data['gui']['mainwindow']['files_view']['sort_order'] = 0 if order else 1
+
+    # splitter width
+    for prefix in ('main', 'second'):
+        widths = (
+            cfg.intValue(f'qt.main_window.{prefix}_splitter_left_w', None),
+            cfg.intValue(f'qt.main_window.{prefix}_splitter_right_w', None)
+        )
+        if all(widths):
+            data['gui']['mainwindow'][f'splitter_{prefix}_widths'] = widths
 
     # each profile
     for profile_id in cfg.profiles():
 
+        # profile specific encfs warning
+        val = cfg.profileBoolValue('msg_shown_encfs', None, profile_id)
+        if val:
+            data['message']['encfs'][profile_id] = val
+
         # qt.last_path
         if cfg.hasProfileKey('qt.last_path', profile_id):
             val = cfg.profileStrValue('qt.last_path', profile_id)
-            data['gui']['mainwindow'] \
-                .setdefault(profile_id, {})['last_path'] = val
+            data['gui']['mainwindow'].setdefault(
+                'last_path', {})[profile_id] = val
 
-        # profile1.qt.places.SortColumn
-        # profile1.qt.places.SortOrder=SortOrder.AscendingOrder
-        if cfg.hasProfileKey('qt.places.SortColumn', profile_id):
-            val = cfg.profileIntValue('qt.places.SortColumn', profile_id)
-            data['gui']['mainwindow'].setdefault(profile_id, {})['places_sort_col'] = val
-            val = cfg.profileIntValue('qt.places.SortOrder', profile_id)
-            data['gui']['mainwindow'].setdefault(profile_id, {})['places_sort_order'] = val
-
-        # profile1.qt.settingsdialog.exclude.SortColumn=1
-        # profile1.qt.settingsdialog.exclude.SortOrder=0
-        if cfg.hasProfileKey('qt.settingsdialog.exclude.SortColumn',
-                             profile_id):
-            val = cfg.profileIntValue(
-                'qt.settingsdialog.exclude.SortColumn', profile_id)
-            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_col_excl'] = val
-            val = cfg.profileIntValue(
-                'qt.settingsdialog.exclude.SortOrder',profile_id)
-            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_order_excl'] = val
-
-        # profile1.qt.settingsdialog.include.SortColumn=1
-        # profile1.qt.settingsdialog.include.SortOrder=0
-        if cfg.hasProfileKey('qt.settingsdialog.include.SortColumn',
-                             profile_id):
-            val = cfg.profileIntValue(
-                'qt.settingsdialog.include.SortColumn', profile_id)
-            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_col_incl'] = val
-            val = cfg.profileIntValue(
-                'qt.settingsdialog.include.SortOrder',profile_id)
-            data['gui']['manage_profiles'].setdefault(profile_id, {})['sort_order_incl'] = val
+        # Columns sorting order
+        process_data = (
+            ('qt.places.', 'mainwindow', 'places_'),
+            ('qt.settingsdialog.exclude.', 'manage_profiles', 'excl_'),
+            ('qt.settingsdialog.include.', 'manage_profiles', 'incl_'),
+        )
+        for org_prefix, widgetname, new_prefix in process_data:
+            if cfg.hasProfileKey(f'{org_prefix}SortColumn', profile_id):
+                col = cfg.profileIntValue(
+                    f'{org_prefix}SortColumn', profile_id)
+                order = cfg.profileIntValue(
+                    f'{org_prefix}SortOrder', profile_id)
+                data['gui'][widgetname].setdefault(
+                    f'{new_prefix}sort_col', {})[profile_id] = col
+                data['gui'][widgetname].setdefault(
+                    f'{new_prefix}sort_order', {})[profile_id] = order
 
     return data
 
@@ -834,7 +863,7 @@ def load_state_data(args: argparse.Namespace) -> None:
 
     except FileNotFoundError:
         logger.debug('State file not found. Using config file.')
-        fp.parent.mkdir(parents=True)
+        fp.parent.mkdir(parents=True, exist_ok=True)
         # extract data from the config file (for later migration)
         cfg = getConfig(args)
         data_dict = _get_state_data_from_config(cfg)

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -811,38 +811,47 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
     if all(widths):
         data.mainwindow_second_splitter_widths = widths
 
-    # ---- XXXX ----
-
     # each profile
     for profile_id in cfg.profiles():
+        profile_state = data.profile(profile_id)
 
         # profile specific encfs warning
         val = cfg.profileBoolValue('msg_shown_encfs', None, profile_id)
         if val:
-            data['message']['encfs'][profile_id] = val
+            profile_state.msg_encfs = val
 
         # qt.last_path
         if cfg.hasProfileKey('qt.last_path', profile_id):
-            val = cfg.profileStrValue('qt.last_path', profile_id)
-            data['gui']['mainwindow'].setdefault(
-                'last_path', {})[profile_id] = val
+            profile_state.last_path \
+                = cfg.profileStrValue('qt.last_path', profile_id)
 
         # Columns sorting order
-        process_data = (
-            ('qt.places.', 'mainwindow', 'places_'),
-            ('qt.settingsdialog.exclude.', 'manage_profiles', 'excl_'),
-            ('qt.settingsdialog.include.', 'manage_profiles', 'incl_'),
-        )
-        for org_prefix, widgetname, new_prefix in process_data:
-            if cfg.hasProfileKey(f'{org_prefix}SortColumn', profile_id):
-                col = cfg.profileIntValue(
-                    f'{org_prefix}SortColumn', profile_id)
-                order = cfg.profileIntValue(
-                    f'{org_prefix}SortOrder', profile_id)
-                data['gui'][widgetname].setdefault(
-                    f'{new_prefix}sort_col', {})[profile_id] = col
-                data['gui'][widgetname].setdefault(
-                    f'{new_prefix}sort_order', {})[profile_id] = order
+        if cfg.hasProfileKey('qt.places.SortColumn', profile_id):
+            sorting = (
+                cfg.profileIntValue('qt.places.SortColumn', profile_id),
+                cfg.profileIntValue('qt.places.SortOrder', profile_id)
+            )
+            profile_state.places_sorting = sorting
+
+        if cfg.hasProfileKey('qt.settingsdialog.exclude.SortColumn',
+                             profile_id):
+            sorting = (
+                cfg.profileIntValue(
+                    'qt.settingsdialog.exclude.SortColumn', profile_id),
+                cfg.profileIntValue(
+                    'qt.settingsdialog.exclude.SortOrder', profile_id)
+            )
+            profile_state.exclude_sorting = sorting
+
+        if cfg.hasProfileKey('qt.settingsdialog.include.SortColumn',
+                             profile_id):
+            sorting = (
+                cfg.profileIntValue(
+                    'qt.settingsdialog.include.SortColumn', profile_id),
+                cfg.profileIntValue(
+                    'qt.settingsdialog.include.SortOrder', profile_id)
+            )
+            profile_state.include_sorting = sorting
 
     return data
 
@@ -863,24 +872,21 @@ def load_state_data(args: argparse.Namespace) -> None:
 
     try:
         # load file
-        data_dict = json.loads(fp.read_text(encoding='utf-8'))
+        state_data = StateData(json.loads(fp.read_text(encoding='utf-8')))
 
     except FileNotFoundError:
         logger.debug('State file not found. Using config file.')
         fp.parent.mkdir(parents=True, exist_ok=True)
         # extract data from the config file (for later migration)
-        cfg = getConfig(args)
-        data_dict = _get_state_data_from_config(cfg)
+        state_data = _get_state_data_from_config(getConfig(args))
 
     except json.decoder.JSONDecodeError as exc:
         logger.warning(f'Unable to read and decode state file "{fp}". '
                        'Ignnoring it.')
         logger.debug(f'{exc=}')
-        data_dict = _STATE_DATA_EMPTY_STRUCT
+        state_data = StateData()
 
-    st = StateData(data_dict)
-
-    atexit.register(st.save)
+    atexit.register(state_data.save)
 
 
 def setQuiet(args):

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -29,7 +29,7 @@ import mount
 import password
 import encfstools
 import cli
-import state
+from state import StateData
 from diagnostics import collect_diagnostics, collect_minimal_diagnostics
 from exceptions import MountException
 from applicationinstance import ApplicationInstance
@@ -527,7 +527,7 @@ def startApp(app_name='backintime'):
             f"Please use either 'sudo -i {app_name}' or 'pkexec {app_name}'.")
 
     # State data
-    init_state_data(args)
+    load_state_data(args)
 
     # Call commands
     if 'func' in dir(args):
@@ -782,7 +782,7 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     return data
 
 
-def init_state_data(args: argparse.Namespace) -> None:
+def load_state_data(args: argparse.Namespace) -> None:
     """Initiate the `State` instance.
 
     The state file is loaded and its date stored in `State`. The later is a
@@ -794,11 +794,7 @@ def init_state_data(args: argparse.Namespace) -> None:
     Args:
        args: Arguments given from command line.
     """
-    xdg_state = os.environ.get('XDG_STATE_HOME',
-                               pathlib.Path.home() / '.local' / 'state')
-    fp = xdg_state / 'backintime.json'
-
-    logger.debug(f'Reading state file "{fp}".')
+    fp = StateData.file_path()
 
     try:
         # load file
@@ -806,12 +802,14 @@ def init_state_data(args: argparse.Namespace) -> None:
 
     except FileNotFoundError:
         logger.debug('State file not found. Using config file.')
+        fp.parent.mkdir(parents=True)
         # extract data from the config file (for later migration)
         cfg = getConfig(args)
         data_dict = _get_state_data_from_config(cfg)
 
-    st = state.State(data_dict)
-    print(st)
+    st = StateData(data_dict)
+
+    atexit.register(st.save)
 
 
 def setQuiet(args):

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -785,7 +785,7 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
 
     # files view
     # Dev note (buhtz, 2024-12): Ignore the column width values because of a
-    # bug. Three columsn are tracked but the widget has four columsn. The "Typ"
+    # bug. Three columns are tracked but the widget has four columns. The "Typ"
     # column is treated as "Date" and the width of the real "Date" column (4th)
     # was never stored.
     # qt.main_window.files_view.name_width

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -727,21 +727,7 @@ def getConfig(args, check=True):
     return cfg
 
 
-_STATE_DATA_EMPTY_STRUCT = {
-    'gui': {
-        'mainwindow': {
-            'files_view': {},
-        },
-        'manage_profiles': {},
-        'logview': {},
-    },
-    'message': {
-        'encfs': {}
-    },
-}
-
-
-def _get_state_data_from_config(cfg: config.Config) -> dict:
+def _get_state_data_from_config(cfg: config.Config) -> StateData:
     """Get data related to application state from the config instance.
 
     It migrates state data from the config file to an instantance of
@@ -756,7 +742,7 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
         dict: The state data.
         """
 
-    data = _STATE_DATA_EMPTY_STRUCT
+    data = StateData()
 
     # internal.manual_starts_countdown
     data['manual_starts_countdown'] \
@@ -765,30 +751,37 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
     # internal.msg_rc
     val = cfg.strValue('internal.msg_rc', None)
     if val:
-        data['message']['release_candidate'] = val
+        data.msg_release_candidate = val
 
     # internal.msg_shown_encfs
     val = cfg.boolValue('internal.msg_shown_encfs', None)
     if val:
-        data['message']['encfs']['global'] = val
+        data.msg_encfs_global = val
 
     # qt.show_hidden_files
-    data['gui']['mainwindow']['show_hidden'] \
-        = cfg.boolValue('qt.show_hidden_files', False)
+    data.mainwindow_show_hidden = cfg.boolValue('qt.show_hidden_files', False)
 
     # Coordinates and dimensions
-    process_data = (
-        ('qt.main_window.', ('x', 'y'), 'mainwindow'),
-        ('qt.main_window.', ('width', 'height'), 'mainwindow'),
-        ('qt.logview.', ('width', 'height'), 'logview'),
+    val = (
+        cfg.intValue('qt.main_window.x', None),
+        cfg.intValue('qt.main_window.y', None)
     )
-    for org_prefix, xyhw, widgetname in process_data:
-        val = (
-            cfg.intValue(f'{org_prefix}{xyhw[0]}', None),
-            cfg.intValue(f'{org_prefix}{xyhw[1]}', None),
-        )
-        if all(val):
-            data['gui'][widgetname]['coords' if 'x' in xyhw else 'dims'] = val
+    if all(val):
+        data.mainwindow_coords = val
+
+    val = (
+        cfg.intValue('qt.main_window.width', None),
+        cfg.intValue('qt.main_window.height', None)
+    )
+    if all(val):
+        data.mainwindow_dims = val
+
+    val = (
+        cfg.intValue('qt.logview.width', None),
+        cfg.intValue('qt.logview.height', None)
+    )
+    if all(val):
+        data.logview_dims = val
 
     # files view
     # Dev note (buhtz, 2024-12): Ignore the column width values because of a
@@ -801,17 +794,22 @@ def _get_state_data_from_config(cfg: config.Config) -> dict:
 
     col = cfg.intValue('qt.main_window.files_view.sort.column', 0)
     order = cfg.boolValue('qt.main_window.files_view.sort.ascending', True)
-    data['gui']['mainwindow']['files_view']['sort_column'] = col
-    data['gui']['mainwindow']['files_view']['sort_order'] = 0 if order else 1
+    data.files_view_sorting = (col, 0 if order else 1)
 
     # splitter width
-    for prefix in ('main', 'second'):
-        widths = (
-            cfg.intValue(f'qt.main_window.{prefix}_splitter_left_w', None),
-            cfg.intValue(f'qt.main_window.{prefix}_splitter_right_w', None)
-        )
-        if all(widths):
-            data['gui']['mainwindow'][f'splitter_{prefix}_widths'] = widths
+    widths = (
+        cfg.intValue('qt.main_window.main_splitter_left_w', None),
+        cfg.intValue('qt.main_window.main_splitter_right_w', None)
+    )
+    if all(widths):
+        data.mainwindow_main_splitter_widths = widths
+
+    widths = (
+        cfg.intValue('qt.main_window.second_splitter_left_w', None),
+        cfg.intValue('qt.main_window.second_splitter_right_w', None)
+    )
+    if all(widths):
+        data.mainwindow_second_splitter_widths = widths
 
     # ---- XXXX ----
 

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -29,7 +29,7 @@ import mount
 import password
 import encfstools
 import cli
-from state import StateData
+from statedata import StateData
 from diagnostics import collect_diagnostics, collect_minimal_diagnostics
 from exceptions import MountException
 from applicationinstance import ApplicationInstance

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -864,7 +864,8 @@ def load_state_data(args: argparse.Namespace) -> None:
 
     Dev note (buhtz, 2024-12): The args argument is a workaround and will be
     removed. Currently it is needed to know where to load the config file
-    from. Related to PR #1850.
+    from. Related to PR #1850. In the future that function can be moved into
+    the StateData class as load() method.
 
     Args:
        args: Arguments given from command line.

--- a/common/config.py
+++ b/common/config.py
@@ -447,27 +447,6 @@ class Config(configfile.ConfigFileWithProfiles):
     def setLanguage(self, language: str):
         self.setStrValue('global.language', language if language else '')
 
-    def manual_starts_countdown(self) -> int:
-        """Countdown value about how often the users started the Back In Time
-        GUI.
-
-        It is an internal variable not meant to be used or manipulated be the
-        users. At the end of the countown the
-        :py:class:`ApproachTranslatorDialog` is presented to the user.
-
-        """
-        return self.intValue('internal.manual_starts_countdown', 10)
-
-    def decrement_manual_starts_countdown(self):
-        """Counts down to -1.
-
-        See :py:func:`manual_starts_countdown()` for details.
-        """
-        val = self.manual_starts_countdown()
-
-        if val > -1:
-            self.setIntValue('internal.manual_starts_countdown', val - 1)
-
     # SSH
     def sshSnapshotsPath(self, profile_id = None):
         #?Snapshot path on remote host. If the path is relative (no leading '/')

--- a/common/singleton.py
+++ b/common/singleton.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2022 Mars Landis
+# SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: CC0-1.0
+#
+# This file is released under Creative Commons Zero 1.0 (CC0-1.0) and part of
+# the program "Back In Time". The program as a whole is released under GNU
+# General Public License v2 or any later version (GPL-2.0-or-later).
+# See file/folder LICENSE or
+# go to <https://spdx.org/licenses/CC0-1.0.html>
+# and <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+#
+# Credits to Mr. Mars Landis describing that solution and comparing it to
+# alternatives in his article 'Better Python Singleton with a Metaclass' at
+# <https://python.plainenglish.io/better-python-singleton-with-a-metaclass-41fb8bfe2127>
+# himself refering to this Stack Overflow
+# <https://stackoverflow.com/q/6760685/4865723> question as his inspiration.
+#
+# Original code adapted by Christian Buhtz.
+
+"""Flexible and pythonic singleton implemention.
+
+Support inheritance and multiple classes. Multilevel inheritance is
+theoretically possible if the '__allow_reinitialization' approach would be
+implemented as described in the original article.
+
+Example ::
+
+    >>> from singleton import Singleton
+    >>>
+    >>> class Foo(metaclass=Singleton):
+    ...     def __init__(self):
+    ...          self.value = 'Alyssa Ogawa'
+    >>>
+    >>> class Bar(metaclass=Singleton):
+    ...     def __init__(self):
+    ...          self.value = 'Naomi Wildmann'
+    >>>
+    >>> f = Foo()
+    >>> ff = Foo()
+    >>> f'{f.value=} :: {ff.value=}'
+    "f.value='Alyssa Ogawa' :: ff.value='Alyssa Ogawa'"
+    >>> ff.value = 'Who?'
+    >>> f'{f.value=} :: {ff.value=}'
+    "f.value='Who?' :: ff.value='Who?'"
+    >>>
+    >>> b = Bar()
+    >>> bb = Bar()
+    >>> f'{b.value=} :: {bb.value=}'
+    "b.value='Naomi Wildmann' :: bb.value='Naomi Wildmann'"
+    >>> b.value = 'thinking ...'
+    >>> f'{b.value=} :: {bb.value=}'
+    "b.value='thinking ...' :: bb.value='thinking ...'"
+    >>>
+    >>> id(f) == id(ff)
+    True
+    >>> id(b) == id(bb)
+    True
+    >>> id(f) == id(b)
+    False
+"""
+
+
+class Singleton(type):
+    """Singleton implemention supporting inheritance and multiple classes."""
+
+    _instances = {}
+    """Hold single instances of multiple classes."""
+
+    def __call__(cls, *args, **kwargs):
+
+        try:
+            # Re-use existing instance
+            return cls._instances[cls]
+
+        except KeyError:
+            # Create new instance
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+
+            return cls._instances[cls]

--- a/common/singleton.py
+++ b/common/singleton.py
@@ -13,12 +13,12 @@
 # Credits to Mr. Mars Landis describing that solution and comparing it to
 # alternatives in his article 'Better Python Singleton with a Metaclass' at
 # <https://python.plainenglish.io/better-python-singleton-with-a-metaclass-41fb8bfe2127>
-# himself refering to this Stack Overflow
+# himself referring to this Stack Overflow
 # <https://stackoverflow.com/q/6760685/4865723> question as his inspiration.
 #
 # Original code adapted by Christian Buhtz.
 
-"""Flexible and pythonic singleton implemention.
+"""Flexible and pythonic singleton implementation.
 
 Support inheritance and multiple classes. Multilevel inheritance is
 theoretically possible if the '__allow_reinitialization' approach would be
@@ -62,7 +62,7 @@ Example ::
 
 
 class Singleton(type):
-    """Singleton implemention supporting inheritance and multiple classes."""
+    """Singleton implementation supporting inheritance and multiple classes."""
 
     _instances = {}
     """Hold single instances of multiple classes."""
@@ -70,7 +70,7 @@ class Singleton(type):
     def __call__(cls, *args, **kwargs):
 
         try:
-            # Re-use existing instance
+            # Reuse existing instance
             return cls._instances[cls]
 
         except KeyError:

--- a/common/state.py
+++ b/common/state.py
@@ -24,6 +24,19 @@ class StateData(dict, metaclass=singleton.Singleton):
     ``metaclass=``. To my current knowledge this is not a big deal.
     """
 
+    _EMPTY_STRUCT = {
+        'gui': {
+            'mainwindow': {
+                'files_view': {},
+            },
+            'manage_profiles': {},
+            'logview': {},
+        },
+        'message': {
+            'encfs': {}
+        },
+    }
+
     @staticmethod
     def file_path() -> Path:
         """Returns the state file path."""
@@ -35,8 +48,11 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         return fp
 
-    def __init__(self, data: dict):
+    def __init__(self, data: dict = None):
         """Constructor."""
+
+        if not data:
+            data = self._EMPTY_STRUCT
 
         # This will initilize self.data (see UserDict docu)
         super().__init__(data)
@@ -81,3 +97,90 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         if val > -1:
             self['manual_starts_countdown'] = val - 1
+
+    @property
+    def msg_release_candidate(self) -> str:
+        return self['message']['release_candidate']
+
+    @msg_release_candidate.setter
+    def msg_release_candidate(self, val: str) -> None:
+        self['message']['release_candidate'] = val
+
+    @property
+    def msg_encfs_global(self) -> bool:
+        return self['message']['encfs']['global']
+
+    @msg_encfs_global.setter
+    def msg_encfs_global(self, val: bool) -> None:
+        self['message']['encfs']['global'] = val
+
+    @property
+    def mainwindow_show_hidden(self) -> bool:
+        return self['gui']['mainwindow']['show_hidden']
+
+    @mainwindow_show_hidden.setter
+    def mainwindow_show_hidden(self, val: boll) -> None:
+        self['gui']['mainwindow']['show_hidden'] = val
+
+    @property
+    def mainwindow_dims(self) -> tuple[int, int]:
+        return self['gui']['mainwindow']['dims']
+
+    @mainwindow_dims.setter
+    def mainwindow_dims(self, vals) -> None:
+        self['gui']['mainwindow']['dims'] = vals
+
+    @property
+    def mainwindow_coords(self) -> tuple[int, int]:
+        return self['gui']['mainwindow']['coords']
+
+    @mainwindow_coords.setter
+    def mainwindow_coords(self, vals) -> None:
+        self['gui']['mainwindow']['coords'] = vals
+
+    @property
+    def logview_dims(self) -> tuple[int, int]:
+        return self['gui']['logview']['dims']
+
+    @logview_dims.setter
+    def logview_dims(self, vals) -> None:
+        self['gui']['logview']['dims'] = vals
+
+    @property
+    def files_view_sorting(self) -> tuple[int, int]:
+        """Column index and sort order.
+
+        Returns:
+            Tuple with column index and its sorting order (0=ascending).
+        """
+        return self['gui']['mainwindow']['files_view']['sorting']
+
+    @files_view_sorting.setter
+    def files_view_sorting(self, vals: tupler[int, int]) -> None:
+        self['gui']['mainwindow']['files_view']['sorting'] = vals
+
+    @property
+    def mainwindow_main_splitter_widths(self) -> tuple[int, int]:
+        """Left and right width of main splitter in main window.
+
+        Returns:
+            Two entry tuple with right and left widths.
+        """
+        return self['gui']['mainwindow']['splitter_main_widths']
+
+    @mainwindow_main_splitter_widths.setter
+    def mainwindow_main_splitter_widths(self, vals: tuple[int, int]) -> None:
+        self['gui']['mainwindow']['splitter_main_widths'] = vals
+
+    @property
+    def mainwindow_second_splitter_widths(self) -> tuple[int, int]:
+        """Left and right width of second splitter in main window.
+
+        Returns:
+            Two entry tuple with right and left widths.
+        """
+        return self['gui']['mainwindow'].get('splitter_second_widths', None)
+
+    @mainwindow_second_splitter_widths.setter
+    def mainwindow_second_splitter_widths(self, vals: tuple[int, int]) -> None:
+        self['gui']['mainwindow']['splitter_second_widths'] = vals

--- a/common/state.py
+++ b/common/state.py
@@ -24,6 +24,78 @@ class StateData(dict, metaclass=singleton.Singleton):
     ``metaclass=``. To my current knowledge this is not a big deal.
     """
 
+    class Profile:
+        """A surrogate to access profile-specific state data."""
+
+        def __init__(self, profile_id: str, state: StateData):
+            self._state = state
+            self._profile_id = profile_id
+
+        @property
+        def msg_encfs(self) -> bool:
+            """If message box about EncFS deprecation was shown already."""
+            return self._state['message']['encfs'][self._profile_id]
+
+        @msg_encfs.setter
+        def msg_encfs(self, val: bool) -> None:
+            self._state['message']['encfs'][self._profile_id] = val
+
+        @property
+        def last_path(self) -> Path:
+            """Last path used in the GUI."""
+            return Path(self._state['gui']['mainwindow'][
+                'last_path'][self._profile_id])
+
+        @last_path.setter
+        def last_path(self, path: Path) -> None:
+            self._state['gui']['mainwindow'][
+                'last_path'][self._profile_id] = str(path)
+
+        @property
+        def places_sorting(self) -> tuple[int, int]:
+            """Column index and sort order.
+
+            Returns:
+                Tuple with column index and its sorting order (0=ascending).
+            """
+            return self._state['gui']['mainwindow'][
+                'places_sorting'][self._profile_id]
+
+        @places_sorting.setter
+        def places_sorting(self, vals: tuple[int, int]) -> None:
+            self._state['gui']['mainwindow'][
+                'places_sorting'][self._profile_id] = vals
+
+        @property
+        def exclude_sorting(self) -> tuple[int, int]:
+            """Column index and sort order.
+
+            Returns:
+                Tuple with column index and its sorting order (0=ascending).
+            """
+            return self._state['gui']['manage_profiles'][
+                'excl_sorting'][self._profile_id]
+
+        @exclude_sorting.setter
+        def exclude_sorting(self, vals: tuple[int, int]) -> None:
+            self._state['gui']['manage_profiles'][
+                'excl_sorting'][self._profile_id] = vals
+
+        @property
+        def include_sorting(self) -> tuple[int, int]:
+            """Column index and sort order.
+
+            Returns:
+                Tuple with column index and its sorting order (0=ascending).
+            """
+            return self._state['gui']['manage_profiles'][
+                'incl_sorting'][self._profile_id]
+
+        @include_sorting.setter
+        def include_sorting(self, vals: tuple[int, int]) -> None:
+            self._state['gui']['manage_profiles'][
+                'incl_sorting'][self._profile_id] = vals
+
     _EMPTY_STRUCT = {
         'gui': {
             'mainwindow': {
@@ -77,7 +149,17 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         with self.file_path().open('w', encoding='utf-8') as handle:
             handle.write(str(self))
-            # json.dump(obj=self._data, fp=handle, indent=4)
+
+    def profile(self, profile_id: str) -> StateData.Profile:
+        """Return a `Profile` object related to the given id.
+
+        Args:
+            profile_id: A profile_id of a snapshot profile.
+
+        Returns:
+            A profile surrogate.
+        """
+        return StateData.Profile(profile_id=profile_id, state=self)
 
     def manual_starts_countdown(self) -> int:
         """Countdown value about how often the users started the Back In Time
@@ -100,6 +182,9 @@ class StateData(dict, metaclass=singleton.Singleton):
 
     @property
     def msg_release_candidate(self) -> str:
+        """Last version of Back In Time in which the release candidate message
+        box was displayed.
+        """
         return self['message']['release_candidate']
 
     @msg_release_candidate.setter
@@ -108,6 +193,7 @@ class StateData(dict, metaclass=singleton.Singleton):
 
     @property
     def msg_encfs_global(self) -> bool:
+        """If global EncFS deprecation message box was displayed allready."""
         return self['message']['encfs']['global']
 
     @msg_encfs_global.setter
@@ -116,34 +202,38 @@ class StateData(dict, metaclass=singleton.Singleton):
 
     @property
     def mainwindow_show_hidden(self) -> bool:
+        """Show hidden files in files view."""
         return self['gui']['mainwindow']['show_hidden']
 
     @mainwindow_show_hidden.setter
-    def mainwindow_show_hidden(self, val: boll) -> None:
+    def mainwindow_show_hidden(self, val: bool) -> None:
         self['gui']['mainwindow']['show_hidden'] = val
 
     @property
     def mainwindow_dims(self) -> tuple[int, int]:
+        """Dimensions of the main window."""
         return self['gui']['mainwindow']['dims']
 
     @mainwindow_dims.setter
-    def mainwindow_dims(self, vals) -> None:
+    def mainwindow_dims(self, vals: tuple[int, int]) -> None:
         self['gui']['mainwindow']['dims'] = vals
 
     @property
     def mainwindow_coords(self) -> tuple[int, int]:
+        """Coordinates (position) of the main window."""
         return self['gui']['mainwindow']['coords']
 
     @mainwindow_coords.setter
-    def mainwindow_coords(self, vals) -> None:
+    def mainwindow_coords(self, vals: tuple[int, int]) -> None:
         self['gui']['mainwindow']['coords'] = vals
 
     @property
     def logview_dims(self) -> tuple[int, int]:
+        """Dimensions of the log view dialog."""
         return self['gui']['logview']['dims']
 
     @logview_dims.setter
-    def logview_dims(self, vals) -> None:
+    def logview_dims(self, vals: tuple[int, int]) -> None:
         self['gui']['logview']['dims'] = vals
 
     @property
@@ -156,7 +246,7 @@ class StateData(dict, metaclass=singleton.Singleton):
         return self['gui']['mainwindow']['files_view']['sorting']
 
     @files_view_sorting.setter
-    def files_view_sorting(self, vals: tupler[int, int]) -> None:
+    def files_view_sorting(self, vals: tuple[int, int]) -> None:
         self['gui']['mainwindow']['files_view']['sorting'] = vals
 
     @property

--- a/common/state.py
+++ b/common/state.py
@@ -62,3 +62,22 @@ class StateData(dict, metaclass=singleton.Singleton):
         with self.file_path().open('w', encoding='utf-8') as handle:
             handle.write(str(self))
             # json.dump(obj=self._data, fp=handle, indent=4)
+
+    def manual_starts_countdown(self) -> int:
+        """Countdown value about how often the users started the Back In Time
+        GUI.
+
+        At the end of the countown the `ApproachTranslatorDialog` is presented
+        to the user.
+        """
+        return self.get('manual_starts_countdown', default=10)
+
+    def decrement_manual_starts_countdown(self):
+        """Counts down to -1.
+
+        See :py:func:`manual_starts_countdown()` for details.
+        """
+        val = self.manual_starts_countdown()
+
+        if val > -1:
+            self['manual_starts_countdown'] = val - 1

--- a/common/state.py
+++ b/common/state.py
@@ -16,8 +16,12 @@ from datetime import datetime, timezone
 from version import __version__
 
 
-class StateData(metaclass=singleton.Singleton):
+class StateData(dict, metaclass=singleton.Singleton):
     """Manage state data for Back In Time.
+
+    Dev note (buhtz, 2024-12): It is recommended and prefered to derive from
+    `collections.UserDict` instead of just `dict`. But this conflicts with the
+    ``metaclass=``. To my current knowledge this is not a big deal.
     """
 
     @staticmethod
@@ -33,10 +37,12 @@ class StateData(metaclass=singleton.Singleton):
 
     def __init__(self, data: dict):
         """Constructor."""
-        self._data = data
+
+        # This will initilize self.data (see UserDict docu)
+        super().__init__(data)
 
     def __str__(self):
-        return json.dumps(self._data, indent=4)
+        return json.dumps(self, indent=4)
 
     def _set_save_meta_data(self):
         meta = {
@@ -45,7 +51,7 @@ class StateData(metaclass=singleton.Singleton):
             'bitversion': __version__,
         }
 
-        self._data['_meta'] = meta
+        self['_meta'] = meta
 
     def save(self):
         """Store application state data to a file."""
@@ -54,4 +60,5 @@ class StateData(metaclass=singleton.Singleton):
         self._set_save_meta_data()
 
         with self.file_path().open('w', encoding='utf-8') as handle:
-            json.dump(obj=self._data, fp=handle, indent=4)
+            handle.write(str(self))
+            # json.dump(obj=self._data, fp=handle, indent=4)

--- a/common/state.py
+++ b/common/state.py
@@ -70,7 +70,7 @@ class StateData(dict, metaclass=singleton.Singleton):
         At the end of the countown the `ApproachTranslatorDialog` is presented
         to the user.
         """
-        return self.get('manual_starts_countdown', default=10)
+        return self.get('manual_starts_countdown', 10)
 
     def decrement_manual_starts_countdown(self):
         """Counts down to -1.

--- a/common/state.py
+++ b/common/state.py
@@ -21,7 +21,8 @@ class StateData(dict, metaclass=singleton.Singleton):
 
     Dev note (buhtz, 2024-12): It is recommended and preferred to derive from
     `collections.UserDict` instead of just `dict`. But this conflicts with the
-    ``metaclass=``. To my current knowledge this is not a big deal.
+    ``metaclass=``. To my current knowledge this is not a big deal and won't
+    introduce any problems.
     """
 
     class Profile:

--- a/common/state.py
+++ b/common/state.py
@@ -7,14 +7,29 @@
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Managment of the state file."""
 from __future__ import annotations
+import os
 import json
 import singleton
 import logger
+from pathlib import Path
+from datetime import datetime, timezone
+from version import __version__
 
 
-class State(metaclass=singleton.Singleton):
+class StateData(metaclass=singleton.Singleton):
     """Manage state data for Back In Time.
     """
+
+    @staticmethod
+    def file_path() -> Path:
+        """Returns the state file path."""
+        xdg_state = os.environ.get('XDG_STATE_HOME',
+                                   Path.home() / '.local' / 'state')
+        fp = xdg_state / 'backintime.json'
+
+        logger.debug(f'State file path: {fp}')
+
+        return fp
 
     def __init__(self, data: dict):
         """Constructor."""
@@ -22,3 +37,21 @@ class State(metaclass=singleton.Singleton):
 
     def __str__(self):
         return json.dumps(self._data, indent=4)
+
+    def _set_save_meta_data(self):
+        meta = {
+            'saved': datetime.now().isoformat(),
+            'saved_utc': datetime.now(timezone.utc).isoformat(),
+            'bitversion': __version__,
+        }
+
+        self._data['_meta'] = meta
+
+    def save(self):
+        """Store application state data to a file."""
+        logger.debug('Save state data.')
+
+        self._set_save_meta_data()
+
+        with self.file_path().open('w', encoding='utf-8') as handle:
+            json.dump(obj=self._data, fp=handle, indent=4)

--- a/common/state.py
+++ b/common/state.py
@@ -9,10 +9,10 @@
 from __future__ import annotations
 import os
 import json
-import singleton
-import logger
 from pathlib import Path
 from datetime import datetime, timezone
+import singleton
+import logger
 from version import __version__
 
 

--- a/common/state.py
+++ b/common/state.py
@@ -5,7 +5,7 @@
 # This file is part of the program "Back In Time" which is released under GNU
 # General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
-"""Managment of the state file."""
+"""Management of the state file."""
 from __future__ import annotations
 import os
 import json
@@ -19,7 +19,7 @@ from version import __version__
 class StateData(dict, metaclass=singleton.Singleton):
     """Manage state data for Back In Time.
 
-    Dev note (buhtz, 2024-12): It is recommended and prefered to derive from
+    Dev note (buhtz, 2024-12): It is recommended and preferred to derive from
     `collections.UserDict` instead of just `dict`. But this conflicts with the
     ``metaclass=``. To my current knowledge this is not a big deal.
     """
@@ -126,7 +126,7 @@ class StateData(dict, metaclass=singleton.Singleton):
         if not data:
             data = self._EMPTY_STRUCT
 
-        # This will initilize self.data (see UserDict docu)
+        # This will initialize self.data (see UserDict docu)
         super().__init__(data)
 
     def __str__(self):
@@ -193,7 +193,7 @@ class StateData(dict, metaclass=singleton.Singleton):
 
     @property
     def msg_encfs_global(self) -> bool:
-        """If global EncFS deprecation message box was displayed allready."""
+        """If global EncFS deprecation message box was displayed already."""
         return self['message']['encfs']['global']
 
     @msg_encfs_global.setter

--- a/common/state.py
+++ b/common/state.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+"""Managment of the state file."""
+from __future__ import annotations
+import json
+import singleton
+import logger
+
+
+class State(metaclass=singleton.Singleton):
+    """Manage state data for Back In Time.
+    """
+
+    def __init__(self, data: dict):
+        """Constructor."""
+        self._data = data
+
+    def __str__(self):
+        return json.dumps(self._data, indent=4)

--- a/common/state.py
+++ b/common/state.py
@@ -19,10 +19,11 @@ from version import __version__
 class StateData(dict, metaclass=singleton.Singleton):
     """Manage state data for Back In Time.
 
-    Dev note (buhtz, 2024-12): It is recommended and preferred to derive from
-    `collections.UserDict` instead of just `dict`. But this conflicts with the
-    ``metaclass=``. To my current knowledge this is not a big deal and won't
-    introduce any problems.
+    Dev note (buhtz, 2024-12): It is usually recommended and preferred to
+    derive from `collections.UserDict` instead of just `dict`. But this
+    conflicts with the ``metaclass=``. To my current knowledge this is not a
+    big deal and won't introduce any problems.
+
     """
 
     class Profile:
@@ -49,8 +50,8 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         @last_path.setter
         def last_path(self, path: Path) -> None:
-            self._state['gui']['mainwindow'].get(
-                'last_path', {})[self._profile_id] = str(path)
+            self._state['gui']['mainwindow'][
+                'last_path'][self._profile_id] = str(path)
 
         @property
         def places_sorting(self) -> tuple[int, int]:
@@ -64,8 +65,8 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         @places_sorting.setter
         def places_sorting(self, vals: tuple[int, int]) -> None:
-            self._state['gui']['mainwindow'].get(
-                'places_sorting', {})[self._profile_id] = vals
+            self._state['gui']['mainwindow'][
+                'places_sorting'][self._profile_id] = vals
 
         @property
         def exclude_sorting(self) -> tuple[int, int]:
@@ -79,8 +80,8 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         @exclude_sorting.setter
         def exclude_sorting(self, vals: tuple[int, int]) -> None:
-            self._state['gui']['manage_profiles'].get(
-                'excl_sorting', {})[self._profile_id] = vals
+            self._state['gui']['manage_profiles'][
+                'excl_sorting'][self._profile_id] = vals
 
         @property
         def include_sorting(self) -> tuple[int, int]:
@@ -96,13 +97,9 @@ class StateData(dict, metaclass=singleton.Singleton):
         def include_sorting(self, vals: tuple[int, int]) -> None:
             self._state['gui']['manage_profiles'][
                 'incl_sorting'][self._profile_id] = vals
-            # except KeyError as exc:
-            #     # Not because of missing profile id
-            #     if exc.args[0] != self._profile_id:
-            #         raise
 
-            #     raise
-
+    # The default strucutre. All properties do rely on them and assuming
+    # it is there.
     _EMPTY_STRUCT = {
         'gui': {
             'mainwindow': {

--- a/common/state.py
+++ b/common/state.py
@@ -186,7 +186,7 @@ class StateData(dict, metaclass=singleton.Singleton):
         """Last version of Back In Time in which the release candidate message
         box was displayed.
         """
-        return self['message']['release_candidate']
+        return self['message'].get('release_candidate', None)
 
     @msg_release_candidate.setter
     def msg_release_candidate(self, val: str) -> None:
@@ -195,7 +195,7 @@ class StateData(dict, metaclass=singleton.Singleton):
     @property
     def msg_encfs_global(self) -> bool:
         """If global EncFS deprecation message box was displayed already."""
-        return self['message']['encfs']['global']
+        return self['message']['encfs'].get('global', False)
 
     @msg_encfs_global.setter
     def msg_encfs_global(self, val: bool) -> None:
@@ -204,7 +204,7 @@ class StateData(dict, metaclass=singleton.Singleton):
     @property
     def mainwindow_show_hidden(self) -> bool:
         """Show hidden files in files view."""
-        return self['gui']['mainwindow']['show_hidden']
+        return self['gui']['mainwindow'].get('show_hidden', False)
 
     @mainwindow_show_hidden.setter
     def mainwindow_show_hidden(self, val: bool) -> None:
@@ -244,11 +244,20 @@ class StateData(dict, metaclass=singleton.Singleton):
         Returns:
             Tuple with column index and its sorting order (0=ascending).
         """
-        return self['gui']['mainwindow']['files_view']['sorting']
+        return self['gui']['mainwindow']['files_view'].get('sorting', (0, 0))
 
     @files_view_sorting.setter
     def files_view_sorting(self, vals: tuple[int, int]) -> None:
         self['gui']['mainwindow']['files_view']['sorting'] = vals
+
+    @property
+    def files_view_col_widths(self) -> tuple:
+        """Widths of columns in the files view."""
+        return self['gui']['mainwindow']['files_view']['col_widths']
+
+    @files_view_col_widths.setter
+    def files_view_col_widths(self, widths: tuple) -> None:
+        self['gui']['mainwindow']['files_view']['col_widths'] = widths
 
     @property
     def mainwindow_main_splitter_widths(self) -> tuple[int, int]:
@@ -257,7 +266,8 @@ class StateData(dict, metaclass=singleton.Singleton):
         Returns:
             Two entry tuple with right and left widths.
         """
-        return self['gui']['mainwindow']['splitter_main_widths']
+        return self['gui']['mainwindow'] \
+            .get('splitter_main_widths', (150, 450))
 
     @mainwindow_main_splitter_widths.setter
     def mainwindow_main_splitter_widths(self, vals: tuple[int, int]) -> None:
@@ -270,7 +280,8 @@ class StateData(dict, metaclass=singleton.Singleton):
         Returns:
             Two entry tuple with right and left widths.
         """
-        return self['gui']['mainwindow'].get('splitter_second_widths', None)
+        return self['gui']['mainwindow'] \
+            .get('splitter_second_widths', (150, 300))
 
     @mainwindow_second_splitter_widths.setter
     def mainwindow_second_splitter_widths(self, vals: tuple[int, int]) -> None:

--- a/common/state.py
+++ b/common/state.py
@@ -49,8 +49,8 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         @last_path.setter
         def last_path(self, path: Path) -> None:
-            self._state['gui']['mainwindow'][
-                'last_path'][self._profile_id] = str(path)
+            self._state['gui']['mainwindow'].get(
+                'last_path', {})[self._profile_id] = str(path)
 
         @property
         def places_sorting(self) -> tuple[int, int]:
@@ -64,8 +64,8 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         @places_sorting.setter
         def places_sorting(self, vals: tuple[int, int]) -> None:
-            self._state['gui']['mainwindow'][
-                'places_sorting'][self._profile_id] = vals
+            self._state['gui']['mainwindow'].get(
+                'places_sorting', {})[self._profile_id] = vals
 
         @property
         def exclude_sorting(self) -> tuple[int, int]:
@@ -79,8 +79,8 @@ class StateData(dict, metaclass=singleton.Singleton):
 
         @exclude_sorting.setter
         def exclude_sorting(self, vals: tuple[int, int]) -> None:
-            self._state['gui']['manage_profiles'][
-                'excl_sorting'][self._profile_id] = vals
+            self._state['gui']['manage_profiles'].get(
+                'excl_sorting', {})[self._profile_id] = vals
 
         @property
         def include_sorting(self) -> tuple[int, int]:
@@ -96,13 +96,22 @@ class StateData(dict, metaclass=singleton.Singleton):
         def include_sorting(self, vals: tuple[int, int]) -> None:
             self._state['gui']['manage_profiles'][
                 'incl_sorting'][self._profile_id] = vals
+            # except KeyError as exc:
+            #     # Not because of missing profile id
+            #     if exc.args[0] != self._profile_id:
+            #         raise
+
+            #     raise
 
     _EMPTY_STRUCT = {
         'gui': {
             'mainwindow': {
                 'files_view': {},
             },
-            'manage_profiles': {},
+            'manage_profiles': {
+                'incl_sorting': {},
+                'excl_sorting': {},
+            },
             'logview': {},
         },
         'message': {
@@ -124,10 +133,11 @@ class StateData(dict, metaclass=singleton.Singleton):
     def __init__(self, data: dict = None):
         """Constructor."""
 
-        if not data:
+        if data:
+            self._EMPTY_STRUCT.update(data)
+        else:
             data = self._EMPTY_STRUCT
 
-        # This will initialize self.data (see UserDict docu)
         super().__init__(data)
 
     def __str__(self):
@@ -231,7 +241,7 @@ class StateData(dict, metaclass=singleton.Singleton):
     @property
     def logview_dims(self) -> tuple[int, int]:
         """Dimensions of the log view dialog."""
-        return self['gui']['logview']['dims']
+        return self['gui']['logview'].get('dims', (800, 500))
 
     @logview_dims.setter
     def logview_dims(self, vals: tuple[int, int]) -> None:

--- a/common/statedata.py
+++ b/common/statedata.py
@@ -25,6 +25,23 @@ class StateData(dict, metaclass=singleton.Singleton):
     big deal and won't introduce any problems.
 
     """
+    # The default structure. All properties do rely on them and assuming
+    # it is there.
+    _EMPTY_STRUCT = {
+        'gui': {
+            'mainwindow': {
+                'files_view': {},
+            },
+            'manage_profiles': {
+                'incl_sorting': {},
+                'excl_sorting': {},
+            },
+            'logview': {},
+        },
+        'message': {
+            'encfs': {}
+        },
+    }
 
     class Profile:
         """A surrogate to access profile-specific state data."""
@@ -97,24 +114,6 @@ class StateData(dict, metaclass=singleton.Singleton):
         def include_sorting(self, vals: tuple[int, int]) -> None:
             self._state['gui']['manage_profiles'][
                 'incl_sorting'][self._profile_id] = vals
-
-    # The default strucutre. All properties do rely on them and assuming
-    # it is there.
-    _EMPTY_STRUCT = {
-        'gui': {
-            'mainwindow': {
-                'files_view': {},
-            },
-            'manage_profiles': {
-                'incl_sorting': {},
-                'excl_sorting': {},
-            },
-            'logview': {},
-        },
-        'message': {
-            'encfs': {}
-        },
-    }
 
     @staticmethod
     def file_path() -> Path:

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -45,11 +45,13 @@ full_test_files = [_base_dir / fp for fp in (
     'bitbase.py',
     'languages.py',
     'schedule.py',
+    'singleton.py',
     'ssh_max_arg.py',
     'state.py',
     'version.py',
     'test/test_lint.py',
     'test/test_mount.py',
+    'test/test_singleton.py',
     'test/test_uniquenessset.py',
 )]
 

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -47,7 +47,7 @@ full_test_files = [_base_dir / fp for fp in (
     'schedule.py',
     'singleton.py',
     'ssh_max_arg.py',
-    'state.py',
+    'statedata.py',
     'version.py',
     'test/test_lint.py',
     'test/test_mount.py',

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -45,6 +45,7 @@ full_test_files = [_base_dir / fp for fp in (
     'languages.py',
     'schedule.py',
     'ssh_max_arg.py',
+    'state.py',
     'version.py',
     'test/test_lint.py',
     'test/test_mount.py',

--- a/common/test/test_singleton.py
+++ b/common/test/test_singleton.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In time" which is released under GNU
+# General Public License v2 (GPLv2).
+# See file LICENSE or go to <https://www.gnu.org/licenses/#GPL>.
+"""Tests about singleton module."""
+# pylint: disable=missing-class-docstring,too-few-public-methods
+import unittest
+import singleton
+
+
+class Test(unittest.TestCase):
+    class Foo(metaclass=singleton.Singleton):
+        def __init__(self):
+            self.value = 'Ogawa'
+
+    class Bar(metaclass=singleton.Singleton):
+        def __init__(self):
+            self.value = 'Naomi'
+
+    def setUp(self):
+        # Clean up all instances
+        singleton.Singleton._instances = {}  # pylint: disable=protected-access
+
+    def test_twins(self):
+        """Identical id and values."""
+        a = self.Foo()
+        b = self.Foo()
+
+        self.assertEqual(id(a), id(b))
+        self.assertEqual(a.value, b.value)
+
+    def test_share_value(self):
+        """Modify value"""
+        a = self.Foo()
+        b = self.Foo()
+        a.value = 'foobar'
+
+        self.assertEqual(a.value, 'foobar')
+        self.assertEqual(a.value, b.value)
+
+    def test_multi_class(self):
+        """Two different singleton classes."""
+        a = self.Foo()
+        b = self.Foo()
+        x = self.Bar()
+        y = self.Bar()
+
+        self.assertEqual(id(a), id(b))
+        self.assertEqual(id(x), id(y))
+        self.assertNotEqual(id(a), id(y))
+
+        self.assertEqual(a.value, 'Ogawa')
+        self.assertEqual(x.value, 'Naomi')
+
+        a.value = 'who'
+        self.assertEqual(b.value, 'who')
+        self.assertEqual(x.value, 'Naomi')
+        self.assertEqual(x.value, y.value)

--- a/qt/app.py
+++ b/qt/app.py
@@ -126,6 +126,8 @@ class MainWindow(QMainWindow):
         self._create_menubar()
         self._create_main_toolbar()
 
+        state_data = StateData()
+
         # timeline (left widget)
         self.timeLine = qttools.TimeLine(self)
         self.timeLine.updateFilesView.connect(self.updateFilesView)
@@ -220,13 +222,17 @@ class MainWindow(QMainWindow):
         self.filesViewDelegate = QStyledItemDelegate(self)
         self.filesView.setItemDelegate(self.filesViewDelegate)
 
-        sortColumn = self.config.intValue(
-            'qt.main_window.files_view.sort.column', 0)
-        sortOrder = self.config.boolValue(
-            'qt.main_window.files_view.sort.ascending', True)
-        sortOrder = Qt.SortOrder.AscendingOrder if sortOrder else Qt.SortOrder.DescendingOrder
+        try:
+            sortColumn = state_data['gui']['mainwindow'][
+                'files_view']['sort_column']
+            sortOrder = state_data['gui']['mainwindow'][
+                'files_view']['sort_order']
+        except KeyError:
+            sortColumn = 0
+            sortOrder = 0
 
-        self.filesView.header().setSortIndicator(sortColumn, sortOrder)
+        self.filesView.header().setSortIndicator(
+            sortColumn, Qt.SortOrder(sortOrder))
         self.filesViewModel.sort(
             self.filesView.header().sortIndicatorSection(),
             self.filesView.header().sortIndicatorOrder())
@@ -291,8 +297,6 @@ class MainWindow(QMainWindow):
         self.widget_current_path.setText(self.path)
         self.path_history = tools.PathHistory(self.path)
 
-        state_data = StateData()
-
         # restore position and size
         try:
             self.move(*state_data['gui']['mainwindow']['coords'])
@@ -300,33 +304,29 @@ class MainWindow(QMainWindow):
         except KeyError:
             pass
 
-        mainSplitterLeftWidth = self.config.intValue(
-            'qt.main_window.main_splitter_left_w', 150)
-        mainSplitterRightWidth = self.config.intValue(
-            'qt.main_window.main_splitter_right_w', 450)
-        sizes = [mainSplitterLeftWidth, mainSplitterRightWidth]
-        self.mainSplitter.setSizes(sizes)
+        try:
+            main_splitter_widths \
+                = state_data['gui']['mainwindow']['splitter_main_widths']
+        except KeyError:
+            main_splitter_widths = (150, 450)
+        self.mainSplitter.setSizes(main_splitter_widths)
 
-        secondSplitterLeftWidth = self.config.intValue(
-            'qt.main_window.second_splitter_left_w', 150)
-        secondSplitterRightWidth = self.config.intValue(
-            'qt.main_window.second_splitter_right_w', 300)
-        sizes = [secondSplitterLeftWidth, secondSplitterRightWidth]
-        self.secondSplitter.setSizes(sizes)
+        try:
+            second_splitter_widths \
+                = state_data['gui']['mainwindow']['splitter_second_widths']
+        except KeyError:
+            second_splitter_widths = (150, 300)
+        self.secondSplitter.setSizes(second_splitter_widths)
 
-        filesViewColumnNameWidth = self.config.intValue(
-            'qt.main_window.files_view.name_width', -1)
-        filesViewColumnSizeWidth = self.config.intValue(
-            'qt.main_window.files_view.size_width', -1)
-        filesViewColumnDateWidth = self.config.intValue(
-            'qt.main_window.files_view.date_width', -1)
-
-        if (filesViewColumnNameWidth > 0
-                and filesViewColumnSizeWidth > 0
-                and filesViewColumnDateWidth > 0):
-            self.filesView.header().resizeSection(0, filesViewColumnNameWidth)
-            self.filesView.header().resizeSection(1, filesViewColumnSizeWidth)
-            self.filesView.header().resizeSection(2, filesViewColumnDateWidth)
+        # FilesView: Column width
+        try:
+            files_view_col_widths = state_data['gui']['mainwindow'][
+                'files_view']['col_widths']
+        except KeyError:
+            pass
+        else:
+            for idx, width in enumerate(files_view_col_widths):
+                self.filesView.header().resizeSection(idx, width)
 
         # Force dialog to import old configuration
         if not config.isConfigured():
@@ -416,8 +416,12 @@ class MainWindow(QMainWindow):
         state_data.decrement_manual_starts_countdown()
 
         # If the encfs-deprecation warning was never shown before
-        if state_data['message']['encfs']['global'] is False:
+        try:
+            msg_encfs_global_shown = state_data['message']['encfs']['global']
+        except KeyError:
+            msg_encfs_global_shown = False
 
+        if msg_encfs_global_shown is False:
             # Are there profiles using EncFS?
             encfs_profiles = []
             for pid in self.config.profiles():
@@ -833,6 +837,8 @@ class MainWindow(QMainWindow):
         return toolbar
 
     def closeEvent(self, event):
+        state_data = StateData()
+
         if self.shutdown.askBeforeQuit():
             msg = _('If you close this window, Back In Time will not be able '
                     'to shut down your system when the snapshot is finished.')
@@ -855,26 +861,26 @@ class MainWindow(QMainWindow):
         state_data['gui']['mainwindow']['coords'] = (self.x(), self.y())
         state_data['gui']['mainwindow']['dims'] = (self.width(), self.height())
 
-        sizes = self.mainSplitter.sizes()
-        self.config.setIntValue('qt.main_window.main_splitter_left_w', sizes[0])
-        self.config.setIntValue('qt.main_window.main_splitter_right_w', sizes[1])
+        state_data['gui']['mainwindow']['splitter_main_widths'] \
+            = self.mainSplitter.sizes()
+        state_data['gui']['mainwindow']['splitter_second_widths'] \
+            = self.secondSplitter.sizes()
 
-        sizes = self.secondSplitter.sizes()
-        self.config.setIntValue('qt.main_window.second_splitter_left_w', sizes[0])
-        self.config.setIntValue('qt.main_window.second_splitter_right_w', sizes[1])
+        state_data['gui']['mainwindow']['files_view']['col_widths'] \
+            = [self.filesView.header().sectionSize(idx)
+               for idx
+               in range(self.filesView.header().count())]
 
-        self.config.setIntValue('qt.main_window.files_view.name_width', self.filesView.header().sectionSize(0))
-        self.config.setIntValue('qt.main_window.files_view.size_width', self.filesView.header().sectionSize(1))
-        self.config.setIntValue('qt.main_window.files_view.date_width', self.filesView.header().sectionSize(2))
-
-        self.config.setIntValue('qt.main_window.files_view.sort.column', self.filesView.header().sortIndicatorSection())
-        self.config.setBoolValue('qt.main_window.files_view.sort.ascending', self.filesView.header().sortIndicatorOrder() == Qt.SortOrder.AscendingOrder)
+        state_data['gui']['mainwindow']['files_view']['sort_column'] \
+            = self.filesView.header().sortIndicatorSection()
+        state_data['gui']['mainwindow']['files_view']['sort_order'] \
+            = self.filesView.header().sortIndicatorOrder().value
 
         self.filesViewModel.deleteLater()
 
-        #umount
+        # umount
         try:
-            mnt = mount.Mount(cfg = self.config, parent = self)
+            mnt = mount.Mount(cfg=self.config, parent=self)
             mnt.umount(self.config.current_hash_id)
         except MountException as ex:
             messagebox.critical(self, str(ex))

--- a/qt/app.py
+++ b/qt/app.py
@@ -294,15 +294,14 @@ class MainWindow(QMainWindow):
         self.widget_current_path.setText(self.path)
         self.path_history = tools.PathHistory(self.path)
 
-        # restore size and position
-        x = self.config.intValue('qt.main_window.x', -1)
-        y = self.config.intValue('qt.main_window.y', -1)
-        if x >= 0 and y >= 0:
-            self.move(x, y)
+        state_data = StateData()
 
-        w = self.config.intValue('qt.main_window.width', 800)
-        h = self.config.intValue('qt.main_window.height', 500)
-        self.resize(w, h)
+        # restore position and size
+        try:
+            self.move(*state_data['gui']['mainwindow']['coords'])
+            self.resize(*state_data['gui']['mainwindow']['dims'])
+        except KeyError:
+            pass
 
         mainSplitterLeftWidth = self.config.intValue(
             'qt.main_window.main_splitter_left_w', 150)
@@ -403,8 +402,6 @@ class MainWindow(QMainWindow):
         self.timerUpdateTakeSnapshot.start()
 
         SetupCron(self).start()
-
-        state_data = StateData()
 
         # Finished countdown of manual GUI starts
         if 0 == state_data.manual_starts_countdown():
@@ -848,6 +845,8 @@ class MainWindow(QMainWindow):
             if answer != QMessageBox.StandardButton.Yes:
                 return event.ignore()
 
+        state_data = StateData()
+
         self.config.setStrValue('qt.last_path', self.path)
         self.config.setProfileStrValue('qt.last_path', self.path)
 
@@ -858,10 +857,9 @@ class MainWindow(QMainWindow):
             'qt.places.SortOrder',
             self.places.header().sortIndicatorOrder())
 
-        self.config.setIntValue('qt.main_window.x', self.x())
-        self.config.setIntValue('qt.main_window.y', self.y())
-        self.config.setIntValue('qt.main_window.width', self.width())
-        self.config.setIntValue('qt.main_window.height', self.height())
+        # store position and size
+        state_data['gui']['mainwindow']['coords'] = (self.x(), self.y())
+        state_data['gui']['mainwindow']['dims'] = (self.width(), self.height())
 
         sizes = self.mainSplitter.sizes()
         self.config.setIntValue('qt.main_window.main_splitter_left_w', sizes[0])

--- a/qt/app.py
+++ b/qt/app.py
@@ -222,14 +222,7 @@ class MainWindow(QMainWindow):
         self.filesViewDelegate = QStyledItemDelegate(self)
         self.filesView.setItemDelegate(self.filesViewDelegate)
 
-        try:
-            sortColumn = state_data['gui']['mainwindow'][
-                'files_view']['sort_column']
-            sortOrder = state_data['gui']['mainwindow'][
-                'files_view']['sort_order']
-        except KeyError:
-            sortColumn = 0
-            sortOrder = 0
+        sortColumn, sortOrder = state_data.files_view_sorting
 
         self.filesView.header().setSortIndicator(
             sortColumn, Qt.SortOrder(sortOrder))
@@ -299,29 +292,19 @@ class MainWindow(QMainWindow):
 
         # restore position and size
         try:
-            self.move(*state_data['gui']['mainwindow']['coords'])
-            self.resize(*state_data['gui']['mainwindow']['dims'])
+            self.move(*state_data.mainwindow_coords)
+            self.resize(*state_data.mainwindow_dims)
         except KeyError:
             pass
 
-        try:
-            main_splitter_widths \
-                = state_data['gui']['mainwindow']['splitter_main_widths']
-        except KeyError:
-            main_splitter_widths = (150, 450)
-        self.mainSplitter.setSizes(main_splitter_widths)
-
-        try:
-            second_splitter_widths \
-                = state_data['gui']['mainwindow']['splitter_second_widths']
-        except KeyError:
-            second_splitter_widths = (150, 300)
-        self.secondSplitter.setSizes(second_splitter_widths)
+        self.mainSplitter.setSizes(
+            state_data.mainwindow_main_splitter_widths)
+        self.secondSplitter.setSizes(
+            state_data.mainwindow_second_splitter_widths)
 
         # FilesView: Column width
         try:
-            files_view_col_widths = state_data['gui']['mainwindow'][
-                'files_view']['col_widths']
+            files_view_col_widths = state_data.files_view_col_widths
         except KeyError:
             pass
         else:
@@ -416,12 +399,7 @@ class MainWindow(QMainWindow):
         state_data.decrement_manual_starts_countdown()
 
         # If the encfs-deprecation warning was never shown before
-        try:
-            msg_encfs_global_shown = state_data['message']['encfs']['global']
-        except KeyError:
-            msg_encfs_global_shown = False
-
-        if msg_encfs_global_shown is False:
+        if state_data.msg_encfs_global is False:
             # Are there profiles using EncFS?
             encfs_profiles = []
             for pid in self.config.profiles():
@@ -433,29 +411,24 @@ class MainWindow(QMainWindow):
             if encfs_profiles:
                 dlg = encfsmsgbox.EncfsExistsWarning(self, encfs_profiles)
                 dlg.exec()
-                state_data['message']['encfs']['global'] = True
+                state_data.msg_encfs_global = True
 
         # Release Candidate
         if version.is_release_candidate():
-            last_vers = state_data['message']['release_candidate']
+            last_vers = state_data.msg_release_candidate
             if last_vers != version.__version__:
-                state_data['message']['release_candidate'] \
-                    = version.__version__
+                state_data.msg_release_candidate = version.__version__
                 self._open_release_candidate_dialog()
 
     @property
     def showHiddenFiles(self):
         state_data = StateData()
-        try:
-            return state_data['gui']['mainwindow']['show_hidden']
-        except KeyError:
-            # default
-            return False
+        return state_data.mainwindow_show_hidden
 
     @showHiddenFiles.setter
     def showHiddenFiles(self, value):
         state_data = StateData()
-        state_data['gui']['mainwindow']['show_hidden'] = value
+        state_data.mainwindow_show_hidden = value
 
     def _create_actions(self):
         """Create all action objects used by this main window.
@@ -838,6 +811,7 @@ class MainWindow(QMainWindow):
 
     def closeEvent(self, event):
         state_data = StateData()
+        profile_state = state_data.profile(self.config.current_profile_id)
 
         if self.shutdown.askBeforeQuit():
             msg = _('If you close this window, Back In Time will not be able '
@@ -848,33 +822,26 @@ class MainWindow(QMainWindow):
             if answer != QMessageBox.StandardButton.Yes:
                 return event.ignore()
 
-        self.config.setProfileStrValue('qt.last_path', self.path)
+        profile_state.last_path = pathlib.Path(self.path)
+        profile_state.places_sorting = (
+            self.places.header().sortIndicatorSection(),
+            self.places.header().sortIndicatorOrder().value,
+        )
 
-        self.config.setProfileIntValue(
-            'qt.places.SortColumn',
-            self.places.header().sortIndicatorSection())
-        self.config.setProfileIntValue(
-            'qt.places.SortOrder',
-            self.places.header().sortIndicatorOrder())
-
-        # store position and size
-        state_data['gui']['mainwindow']['coords'] = (self.x(), self.y())
-        state_data['gui']['mainwindow']['dims'] = (self.width(), self.height())
-
-        state_data['gui']['mainwindow']['splitter_main_widths'] \
-            = self.mainSplitter.sizes()
-        state_data['gui']['mainwindow']['splitter_second_widths'] \
+        state_data.mainwindow_coords = (self.x(), self.y())
+        state_data.mainwindow_dims = (self.width(), self.height())
+        state_data.mainwindow_main_splitter_widths = self.mainSplitter.sizes()
+        state_data.mainwindow_second_splitter_widths \
             = self.secondSplitter.sizes()
-
-        state_data['gui']['mainwindow']['files_view']['col_widths'] \
-            = [self.filesView.header().sectionSize(idx)
-               for idx
-               in range(self.filesView.header().count())]
-
-        state_data['gui']['mainwindow']['files_view']['sort_column'] \
-            = self.filesView.header().sortIndicatorSection()
-        state_data['gui']['mainwindow']['files_view']['sort_order'] \
-            = self.filesView.header().sortIndicatorOrder().value
+        state_data.files_view_col_widths = [
+            self.filesView.header().sectionSize(idx)
+            for idx
+            in range(self.filesView.header().count())
+        ]
+        state_data.files_view_sorting = (
+            self.filesView.header().sortIndicatorSection(),
+            self.filesView.header().sortIndicatorOrder().value
+        )
 
         self.filesViewModel.deleteLater()
 
@@ -1721,7 +1688,7 @@ class MainWindow(QMainWindow):
         if sid:
             sid = '_' + sid.sid
 
-        d = TemporaryDirectory(prefix='backintime_', suffix = sid)
+        d = TemporaryDirectory(prefix='backintime_', suffix=sid)
         tmp_file = os.path.join(d.name, os.path.basename(full_path))
 
         if os.path.isdir(full_path):
@@ -1758,13 +1725,24 @@ class MainWindow(QMainWindow):
                 self.run = QDesktopServices.openUrl(file_url)
 
     @pyqtSlot(int)
-    def updateFilesView(self, changed_from, selected_file = None, show_snapshots = False): #0 - files view change directory, 1 - files view, 2 - time_line, 3 - places
+    def updateFilesView(self,
+                        changed_from,
+                        selected_file=None,
+                        show_snapshots=False):
+        """
+        changed_from? WTF!
+            0 - files view change directory,
+            1 - files view,
+            2 - time_line,
+            3 - places
+        """
         if 0 == changed_from or 3 == changed_from:
             selected_file = ''
 
         if 0 == changed_from:
             # update places
             self.places.setCurrentItem(None)
+
             for place_index in range(self.places.topLevelItemCount()):
                 item = self.places.topLevelItem(place_index)
                 if self.path == str(item.data(0, Qt.ItemDataRole.UserRole)):
@@ -1774,6 +1752,7 @@ class MainWindow(QMainWindow):
         text = ''
         if self.sid.isRoot:
             text = _('Now')
+
         else:
             name = self.sid.displayName
             # buhtz (2023-07)3 blanks at the end of that string as a
@@ -1794,8 +1773,10 @@ class MainWindow(QMainWindow):
         full_path = self.sid.pathBackup(self.path)
 
         if os.path.isdir(full_path):
+
             if self.showHiddenFiles:
                 self.filesViewProxyModel.setFilterRegularExpression(r'')
+
             else:
                 self.filesViewProxyModel.setFilterRegularExpression(r'^[^\.]')
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -22,17 +22,13 @@ import shutil
 import signal
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
-
 # We need to import common/tools.py
 import qttools_path
 qttools_path.registerBackintimePath('common')
-
 # Workaround until the codebase is rectified/equalized.
 import tools
 tools.initiate_translation(None)
-
 import qttools
-
 import backintime
 import tools
 import logger
@@ -42,7 +38,7 @@ import mount
 import progress
 import encfsmsgbox
 from exceptions import MountException
-
+from state import StateData
 from PyQt6.QtGui import (QAction,
                          QShortcut,
                          QDesktopServices,
@@ -408,8 +404,10 @@ class MainWindow(QMainWindow):
 
         SetupCron(self).start()
 
+        state_data = StateData()
+
         # Finished countdown of manual GUI starts
-        if 0 == self.config.manual_starts_countdown():
+        if 0 == state_data.manual_starts_countdown():
 
             # Do nothing if English is the current used language
             if self.config.language_used != 'en':
@@ -421,10 +419,10 @@ class MainWindow(QMainWindow):
         # BIT counts down how often the GUI was started. Until the end of that
         # countdown a dialog with a text about contributing to translating
         # BIT is presented to the users.
-        self.config.decrement_manual_starts_countdown()
+        state_data.decrement_manual_starts_countdown()
 
         # If the encfs-deprecation warning was never shown before
-        if self.config.boolValue('internal.msg_shown_encfs') == False:
+        if state_data['message']['encfs']['global'] is False:
 
             # Are there profiles using EncFS?
             encfs_profiles = []
@@ -437,23 +435,29 @@ class MainWindow(QMainWindow):
             if encfs_profiles:
                 dlg = encfsmsgbox.EncfsExistsWarning(self, encfs_profiles)
                 dlg.exec()
-                self.config.setBoolValue('internal.msg_shown_encfs', True)
+                state_data['message']['encfs']['global'] = True
 
         # Release Candidate
         if version.is_release_candidate():
-            last_vers = self.config.strValue('internal.msg_rc')
+            last_vers = state_data['message']['release_candidate']
             if last_vers != version.__version__:
-                self.config.setStrValue('internal.msg_rc', version.__version__)
+                state_data['message']['release_candidate'] \
+                    = version.__version__
                 self._open_release_candidate_dialog()
 
     @property
     def showHiddenFiles(self):
-        return self.config.boolValue('qt.show_hidden_files', False)
+        state_data = StateData()
+        try:
+            return state_data['gui']['mainwindow']['show_hidden']
+        except KeyError:
+            # default
+            return False
 
-    # TODO The qt.show_hidden_files key should be a constant instead of a duplicated string
     @showHiddenFiles.setter
     def showHiddenFiles(self, value):
-        self.config.setBoolValue('qt.show_hidden_files', value)
+        state_data = StateData()
+        state_data['gui']['mainwindow']['show_hidden'] = value
 
     def _create_actions(self):
         """Create all action objects used by this main window.

--- a/qt/app.py
+++ b/qt/app.py
@@ -2136,6 +2136,7 @@ class ExtraMouseButtonEventFilter(QObject):
             return super(ExtraMouseButtonEventFilter, self) \
                 .eventFilter(receiver, event)
 
+
 class RemoveSnapshotThread(QThread):
     """
     remove snapshots in background thread so GUI will not freeze

--- a/qt/app.py
+++ b/qt/app.py
@@ -38,7 +38,7 @@ import mount
 import progress
 import encfsmsgbox
 from exceptions import MountException
-from state import StateData
+from statedata import StateData
 from PyQt6.QtGui import (QAction,
                          QShortcut,
                          QDesktopServices,

--- a/qt/app.py
+++ b/qt/app.py
@@ -383,7 +383,7 @@ class MainWindow(QMainWindow):
 
         SetupCron(self).start()
 
-        # Finished countdown of manual GUI starts
+        # Countdown of manual GUI starts finished?
         if 0 == state_data.manual_starts_countdown():
 
             # Do nothing if English is the current used language

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -25,6 +25,7 @@ import encfstools
 import snapshotlog
 import tools
 import qttools
+from state import StateData
 
 
 class LogViewDialog(QDialog):
@@ -50,9 +51,8 @@ class LogViewDialog(QDialog):
         self.enableUpdate = False
         self.decode = None
 
-        w = self.config.intValue('qt.logview.width', 800)
-        h = self.config.intValue('qt.logview.height', 500)
-        self.resize(w, h)
+        state_data = StateData()
+        self.resize(*state_data['gui']['logview'].get('dims', (800, 500)))
 
         import icon
         self.setWindowIcon(icon.VIEW_SNAPSHOT_LOG)
@@ -102,13 +102,17 @@ class LogViewDialog(QDialog):
         # "Few" in Polish.
         # Research in translation community indicate this as the best fit to
         # the meaning of "all".
-        self.comboFilter.addItem(' + '.join((_('Errors'), _('Changes'))), snapshotlog.LogFilter.ERROR_AND_CHANGES)
+        self.comboFilter.addItem(
+            ' + '.join((_('Errors'), _('Changes'))),
+            snapshotlog.LogFilter.ERROR_AND_CHANGES)
         self.comboFilter.setCurrentIndex(self.comboFilter.count() - 1)
         self.comboFilter.addItem(_('Errors'), snapshotlog.LogFilter.ERROR)
         self.comboFilter.addItem(_('Changes'), snapshotlog.LogFilter.CHANGES)
         self.comboFilter.addItem(ngettext('Information', 'Information', 2),
                                  snapshotlog.LogFilter.INFORMATION)
-        self.comboFilter.addItem(_('rsync transfer failures (experimental)'), snapshotlog.LogFilter.RSYNC_TRANSFER_FAILURES)
+        self.comboFilter.addItem(
+            _('rsync transfer failures (experimental)'),
+            snapshotlog.LogFilter.RSYNC_TRANSFER_FAILURES)
 
         # text view
         self.txtLogView = QPlainTextEdit(self)
@@ -247,6 +251,6 @@ class LogViewDialog(QDialog):
             self.txtLogView.setPlainText('\n'.join(self.sid.log(mode, decode = self.decode)))
 
     def closeEvent(self, event):
-        self.config.setIntValue('qt.logview.width', self.width())
-        self.config.setIntValue('qt.logview.height', self.height())
+        state_data = StateData()
+        state_data['gui']['logview']['dims'] = (self.width(), self.height())
         event.accept()

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -25,7 +25,7 @@ import encfstools
 import snapshotlog
 import tools
 import qttools
-from state import StateData
+from statedata import StateData
 
 
 class LogViewDialog(QDialog):

--- a/qt/logviewdialog.py
+++ b/qt/logviewdialog.py
@@ -52,7 +52,7 @@ class LogViewDialog(QDialog):
         self.decode = None
 
         state_data = StateData()
-        self.resize(*state_data['gui']['logview'].get('dims', (800, 500)))
+        self.resize(*state_data.logview_dims)
 
         import icon
         self.setWindowIcon(icon.VIEW_SNAPSHOT_LOG)
@@ -228,29 +228,37 @@ class LogViewDialog(QDialog):
 
         mode = self.comboFilter.itemData(self.comboFilter.currentIndex())
 
-        # TODO This expressions is hard to understand (watchPath is not a boolean!)
+        # TODO This expressions is hard to understand (watchPath is not a
+        # boolean!)
         if watchPath and self.sid is None:
-            # remove path from watch to prevent multiple updates at the same time
+            # remove path from watch to prevent multiple updates at the same
+            # time
             self.watcher.removePath(watchPath)
             # append only new lines to txtLogView
-            log = snapshotlog.SnapshotLog(self.config, self.comboProfiles.currentProfileID())
-            for line in log.get(mode = mode,
-                                decode = self.decode,
-                                skipLines = self.txtLogView.document().lineCount() - 1):
+            log = snapshotlog.SnapshotLog(
+                self.config, self.comboProfiles.currentProfileID())
+            for line in log.get(mode=mode,
+                                decode=self.decode,
+                                skipLines=self.txtLogView.document().lineCount()-1):
                 self.txtLogView.appendPlainText(line)
 
             # re-add path to watch after 5sec delay
-            alarm = tools.Alarm(callback = lambda: self.watcher.addPath(watchPath),
-                                overwrite = False)
+            alarm = tools.Alarm(
+                callback=lambda: self.watcher.addPath(watchPath),
+                overwrite=False)
             alarm.start(5)
 
         elif self.sid is None:
-            log = snapshotlog.SnapshotLog(self.config, self.comboProfiles.currentProfileID())
-            self.txtLogView.setPlainText('\n'.join(log.get(mode = mode, decode = self.decode)))
+            log = snapshotlog.SnapshotLog(
+                self.config, self.comboProfiles.currentProfileID())
+            self.txtLogView.setPlainText(
+                '\n'.join(log.get(mode=mode, decode=self.decode)))
+
         else:
-            self.txtLogView.setPlainText('\n'.join(self.sid.log(mode, decode = self.decode)))
+            self.txtLogView.setPlainText(
+                '\n'.join(self.sid.log(mode, decode=self.decode)))
 
     def closeEvent(self, event):
         state_data = StateData()
-        state_data['gui']['logview']['dims'] = (self.width(), self.height())
+        state_data.logview_dims = (self.width(), self.height())
         event.accept()

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -402,20 +402,11 @@ class SettingsDialog(QDialog):
         self.cbExcludeBySize.setChecked(self.config.excludeBySizeEnabled())
         self.spbExcludeBySize.setValue(self.config.excludeBySize())
 
-        # excludeSortColumn = int(self.config.profileIntValue(
-        #     'qt.settingsdialog.exclude.SortColumn', 1))
-        # excludeSortOrder = Qt.SortOrder(
-        #     self.config.profileIntValue('qt.settingsdialog.exclude.SortOrder',
-        #                                 Qt.SortOrder.AscendingOrder)
-        # )
-        # self.listExclude.sortItems(excludeSortColumn, excludeSortOrder)
-
         try:
             incl_sort = profile_state.include_sorting
             excl_sort = profile_state.exclude_sorting
             self.listInclude.sortItems(
-                incl_sort[0],
-                Qt.SortOrder(incl_sort[1])
+                incl_sort[0], Qt.SortOrder(incl_sort[1])
             )
             self.listExclude.sortItems(
                 excl_sort[0], Qt.SortOrder(excl_sort[1]))

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -35,6 +35,7 @@ from PyQt6.QtCore import Qt
 import tools
 import qttools
 import messagebox
+from state import StateData
 from manageprofiles.tab_general import GeneralTab
 from manageprofiles.tab_auto_remove import AutoRemoveTab
 from manageprofiles.tab_options import OptionsTab
@@ -382,6 +383,8 @@ class SettingsDialog(QDialog):
             self.btnRemoveProfile.setEnabled(True)
         self.btnAddProfile.setEnabled(self.config.isConfigured('1'))
 
+        profile_state = StateData().profile(self.config.currentProfile())
+
         # TAB: General
         self._tab_general.load_values()
 
@@ -391,16 +394,6 @@ class SettingsDialog(QDialog):
         for include in self.config.include():
             self.addInclude(include)
 
-        includeSortColumn = int(
-            self.config.profileIntValue('qt.settingsdialog.include.SortColumn',
-                                        1)
-        )
-        includeSortOrder = Qt.SortOrder(
-            self.config.profileIntValue('qt.settingsdialog.include.SortOrder',
-                                        Qt.SortOrder.AscendingOrder)
-        )
-        self.listInclude.sortItems(includeSortColumn, includeSortOrder)
-
         # TAB: Exclude
         self.listExclude.clear()
 
@@ -409,13 +402,26 @@ class SettingsDialog(QDialog):
         self.cbExcludeBySize.setChecked(self.config.excludeBySizeEnabled())
         self.spbExcludeBySize.setValue(self.config.excludeBySize())
 
-        excludeSortColumn = int(self.config.profileIntValue(
-            'qt.settingsdialog.exclude.SortColumn', 1))
-        excludeSortOrder = Qt.SortOrder(
-            self.config.profileIntValue('qt.settingsdialog.exclude.SortOrder',
-                                        Qt.SortOrder.AscendingOrder)
-        )
-        self.listExclude.sortItems(excludeSortColumn, excludeSortOrder)
+        # excludeSortColumn = int(self.config.profileIntValue(
+        #     'qt.settingsdialog.exclude.SortColumn', 1))
+        # excludeSortOrder = Qt.SortOrder(
+        #     self.config.profileIntValue('qt.settingsdialog.exclude.SortOrder',
+        #                                 Qt.SortOrder.AscendingOrder)
+        # )
+        # self.listExclude.sortItems(excludeSortColumn, excludeSortOrder)
+
+        try:
+            incl_sort = profile_state.include_sorting
+            excl_sort = profile_state.exclude_sorting
+            self.listInclude.sortItems(
+                incl_sort[0],
+                Qt.SortOrder(incl_sort[1])
+            )
+            self.listExclude.sortItems(
+                excl_sort[0], Qt.SortOrder(excl_sort[1]))
+        except KeyError:
+            pass
+
         self._update_exclude_recommend_label()
 
         self._tab_auto_remove.load_values()
@@ -437,13 +443,14 @@ class SettingsDialog(QDialog):
         if success is False:
             return False
 
+        profile_state = StateData().profile(self.config.currentProfile())
+
         # include list
-        self.config.setProfileIntValue(
-            'qt.settingsdialog.include.SortColumn',
-            self.listInclude.header().sortIndicatorSection())
-        self.config.setProfileIntValue(
-            'qt.settingsdialog.include.SortOrder',
-            self.listInclude.header().sortIndicatorOrder())
+        profile_state.include_sorting = (
+            self.listInclude.header().sortIndicatorSection(),
+            self.listInclude.header().sortIndicatorOrder().value
+        )
+        # Why?
         self.listInclude.sortItems(1, Qt.SortOrder.AscendingOrder)
 
         include_list = []
@@ -455,12 +462,11 @@ class SettingsDialog(QDialog):
         self.config.setInclude(include_list)
 
         # exclude patterns
-        self.config.setProfileIntValue(
-            'qt.settingsdialog.exclude.SortColumn',
-            self.listExclude.header().sortIndicatorSection())
-        self.config.setProfileIntValue(
-            'qt.settingsdialog.exclude.SortOrder',
-            self.listExclude.header().sortIndicatorOrder())
+        profile_state.exclude_sorting = (
+            self.listExclude.header().sortIndicatorSection(),
+            self.listExclude.header().sortIndicatorOrder().value
+        )
+        # Why?
         self.listExclude.sortItems(1, Qt.SortOrder.AscendingOrder)
 
         exclude_list = []

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -35,7 +35,7 @@ from PyQt6.QtCore import Qt
 import tools
 import qttools
 import messagebox
-from state import StateData
+from statedata import StateData
 from manageprofiles.tab_general import GeneralTab
 from manageprofiles.tab_auto_remove import AutoRemoveTab
 from manageprofiles.tab_options import OptionsTab


### PR DESCRIPTION
This introduce a state file at `$XDG_STATE_HOME/backintime.json` in JSON format. Several fields from the config file `$XDG_CONFIG_HOME/backintime/config` are moved into it.

Fix also a minor GUI bug where the width of the fourth column ("Date") in files view was not stored between sessions.

This PR is in preparation of #1850 (introduce a new configuration management).