### PR TITLE
fix(test): Remove state file migration tests

### DIFF
--- a/common/statedata.py
+++ b/common/statedata.py
@@ -158,7 +158,8 @@ class StateData(dict, metaclass=singleton.Singleton):
         self['_meta'] = meta
 
     def save(self):
-        """Store application state data to a file."""
+        """Store application state data to a file.
+        """
         logger.debug('Save state data.')
 
         self._set_save_meta_data()

--- a/common/test/test_statedata.py
+++ b/common/test/test_statedata.py
@@ -5,12 +5,17 @@
 # This file is part of the program "Back In Time" which is released under GNU
 # General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
-"""Tests about statefile module."""
+"""Tests about statefile module.
+
+Dev note (buhtz, 2025-01):
+Consider that the state file is written to disc, via StateData.save() method,
+when the application exists. This is triggered using the atexit module. But
+at the point of application exit PyFakeFS do not work anymore. So state data
+from unit tests is written to the real disc.
+"""
 # pylint: disable=R0801
 import unittest
 import inspect
-import atexit
-import argparse
 from pathlib import Path
 import pyfakefs.fake_filesystem_unittest as pyfakefs_ut
 import statedata
@@ -53,113 +58,6 @@ class IsSingleton(unittest.TestCase):
         one['foobar'] = 7
 
         self.assertEqual(one, two)
-
-
-class Migration(pyfakefs_ut.TestCase):
-    """Migration from config file into state file."""
-    @classmethod
-    def tearDownClass(cls):
-        # Delete existing StateData instance
-        try:
-            # pylint: disable-next=protected-access
-            del statedata.StateData._instances[statedata.StateData]
-        except KeyError:
-            pass
-
-    def _create_config_file(self, extra_content=None):
-        """Minimal config file"""
-        # pylint: disable-next=duplicate-code
-        cfg_content = inspect.cleandoc('''
-            config.version=6
-            profile1.snapshots.no_on_battery=false
-            profile1.snapshots.notify.enabled=true
-            profile1.snapshots.path=rootpath/destination
-            profile1.snapshots.path.host=test-host
-            profile1.snapshots.path.profile=1
-            profile1.snapshots.path.user=test-user
-            profile1.snapshots.remove_old_snapshots.enabled=true
-            profile1.snapshots.remove_old_snapshots.unit=80
-            profile1.snapshots.remove_old_snapshots.value=10
-            profile1.snapshots.include.1.type=0
-            profile1.snapshots.include.1.value=rootpath/source
-            profile1.snapshots.include.size=1
-            profile1.snapshots.preserve_acl=false
-            profile1.snapshots.preserve_xattr=false
-            profile1.snapshots.rsync_options.enabled=false
-            profile1.snapshots.rsync_options.value=
-            profiles.version=1
-            qt.main_window.x=123
-            qt.main_window.y=456
-        ''')  # pylint: disable=R0801
-
-        if extra_content:
-            cfg_content = cfg_content + '\n' + '\n'.join(extra_content)
-
-        # config file location
-        config_fp = Path.home() / '.config' / 'backintime' / 'config'
-        config_fp.parent.mkdir(parents=True)
-        config_fp.write_text(cfg_content, 'utf-8')
-
-        return config_fp
-
-    def tearDown(self):
-        self.config_fp.unlink(missing_ok=True)
-        self.state_fp.unlink(missing_ok=True)
-
-    def setUp(self):
-        """Setup a fake filesystem with a config file."""
-        self.setUpPyfakefs(allow_root_user=False)
-
-        # Delete existing StateData instance
-        try:
-            # pylint: disable-next=protected-access
-            del statedata.StateData._instances[statedata.StateData]
-        except KeyError:
-            pass
-
-        self.config_fp = self._create_config_file()
-        self.state_fp = Path.home() / '.local' / 'state' / 'backintime.json'
-
-    def test_create_json_file_at_exit(self):
-        """Create state file if not exists."""
-
-        # State file does not exist
-        self.assertFalse(self.state_fp.exists())
-
-        # Try to load statefile will trigger migration of config values
-        # into a fresh state object
-        args = argparse.Namespace(
-            config="/home/user/.config/backintime/config",
-            share_path="/home/user/.local/share")
-        backintime.load_state_data(args)
-
-        statedata.StateData()
-
-        # File still not written to filesystem
-        self.assertFalse(self.state_fp.exists())
-
-        # Exit application trigger state file write
-        atexit._run_exitfuncs()  # pylint: disable=protected-access
-
-        # Not it exists
-        self.assertTrue(self.state_fp.exists())
-
-    def test_migrate_config(self):
-        """Values from config file migrated to state data."""
-
-        # State file does not exist
-        self.assertFalse(self.state_fp.exists())
-
-        # Try to load statefile will trigger migration of config values
-        # into a fresh state object
-        args = argparse.Namespace(
-            config=str(Path.home() / ".config" / "backintime" / "config"),
-            share_path=str(Path.home() / ".local" / "share"))
-        backintime.load_state_data(args)
-
-        sut = statedata.StateData()
-
-        self.assertEqual(sut.mainwindow_coords, (123, 456))
 
 
 class Properties(unittest.TestCase):


### PR DESCRIPTION
Maybe don't merge because of
- #2010 

Some unit tests has overwritten the real state file, no matter that PyFakeFS was used.
The fake file system was not active anymore because StateData.save() is triggered at application exit (atexit module) when PyFakeFS is not active anymore.

After calculating maintenance cost and benefit the test was removed. Mocking around would have made to complex.

Fix #2001