### PR TITLE
feat(gui): Toolbar context menu to display the buttons as or with text

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Fix: Crash (KeyError) opening language setup dialog with unknown locale/language
 * Changed: Completed license information to conform the REUSE.software and SPDX standards.
 * Breaking Change: Auto-remove rules "Free inodes" and "Free space" disabled by default (#1976)
+* Feature: Toolbar context menu to display the buttons in different combinations with icons and text (#1105) (@mooresamuel)
 
 Version 1.5.3 (2024-11-13)
 * Doc: User manual (build with MkDocs) (#1838) (Kosta Vukicevic @stcksmsh)

--- a/qt/app.py
+++ b/qt/app.py
@@ -742,10 +742,10 @@ class MainWindow(QMainWindow):
         """
         context_menu = QMenu(self)
         options = (
-            (_('Icon Only'), Qt.ToolButtonStyle.ToolButtonIconOnly),
-            (_('Text Only'), Qt.ToolButtonStyle.ToolButtonTextOnly),
-            (_('Text Under Icon'), Qt.ToolButtonStyle.ToolButtonTextUnderIcon),
-            (_('Text Beside Icon'), Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
+            (_('Icons only'), Qt.ToolButtonStyle.ToolButtonIconOnly),
+            (_('Text only'), Qt.ToolButtonStyle.ToolButtonTextOnly),
+            (_('Text below icons'), Qt.ToolButtonStyle.ToolButtonTextUnderIcon),
+            (_('Text beside icon'), Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
         )
         for text, style in options:
             text = '✔ ' + text if toolbar.toolButtonStyle() == style else '  ' + text

--- a/qt/app.py
+++ b/qt/app.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
 # SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
 # SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
+# SPDX-FileCopyrightText: © 2025 moresamuel
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -737,27 +738,38 @@ class MainWindow(QMainWindow):
         restore.insertSeparator(self.act_restore_parent)
         restore.setToolTipsVisible(True)
 
-    def style_setter(self, point, toolbar):
+    def _context_menu_toolbar_style(self,
+                                    point: QPoint,
+                                    toolbar: QToolBar) -> None:
+        """Open a context menu to modify styling of tooblar buttons
+        buttons.
         """
-        Create a context menu for changing the style of the icons
-        """
-        context_menu = QMenu(self)
+        menu = QMenu(self)
         group = QActionGroup(self)
         options = (
-            (_('Icons only'), Qt.ToolButtonStyle.ToolButtonIconOnly),
-            (_('Text only'), Qt.ToolButtonStyle.ToolButtonTextOnly),
-            (_('Text below icons'), Qt.ToolButtonStyle.ToolButtonTextUnderIcon),
-            (_('Text beside icon'), Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
+            (
+                _('Icons only'),
+                Qt.ToolButtonStyle.ToolButtonIconOnly),
+            (
+                _('Text only'),
+                Qt.ToolButtonStyle.ToolButtonTextOnly),
+            (
+                _('Text below icons'),
+                Qt.ToolButtonStyle.ToolButtonTextUnderIcon),
+            (
+                _('Text beside icon'),
+                Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
         )
         for text, style in options:
             action = QAction(text, self)
             action.setCheckable(True)
             action.setChecked(toolbar.toolButtonStyle() == style)
             group.addAction(action)
-            action.triggered.connect(lambda _, s=style: toolbar.setToolButtonStyle(s))
+            action.triggered.connect(
+                lambda _, s=style: toolbar.setToolButtonStyle(s))
 
-        context_menu.addActions(group.actions())
-        context_menu.exec(toolbar.mapToGlobal(point))
+        menu.addActions(group.actions())
+        menu.exec(toolbar.mapToGlobal(point))
 
     def _create_main_toolbar(self):
         """Create the main toolbar and connect it to actions."""
@@ -765,9 +777,10 @@ class MainWindow(QMainWindow):
         toolbar = self.addToolBar('main')
         toolbar.setFloatable(False)
 
-        # create context menu for right click
+        # Context menu to modify button styling
         toolbar.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        toolbar.customContextMenuRequested.connect(lambda point: self.style_setter(point, toolbar))
+        toolbar.customContextMenuRequested.connect(
+            lambda point: self._context_menu_toolbar_style(point, toolbar))
 
         # Drop-Down: Profiles
         self.comboProfiles = qttools.ProfileCombo(self)

--- a/qt/app.py
+++ b/qt/app.py
@@ -32,7 +32,7 @@ import tools
 tools.initiate_translation(None)
 
 import qttools
-from textwrap import TextWrapper
+from textwrap import fill
 
 import backintime
 import tools
@@ -799,7 +799,7 @@ class MainWindow(QMainWindow):
 
                 toolbar.widgetForAction(act).setToolTip(button_tip)
 
-            act.setText(TextWrapper(width=8, break_long_words=False).fill(act.text()))
+            act.setText(fill(act.text(), width=8, break_long_words=False))
 
         # toolbar sub menu: take snapshot
         submenu_take_snapshot = QMenu(self)

--- a/qt/app.py
+++ b/qt/app.py
@@ -799,7 +799,7 @@ class MainWindow(QMainWindow):
 
                 toolbar.widgetForAction(act).setToolTip(button_tip)
 
-            act.setText(fill(act.text(), width=8, break_long_words=False))
+            act.setText(textwrap.fill(act.text(), width=8, break_long_words=False))
 
         # toolbar sub menu: take snapshot
         submenu_take_snapshot = QMenu(self)

--- a/qt/app.py
+++ b/qt/app.py
@@ -32,6 +32,7 @@ import tools
 tools.initiate_translation(None)
 
 import qttools
+from textwrap import TextWrapper
 
 import backintime
 import tools
@@ -735,42 +736,19 @@ class MainWindow(QMainWindow):
         restore.insertSeparator(self.act_restore_parent)
         restore.setToolTipsVisible(True)
 
-    def wrap_text(self, text, max_len):
-        """Helper function to insert newlines into text for 
-        word wrapping effect
-        
-        args:
-            text (str): sentence to have newlines added
-            max_len (int): maximum characters before newline insertion
-            
-        returns:
-            string of lines joined by newline characters
-        """
-        lines = []
-        line = []
-        words = text.split()
-        for word in words:
-            if len(word) + len(line) <= max_len:
-                line.append(word)
-            else:
-                lines.append(" ".join(line))
-                line = [word]
-        if line:
-            lines.append(" ".join(line))
-        return '\n'.join(lines)
-
     def style_setter(self, point, toolbar):
         """
         Create a context menu for changing the style of the icons
         """
         context_menu = QMenu(self)
         options = (
-            ('Text Under Icon', Qt.ToolButtonStyle.ToolButtonTextUnderIcon),
-            ('Text Only', Qt.ToolButtonStyle.ToolButtonTextOnly),
-            ('Text Beside Icon', Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
-            ('Icon Only', Qt.ToolButtonStyle.ToolButtonIconOnly),
+            (_('Icon Only'), Qt.ToolButtonStyle.ToolButtonIconOnly),
+            (_('Text Only'), Qt.ToolButtonStyle.ToolButtonTextOnly),
+            (_('Text Under Icon'), Qt.ToolButtonStyle.ToolButtonTextUnderIcon),
+            (_('Text Beside Icon'), Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
         )
         for text, style in options:
+            text = '✔ ' + text if toolbar.toolButtonStyle() == style else '  ' + text
             menu_item = QAction(text, self)
             menu_item.triggered.connect(lambda checked, s=style: toolbar.setToolButtonStyle(s))
             context_menu.addAction(menu_item)
@@ -821,8 +799,7 @@ class MainWindow(QMainWindow):
 
                 toolbar.widgetForAction(act).setToolTip(button_tip)
 
-            # add linebreaks for wrapping text
-            act.setText(self.wrap_text(act.text(), 8))
+            act.setText(TextWrapper(width=8, break_long_words=False).fill(act.text()))
 
         # toolbar sub menu: take snapshot
         submenu_take_snapshot = QMenu(self)

--- a/qt/app.py
+++ b/qt/app.py
@@ -758,7 +758,7 @@ class MainWindow(QMainWindow):
         if line:
             lines.append(" ".join(line))
         return '\n'.join(lines)
-    
+
     def style_setter(self, point, toolbar):
         """
         Create a context menu for changing the style of the icons
@@ -781,7 +781,7 @@ class MainWindow(QMainWindow):
 
         toolbar = self.addToolBar('main')
         toolbar.setFloatable(False)
-    
+
         # create context menu for right click
         toolbar.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
         toolbar.customContextMenuRequested.connect(lambda point: self.style_setter(point, toolbar))

--- a/qt/app.py
+++ b/qt/app.py
@@ -45,6 +45,7 @@ import encfsmsgbox
 from exceptions import MountException
 
 from PyQt6.QtGui import (QAction,
+                         QActionGroup,
                          QShortcut,
                          QDesktopServices,
                          QPalette,
@@ -741,6 +742,7 @@ class MainWindow(QMainWindow):
         Create a context menu for changing the style of the icons
         """
         context_menu = QMenu(self)
+        group = QActionGroup(self)
         options = (
             (_('Icons only'), Qt.ToolButtonStyle.ToolButtonIconOnly),
             (_('Text only'), Qt.ToolButtonStyle.ToolButtonTextOnly),
@@ -748,10 +750,13 @@ class MainWindow(QMainWindow):
             (_('Text beside icon'), Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
         )
         for text, style in options:
-            text = '✔ ' + text if toolbar.toolButtonStyle() == style else '  ' + text
-            menu_item = QAction(text, self)
-            menu_item.triggered.connect(lambda checked, s=style: toolbar.setToolButtonStyle(s))
-            context_menu.addAction(menu_item)
+            action = QAction(text, self)
+            action.setCheckable(True)
+            action.setChecked(toolbar.toolButtonStyle() == style)
+            group.addAction(action)
+            action.triggered.connect(lambda _, s=style: toolbar.setToolButtonStyle(s))
+
+        context_menu.addActions(group.actions())
         context_menu.exec(toolbar.mapToGlobal(point))
 
     def _create_main_toolbar(self):

--- a/qt/app.py
+++ b/qt/app.py
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
 # SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
 # SPDX-FileCopyrightText: © 2024 Christian Buhtz <c.buhtz@posteo.jp>
-# SPDX-FileCopyrightText: © 2025 moresamuel
+# SPDX-FileCopyrightText: © 2025 Samuel Moore
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/qt/app.py
+++ b/qt/app.py
@@ -32,7 +32,7 @@ import tools
 tools.initiate_translation(None)
 
 import qttools
-from textwrap import fill
+import textwrap
 
 import backintime
 import tools


### PR DESCRIPTION
Added a context menu when right clicking on the tool tray which gives the option to customize the dsiplay of the icons by choosing between text, icon, text alongside icon, and text below icon

Close #1105