### PR TITLE
feat(doc): Open user manual from the GUI

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Feature: Open user manual (local if available otherwise online) via Help menu
 * Fix: Snapshot compare copy symlink as symlink (#1902) (Peter Sevens @sevens)
 * Fix: Crash when comparing a snapshot with a symlink pointing to a nonexistent target (Peter Sevens @sevens)
 * Fix: Crash (KeyError) opening language setup dialog with unknown locale/language

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -6,14 +6,17 @@
 # General Public License v2 (GPLv2). See file/folder LICENSE or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Basic constants used in multiple modules."""
-
 from enum import Enum
+from pathlib import Path
 
 # See issue #1734 and #1735
 URL_ENCRYPT_TRANSITION = 'https://github.com/bit-team/backintime' \
                          '/blob/-/doc/ENCRYPT_TRANSITION.md'
 
-URL_USER_MANUAL = 'https://github.com/bit-team/backintime/'
+USER_MANUAL_ONLINE_URL = 'https://backintime.readthedocs.io'
+USER_MANUAL_LOCAL_PATH = Path('/') / 'usr' / 'share' / 'doc' / \
+    'backintime-common' / 'manual' / 'index.html'
+
 
 class TimeUnit(Enum):
     """Describe time units used in context of scheduling.

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -13,6 +13,7 @@ from enum import Enum
 URL_ENCRYPT_TRANSITION = 'https://github.com/bit-team/backintime' \
                          '/blob/-/doc/ENCRYPT_TRANSITION.md'
 
+URL_USER_MANUAL = 'https://github.com/bit-team/backintime/'
 
 class TimeUnit(Enum):
     """Describe time units used in context of scheduling.

--- a/qt/app.py
+++ b/qt/app.py
@@ -711,6 +711,7 @@ class MainWindow(QMainWindow):
                 self.act_restore_parent_to,
             ),
             _('&Help'): (
+                self.act_help_user_manual,
                 self.act_help_man_backintime,
                 self.act_help_man_config,
                 self.act_help_website,
@@ -1385,7 +1386,10 @@ class MainWindow(QMainWindow):
             dlg.exec()
 
     def btn_help_user_manual(self):
-        self.openUrl(bitbase.URL_USER_MANUAL)
+        if bitbase.USER_MANUAL_LOCAL_PATH.exists():
+            self.openUrl(bitbase.USER_MANUAL_LOCAL_PATH.as_uri())
+        else:
+            self.openUrl(bitbase.USER_MANUAL_ONLINE_URL)
 
     def btn_help_man_backintime(self):
         self.openManPage('backintime')

--- a/qt/app.py
+++ b/qt/app.py
@@ -34,6 +34,7 @@ tools.initiate_translation(None)
 import qttools
 
 import backintime
+import bitbase
 import tools
 import logger
 import snapshots
@@ -539,9 +540,15 @@ class MainWindow(QMainWindow):
                 icon.EXIT, _('Exit'),
                 self.close, ['Ctrl+Q'],
                 None),
+            'act_help_user_manual': (
+                icon.HELP, _('User manual'),
+                self.btn_help_user_manual, ['F1'],
+                _('Open user manual in browser (local if '
+                  'available otherwise online)'),
+            ),
             'act_help_man_backintime': (
                 icon.HELP, _('man page: Back In Time'),
-                self.btn_help_man_backintime, ['F1'],
+                self.btn_help_man_backintime, None,
                 _('Displays man page about Back In Time (backintime)')
             ),
             'act_help_man_config': (
@@ -1376,6 +1383,9 @@ class MainWindow(QMainWindow):
         with self.suspendMouseButtonNavigation():
             dlg = AboutDlg(self)
             dlg.exec()
+
+    def btn_help_user_manual(self):
+        self.openUrl(bitbase.URL_USER_MANUAL)
 
     def btn_help_man_backintime(self):
         self.openManPage('backintime')

--- a/qt/app.py
+++ b/qt/app.py
@@ -539,25 +539,34 @@ class MainWindow(QMainWindow):
                 icon.EXIT, _('Exit'),
                 self.close, ['Ctrl+Q'],
                 None),
-            'act_help_help': (
-                icon.HELP, _('Help'),
-                self.btnHelpClicked, ['F1'],
-                None),
-            'act_help_configfile': (
-                icon.HELP, _('Profiles config file'),
-                self.btnHelpConfigClicked, None, None),
+            'act_help_man_backintime': (
+                icon.HELP, _('man page: Back In Time'),
+                self.btn_help_man_backintime, ['F1'],
+                _('Displays man page about Back In Time (backintime)')
+            ),
+            'act_help_man_config': (
+                icon.HELP, _('man page: Profiles config file'),
+                self.btn_help_man_config,
+                None,
+                _('Displays man page about profiles config file '
+                  '(backintime-config)')
+            ),
             'act_help_website': (
-                icon.WEBSITE, _('Website'),
-                self.btnWebsiteClicked, None, None),
+                icon.WEBSITE, _('Project website'),
+                self.btnWebsiteClicked,
+                None,
+                _('Open Back In Time website in browser')),
             'act_help_changelog': (
                 icon.CHANGELOG, _('Changelog'),
                 self.btnChangelogClicked, None, None),
             'act_help_faq': (
                 icon.FAQ, _('FAQ'),
-                self.btnFaqClicked, None, None),
+                self.btnFaqClicked, None,
+                _('Open Frequently Asked Questions (FAQ) in browser')),
             'act_help_question': (
                 icon.QUESTION, _('Ask a question'),
-                self.btnAskQuestionClicked, None, None),
+                self.btnAskQuestionClicked, None,
+                None),
             'act_help_bugreport': (
                 icon.BUG, _('Report a bug'),
                 self.btnReportBugClicked, None, None),
@@ -695,8 +704,8 @@ class MainWindow(QMainWindow):
                 self.act_restore_parent_to,
             ),
             _('&Help'): (
-                self.act_help_help,
-                self.act_help_configfile,
+                self.act_help_man_backintime,
+                self.act_help_man_config,
                 self.act_help_website,
                 self.act_help_changelog,
                 self.act_help_faq,
@@ -1368,10 +1377,10 @@ class MainWindow(QMainWindow):
             dlg = AboutDlg(self)
             dlg.exec()
 
-    def btnHelpClicked(self):
+    def btn_help_man_backintime(self):
         self.openManPage('backintime')
 
-    def btnHelpConfigClicked(self):
+    def btn_help_man_config(self):
         self.openManPage('backintime-config')
 
     def btnWebsiteClicked(self):


### PR DESCRIPTION
Open the user manual from the GUI's Help menu.

A local stored user manual is used if available in /usr/share/doc/backintime-common/manual otherwise online version at readthedocs.

Close #1988