### PR TITLE
chore: mkdocs compliant spdx meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ features. This work is carried out voluntarily during their limited spare time.
 
 # Installation
 
-_Back In Time_ is included in [many GNU/Linux distributions](https://repology.org/project/backintime/badges).
-Use their repositories to install it. If you want to contribute or using the latest development version
-of _Back In Time_ please see section [Build & Install](CONTRIBUTING.md#build--install) in [`CONTRIBUTING.md`](CONTRIBUTING.md).
-Also the dependencies are described there.
+_Back In Time_ is included in
+[many GNU/Linux distributions](https://repology.org/project/backintime/badges).
+Use their repositories to install it. If you want to contribute or using the
+latest development version of _Back In Time_ please see section
+[Build & Install](CONTRIBUTING.md#build--install) in
+[`CONTRIBUTING.md`](CONTRIBUTING.md). Also the dependencies are described there.
 
 ## Alternative installation options
 Besides the repositories of the official GNU/Linux distributions, there are other alternative

--- a/doc/README.md
+++ b/doc/README.md
@@ -7,6 +7,11 @@ This file is part of the program "Back In Time" which is released under GNU
 General Public License v2 (GPLv2). See directory LICENSES or go to
 <https://spdx.org/licenses/GPL-2.0-or-later.html>
 -->
+- [Overview](#overview)
+- [Build user manual](#build-user-manual)
+- [How to reduce file size of images](#how-to-reduce-file-size-of-images)
+
+# Overview
 This directory contains the source files for various types of documentation
 for _Back In Time_.
 
@@ -16,7 +21,36 @@ for _Back In Time_.
   project and nearly all other documents not fitting to one of the other
   categories.
 
-### How to reduce file size of images
+# Build user manual
+The user manual is build from markdown files (in directory `src`) and converted
+into HTML (directory `html`). The tool `mkdocs` is used for this.
+
+```sh
+$ cd backintime/doc/manual
+$ mkdocs build
+INFO    -  Cleaning site directory
+INFO    -  Building documentation to directory: XYZ
+INFO    -  Documentation built in 2.66 seconds 
+$
+```
+Open `html/index.html` to inspect the result.
+
+As an alternative `mkdocs` is able to provide a live preview of docs while
+editing the markdown files. A local web server is used for this.
+
+```sh
+$ cd backintime/doc/manual
+$ mkdocs serve
+INFO    -  Building documentation...
+INFO    -  Cleaning site directory
+INFO    -  Documentation built in 1.40 seconds
+INFO    -  [10:17:21] Watching paths for changes: 'src', 'mkdocs.yml'
+INFO    -  [10:17:21] Serving on http://127.0.0.1:8000/     
+```
+
+Inspect the result in browser: [127.0.0.1:8000](http://127.0.0.1:8000).
+
+# How to reduce file size of images
 For PNG images `optipng` could be used. *Attention*: By default it overwrites
 the original files. The following command use the highest possible optimization
 and write the result in a subfolder.

--- a/doc/manual/src/additional.md
+++ b/doc/manual/src/additional.md
@@ -11,6 +11,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - [FAQ - Frequently Asked Questions](https://github.com/bit-team/backintime/blob/dev/FAQ.md)
 - [Source code documentation for developers](https://backintime-dev.readthedocs.org)
 - [Issue Tracker](https://github.com/bit-team/backintime/issues)
-- Mailing list [bit-dev](https://mail.python.org/mailman3/lists/bit-dev.python.org) ([Archive](https://mail.python.org/archives/list/bit-dev@python.org/latest?count=200))
 - [Contributing to Back In Time](https://github.com/bit-team/backintime/blob/dev/CONTRIBUTING.md)
 - [Project Website at Microsoft GitHub](https://github.com/bit-team/backintime)
+- **Mailing list**: [bit-dev](https://mail.python.org/mailman3/lists/bit-dev.python.org) ([Archive](https://mail.python.org/archives/list/bit-dev@python.org/latest?count=200))
+- **Fediverse** on **Mastodon**: [@backintime@fosstodon.org](https://fosstodon.org/@backintime)

--- a/doc/manual/src/additional.md
+++ b/doc/manual/src/additional.md
@@ -1,13 +1,11 @@
-<!--
+---
 SPDX-FileCopyrightText: © 2016 Germar Reitze
-
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2).
-See file/folder LICENSE or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>
--->
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
 # Additional sources
 
 - [FAQ - Frequently Asked Questions](https://github.com/bit-team/backintime/blob/dev/FAQ.md)

--- a/doc/manual/src/additional.md
+++ b/doc/manual/src/additional.md
@@ -1,13 +1,13 @@
----
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-SPDX-License-Identifier: GPL-2.0-or-later
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
 # Additional sources
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
 
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 - [FAQ - Frequently Asked Questions](https://github.com/bit-team/backintime/blob/dev/FAQ.md)
 - [Source code documentation for developers](https://backintime-dev.readthedocs.org)
 - [Issue Tracker](https://github.com/bit-team/backintime/issues)

--- a/doc/manual/src/index.md
+++ b/doc/manual/src/index.md
@@ -1,13 +1,11 @@
-<!--
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-
+---
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2).
-See file/folder LICENSE or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>
--->
+SPDX-FileCopyrightText: © 2016 Germar Reitze
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
 # Introduction
 ![Back In Time main window](_images/light/main_window.png#only-light)
 ![Back In Time main window](_images/dark/main_window.png#only-dark)

--- a/doc/manual/src/index.md
+++ b/doc/manual/src/index.md
@@ -1,12 +1,13 @@
----
-SPDX-License-Identifier: GPL-2.0-or-later
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
 # Introduction
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
+
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 ![Back In Time main window](_images/light/main_window.png#only-light)
 ![Back In Time main window](_images/dark/main_window.png#only-dark)
 

--- a/doc/manual/src/log.md
+++ b/doc/manual/src/log.md
@@ -1,13 +1,13 @@
----
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-SPDX-License-Identifier: GPL-2.0-or-later
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
 # Log View
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
 
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 ## Last Log View
 
 ![Last Log View](_images/light/last_log_view.png#only-light)

--- a/doc/manual/src/log.md
+++ b/doc/manual/src/log.md
@@ -1,14 +1,12 @@
-<!--
+---
 SPDX-FileCopyrightText: © 2016 Germar Reitze
-
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2).
-See file/folder LICENSE or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>
--->
-# Log
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
+# Log View
 
 ## Last Log View
 

--- a/doc/manual/src/main-window.md
+++ b/doc/manual/src/main-window.md
@@ -31,16 +31,19 @@ Refresh the Snapshots in [Timeline](#timeline).
 
 Add a name for a Snapshot so you can easily identify it later. If `Don't remove
 named snapshots` in **Settings \--\> Auto Remove** is enabled this will also
-prevent the Snapshot from being removed. If this button is grayed out you need to select a snapshot in[Timeline](#timeline).
+prevent the Snapshot from being removed. If this button is grayed out you need
+to select a snapshot in [Timeline](#timeline).
 
 ![remove_snapshot](_images/edit-delete_btn.svg) Remove Snapshot
 
 Remove one or more Snapshots from Timeline. `Now` can not be removed as this is
-no Snapshot but the live view of the local file-system. If this button is grayed out you need to select a snapshot in[Timeline](#timeline).
+no Snapshot but the live view of the local file-system. If this button is
+grayed out you need to select a snapshot in [Timeline](#timeline).
 
 ![view_log](_images/text-plain_btn.svg) View Snapshot Log
 
-View the log of the selected Snapshot. If this button is grayed out you need to select a snapshot in[Timeline](#timeline).
+View the log of the selected Snapshot. If this button is grayed out you need to
+select a snapshot in [Timeline](#timeline).
 
 ![view_log](_images/document-new_btn.svg) View Last Log
 
@@ -50,9 +53,12 @@ View the log from the last snapshot attempt.
 
 Open [*Settings*](settings.md).
 
-![shutdown](_images/system-shutdown_btn.svg) Shutdown System after Snapshot has finished
+![shutdown](_images/system-shutdown_btn.svg) Shutdown System after Snapshot has
+finished
 
-Shutdown the computer and poweroff after a snapshot has finished. The main window must stay open for this. If shutdown is not supported on the system this button will be grayed out.
+Shutdown the computer and poweroff after a snapshot has finished. The main
+window must stay open for this. If shutdown is not supported on the system this
+button will be grayed out.
 
 ![exit](_images/window-close_btn.svg) Exit
 
@@ -75,7 +81,8 @@ Toggle hidden files (starting with a dot) to be shown in files view.
 ![restore](_images/edit-undo_btn.svg) Restore
 
 Restore selected files or folders. This button has a sub-menu (hold down the
-button). Default action is `Restore`. If this button is grayed out you need to select a snapshot in[Timeline](#timeline).
+button). Default action is `Restore`. If this button is grayed out you need to
+select a snapshot in [Timeline](#timeline).
 
 ![restore](_images/edit-undo_btn.svg) Restore
 
@@ -87,7 +94,8 @@ Restore the selected files or folders to a new destination.
 
 ![restore](_images/edit-undo_btn.svg) Restore */path*
 
-Restore the currently shown folder and all its content to the original destination.
+Restore the currently shown folder and all its content to the original
+destination.
 
 ![restore_to](_images/document-revert_btn.svg) Restore *path* to...
 
@@ -99,12 +107,21 @@ Open [Snapshots dialog](snapshots-dialog.md).
 
 ## Timeline
 
-The Timeline lists all Snapshots which where already taken. You can browse them to see its contents in right hand [Files View](#files-view). The first item `Now` is not a Snapshot. It is a live view on the local file-system. It shows exact the same as your normal file browser. Multi selection is possible to remove multiple Snapshots altogether.
+The Timeline lists all Snapshots which where already taken. You can browse them
+to see its contents in right hand [Files View](#files-view). The first item
+`Now` is not a Snapshot. It is a live view on the local file-system. It shows
+exact the same as your normal file browser. Multi selection is possible to
+remove multiple Snapshots altogether.
 
 ## Files View
 
-Depending on selection in left hand [Timeline](#timeline) this will either show the original files or the files in the selected snapshot. You can jump directly to your home or include folders in `Shortcuts`.
+Depending on selection in left hand [Timeline](#timeline) this will either show
+the original files or the files in the selected snapshot. You can jump directly
+to your home or include folders in `Shortcuts`.
 
 ## Statusbar
 
-Show current status. While a snapshot is running this will show a progress-bar combined with current speed, already transferred data and the last message from `rsync`.
+Show current status. While a snapshot is running this will show a progress-bar
+combined with current speed, already transferred data and the last message from
+`rsync`.
+

--- a/doc/manual/src/main-window.md
+++ b/doc/manual/src/main-window.md
@@ -1,13 +1,11 @@
-<!--
+---
 SPDX-FileCopyrightText: © 2016 Germar Reitze
-
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2).
-See file/folder LICENSE or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>
--->
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
 # Main Window
 
 ![Back In Time main window](_images/light/main_window_sections.png#only-light)

--- a/doc/manual/src/main-window.md
+++ b/doc/manual/src/main-window.md
@@ -1,13 +1,13 @@
----
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-SPDX-License-Identifier: GPL-2.0-or-later
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
 # Main Window
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
 
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 ![Back In Time main window](_images/light/main_window_sections.png#only-light)
 ![Back In Time main window](_images/dark/main_window_sections.png#only-dark)
 

--- a/doc/manual/src/quick-start.md
+++ b/doc/manual/src/quick-start.md
@@ -9,9 +9,11 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 <https://spdx.org/licenses/GPL-2.0-or-later.html>
 -->
 - Start *Back In Time* from your applications menu.
-- Select a destination directory for backups in the *General* tab (USB drive/local directory/network location…).
+- Select a destination directory for backups in the *General* tab (USB
+  drive/local directory/network location…).
 - Optionally, select a schedule for automatic backups (e.g. *Every week*).
-- In the *Include* tab, add files/directories to backup (e.g. Documents, Music…).
+- In the *Include* tab, add files/directories to backup (e.g. Documents,
+  Music…).
 - Save your settings with *OK*.
 - Start the backup operation.
 

--- a/doc/manual/src/quick-start.md
+++ b/doc/manual/src/quick-start.md
@@ -1,14 +1,12 @@
-<!--
+---
 SPDX-FileCopyrightText: © 2016 Germar Reitze
-
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2).
-See file/folder LICENSE or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>
--->
-# Quick start
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
+# Quick Start
 
 - Start *Back In Time* from your applications menu.
 - Select a destination directory for backups in the *General* tab (USB drive/local directory/network location…).

--- a/doc/manual/src/quick-start.md
+++ b/doc/manual/src/quick-start.md
@@ -1,13 +1,13 @@
----
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-SPDX-License-Identifier: GPL-2.0-or-later
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
 # Quick Start
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
 
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 - Start *Back In Time* from your applications menu.
 - Select a destination directory for backups in the *General* tab (USB drive/local directory/network location…).
 - Optionally, select a schedule for automatic backups (e.g. *Every week*).

--- a/doc/manual/src/settings.md
+++ b/doc/manual/src/settings.md
@@ -21,16 +21,27 @@ Available modes:
 
 ### Local
 
-Local snapshots can be stored on internal or external hard-drives or on mounted shares. The destination file-system must support hard-links. Also the protocol used to mount the remote share must support hard-links and symlinks. By default Samba (SMB/CIFS) servers do not support symlinks (can be activated with `follow symlinks = yes` and `wide links = yes` in `/etc/samba/smb.conf`). sshfs mounted shares do not support hard-links.
+Local snapshots can be stored on internal or external hard-drives or on mounted
+shares. The destination file-system must support hard-links. Also the protocol
+used to mount the remote share must support hard-links and symlinks. By default
+Samba (SMB/CIFS) servers do not support symlinks (can be activated with `follow
+symlinks = yes` and `wide links = yes` in `/etc/samba/smb.conf`). sshfs mounted
+shares do not support hard-links.
 
 ![Settings - General](_images/light/settings_general.png#only-light)
 ![Settings - General](_images/dark/settings_general.png#only-dark)
 
-Choose the destination path for snapshots with the ![folder](_images/folder_btn.svg) Folder button (to show hidden files use CTRL + H or context menu with right mouse button). [Back in Time will create sub-folders `backintime/<HOST>/<USER>/<PROFILE>/` inside that folder. Snapshots will be placed inside the `<PROFILE>/` folder.
+Choose the destination path for snapshots with the
+![folder](_images/folder_btn.svg) Folder button (to show hidden files use
+CTRL + H or context menu with right mouse button). [Back in Time will create
+sub-folders `backintime/<HOST>/<USER>/<PROFILE>/` inside that folder. Snapshots
+will be placed inside the `<PROFILE>/` folder.
 
 ### Local Encrypted
 
-[Local Encrypted](#local-encrypted) works like [Local](#local) but the snapshots will be stored encrypted with `EncFs`. The encrypted folder will be created automatically inside the selected folder.
+[Local Encrypted](#local-encrypted) works like [Local](#local) but the
+snapshots will be stored encrypted with `EncFs`. The encrypted folder will be
+created automatically inside the selected folder.
 
 !!! Danger
 
@@ -45,32 +56,72 @@ This might be a problem with Back In Time snapshots.
 ![Settings - General](_images/light/settings_general_local_encrypted.png#only-light)
 ![Settings - General](_images/dark/settings_general_local_encrypted.png#only-dark)
 
-Enter the password for `EncFs` in `Encryption`. The password can be stored in users keyring. The keyring is unlocked with the users password during login. When running a scheduled backup-job while the user is not logged in the keyring is not available. For this case, the password can be cached in memory by Back in Time.
+Enter the password for `EncFs` in `Encryption`. The password can be stored in
+users keyring. The keyring is unlocked with the users password during
+login. When running a scheduled backup-job while the user is not logged in the
+keyring is not available. For this case, the password can be cached in memory
+by Back in Time.
 
 ### SSH
 
-This mode will store snapshots on a remote host which is available through `SSH`. It will run `rsync` directly on the remote host which makes it a lot faster than syncing to a local mounted share.
+This mode will store snapshots on a remote host which is available through
+`SSH`. It will run `rsync` directly on the remote host which makes it a lot
+faster than syncing to a local mounted share.
 
-In order to use this mode the remote host need to be in your `known_hosts` file. Keep in mind that hostnames treated case-sensitive in that file. You need to have a public/private SSH key pair installed on the remote host. Starting with Back in Time version 1.2.0 this will be done automatically. For versions lower than 1.2.0 you need to do this manually:
+In order to use this mode the remote host need to be in your `known_hosts`
+file. Keep in mind that hostnames treated case-sensitive in that file. You need
+to have a public/private SSH key pair installed on the remote host. Starting
+with Back in Time version 1.2.0 this will be done automatically. For versions
+lower than 1.2.0 you need to do this manually:
 
-- if you did not login into the remote host before you need to run `ssh USER@HOST` in Terminal. You will be asked to confirm the fingerprint of the remote host-key with `yes`. In order to compare the host-key you need to login to the remote host locally and run `ssh-keygen -l -f /etc/ssh/ssh_host_ecdsa_key.pub`. The fingerprint from this output must match the fingerprint you got asked above. You can exit immediately after this.
-- generate a new public/private SSH key with `ssh-keygen`. Press Enter to accept the default path and enter a password for the new key (this has nothing to do with your user-password on the remote host).
-- run `ssh-copy-id -i ~/.ssh/id_rsa.pub USER@HOST` to install the newly created key on the remote host. For the last time you need to enter the login password for the remote user. If successful you should now be able to log in without being asked for your login password.
+- If you did not login into the remote host before you need to run `ssh
+  USER@HOST` in Terminal. You will be asked to confirm the fingerprint of the
+  remote host-key with `yes`. In order to compare the host-key you need to
+  login to the remote host locally and run `ssh-keygen -l -f
+  /etc/ssh/ssh_host_ecdsa_key.pub`. The fingerprint from this output must match
+  the fingerprint you got asked above. You can exit immediately after this.
+- Generate a new public/private SSH key with `ssh-keygen`. Press Enter to
+  accept the default path and enter a password for the new key (this has
+  nothing to do with your user-password on the remote host).
+- Run `ssh-copy-id -i ~/.ssh/id_rsa.pub USER@HOST` to install the newly created
+  key on the remote host. For the last time you need to enter the login
+  password for the remote user. If successful you should now be able to log in
+  without being asked for your login password.
 
 ![Settings - General](_images/light/settings_general_ssh.png#only-light)
 ![Settings - General](_images/dark/settings_general_ssh.png#only-dark)
 
-Enter the name or IP-address of the remote host in `Host` and the port of the remote SSH-server in `Port` (default `22`). `User` need to be the remote user. `Path` can be empty to place the snapshot folder directly into remote users home folder. Relative paths without leading slash (`foo/bar/`) will be sub-folders of users home. Paths with leading slash (`/mnt/foo/bar/`) will be absolute.
+Enter the name or IP-address of the remote host in `Host` and the port of the
+remote SSH-server in `Port` (default `22`). `User` need to be the remote
+user. `Path` can be empty to place the snapshot folder directly into remote
+users home folder. Relative paths without leading slash (`foo/bar/`) will be
+sub-folders of users home. Paths with leading slash (`/mnt/foo/bar/`) will be
+absolute.
 
-In `Cipher` you can choose the cipher (algorithm used to encrypt) for SSH transfer. Depending on the involved systems it could be faster to select a different cipher than default. Some of them might not work because they are known to be insecure. You can run `backintime benchmark-cipher` to compare transfer speed of all ciphers.
+In `Cipher` you can choose the cipher (algorithm used to encrypt) for SSH
+transfer. Depending on the involved systems it could be faster to select a
+different cipher than default. Some of them might not work because they are
+known to be insecure. You can run `backintime benchmark-cipher` to compare
+transfer speed of all ciphers.
 
-In `Private Key` you need to select your private SSH key. If this does not yet exist, you can create a new public/private SSH key without password by clicking on ![add](_images/list-add_btn.svg)
+In `Private Key` you need to select your private SSH key. If this does not yet
+exist, you can create a new public/private SSH key without password by clicking
+on ![add](_images/list-add_btn.svg)
 
-Enter the private key password in `SSH private key` (this is the password you chose above during creating the public/private key pair, not the login password for the remote user). The password can be stored in users keyring. The keyring is unlocked with the users password during login. When running a scheduled backup-job while the user is not logged in, the keyring is not available. For this case, the password can be cached in memory by Back in Time.
+Enter the private key password in `SSH private key` (this is the password you
+chose above during creating the public/private key pair, not the login password
+for the remote user). The password can be stored in users keyring. The keyring
+is unlocked with the users password during login. When running a scheduled
+backup-job while the user is not logged in, the keyring is not available. For
+this case, the password can be cached in memory by Back in Time.
 
 ### SSH Encrypted
 
-SSH Encrypted](#ssh-encrypted) will work like [SSH](#ssh) but the snapshots will be stored encrypted using `encfs --reverse`. Back in Time will mount an encrypted view of the local root file-system (`/`) and sync it with `rsync` to the remote host. As [Back in Time will backup the encrypted files, all logs and status messages will show cypher text.
+SSH Encrypted](#ssh-encrypted) will work like [SSH](#ssh) but the snapshots
+will be stored encrypted using `encfs --reverse`. Back in Time will mount an
+encrypted view of the local root file-system (`/`) and sync it with `rsync` to
+the remote host. As [Back in Time will backup the encrypted files, all logs and
+status messages will show cypher text.
 
 !!! Danger
 
@@ -78,33 +129,75 @@ SSH Encrypted](#ssh-encrypted) will work like [SSH](#ssh) but the snapshots will
 
     From [https://defuse.ca/audits/encfs.htm](https://defuse.ca/audits/encfs.htm):
 
-    > EncFS is probably safe as long as the adversary only gets one copy of the ciphertext and nothing more. EncFS is not safe if the adversary has the opportunity to see two or more snapshots of the ciphertext at different times. EncFS attempts to protect files from malicious modification, but there are serious problems with this feature.
+    > EncFS is probably safe as long as the adversary only gets one copy of
+    > the ciphertext and nothing more. EncFS is not safe if the adversary has
+    > the opportunity to see two or more snapshots of the ciphertext at
+    > different times. EncFS attempts to protect files from malicious
+    > modification, but there are serious problems with this feature.
 
 This might be a problem with *Back In Time* snapshots.
 
 ![Settings - General](_images/light/settings_general_ssh_encrypted.png#only-light)
 ![Settings - General](_images/dark/settings_general_ssh_encrypted.png#only-dark)
 
-Additional to those settings from [SSH](#ssh) you need to provide a password for encryption.
+Additional to those settings from [SSH](#ssh) you need to provide a password
+for encryption.
 
 ### Advanced
 
-`Host`, `User` and `Profile` will be filled automatically (must not be empty). They are used for the snapshot path `backintime/<HOST>/<USER>/<PROFILE>/`. The full snapshot path will be shown below. You can change them to match paths from other machines.
+`Host`, `User` and `Profile` will be filled automatically (must not be
+empty). They are used for the snapshot path
+`backintime/<HOST>/<USER>/<PROFILE>/`. The full snapshot path will be shown
+below. You can change them to match paths from other machines.
 
 ### Schedule
 
-You can choose between couple different schedules which will automatically start a new snapshot. Most of them will use `crontab` to set up new schedules. You can use `crontab -l` to view them or `crontab -e` to edit.
+You can choose between couple different schedules which will automatically
+start a new snapshot. Most of them will use `crontab` to set up new
+schedules. You can use `crontab -l` to view them or `crontab -e` to edit.
 
-- **At every boot/reboot**: start a new snapshot immediately after startup. This will add a `@reboot <COMMAND>` line in `crontab`. Wake up from suspend/hibernate will not trigger this schedule.
-- **Every X minutes**: start a new snapshot every 5, 10 or 30 minutes. This will add a line `*/<X> * * * * <COMMAND>` in `crontab`.
-- **Every hour**: start a new snapshot on every full hour. This will add a line `0 * * * * <COMMAND>` in `crontab`.
-- **Every X hours**: start a new snapshot every 2, 4, 6 or 12 hours at the full hour (e.g. at 0:00, 6:00, 12:00 and 18:00 with schedule [Every 6 hours). This will add a line `0 */<X> * * * <COMMAND>` in `crontab`. If the computer is not running at scheduled time there will be no new snapshot. This will not resume after switching on again.
-- **Custom Hours**: define custom pattern for `crontab`. This can be either a comma separated list of hours (e.g 0,10,13,15,17,20,23) or \*/\<X\> (e.g. [\*/3) for periodic schedules. This will add a line `0 0,10,13,15,17,20,23 * * * <COMMAND>` in `crontab`. If the computer is not running at scheduled time there will be no new snapshot. This will not resume after switching on again.
-- **Every Day**: start a new snapshot on a configurable time on every day. If the computer is not running at the configured time there will be no new snapshot for the day.
-- **Repeatedly (anacron)**: this schedule will start new snapshots after a configurable time (hours, days or weeks) when the last snapshot was done before this delay. This will also work when the system was powered off. It does imitate anacron but doesn't use it. Instead Back in Time writes it's own time-stamp after each successful snapshot and add a `crontab` job which will start Back in Time every 15min (or every hour if configured for weeks). If the configured delay is not done yet it will just exit immediately. If an error occurred during taking the snapshot it won't write a new time-stamp and so will try again after 15min/one hour.
-- **When drive get connected (udev)**: this schedule will start a new snapshot as soon as the USB/eSATA/Firewire drive get connected. You can configure a delay (hours, days or weeks like in schedule Repeatedly) so it won't start on every new connection. This will add a new udev rule in `/etc/udev/rules.d/99-backintime-<USER>.rules` using the partitions UUID. If using KDE you need to enable auto-mount for the device in System-Settings.
-- **Every Week**: start a new snapshot on a configurable week-day/time every week. If the computer is not running at the configured time there will be no new snapshot for the week.
-- **Every Month**: start a new snapshot on a configurable day/time every month. If the computer is not running at the configured time there will be no new snapshot for the month.
+- **At every boot/reboot**: start a new snapshot immediately after
+  startup. This will add a `@reboot <COMMAND>` line in `crontab`. Wake up from
+  suspend/hibernate will not trigger this schedule.
+- **Every X minutes**: start a new snapshot every 5, 10 or 30 minutes. This
+  will add a line `*/<X> * * * * <COMMAND>` in `crontab`.
+- **Every hour**: start a new snapshot on every full hour. This will add a line
+  `0 * * * * <COMMAND>` in `crontab`.
+- **Every X hours**: start a new snapshot every 2, 4, 6 or 12 hours at the full
+  hour (e.g. at 0:00, 6:00, 12:00 and 18:00 with schedule [Every 6 hours). This
+  will add a line `0 */<X> * * * <COMMAND>` in `crontab`. If the computer is
+  not running at scheduled time there will be no new snapshot. This will not
+  resume after switching on again.
+- **Custom Hours**: define custom pattern for `crontab`. This can be either a
+  comma separated list of hours (e.g 0,10,13,15,17,20,23) or \*/\<X\>
+  (e.g. [\*/3) for periodic schedules. This will add a line `0
+  0,10,13,15,17,20,23 * * * <COMMAND>` in `crontab`. If the computer is not
+  running at scheduled time there will be no new snapshot. This will not resume
+  after switching on again.
+- **Every Day**: start a new snapshot on a configurable time on every day. If
+  the computer is not running at the configured time there will be no new
+  snapshot for the day.
+- **Repeatedly (anacron)**: this schedule will start new snapshots after a
+  configurable time (hours, days or weeks) when the last snapshot was done
+  before this delay. This will also work when the system was powered off. It
+  does imitate anacron but doesn't use it. Instead Back in Time writes it's own
+  time-stamp after each successful snapshot and add a `crontab` job which will
+  start Back in Time every 15min (or every hour if configured for weeks). If
+  the configured delay is not done yet it will just exit immediately. If an
+  error occurred during taking the snapshot it won't write a new time-stamp and
+  so will try again after 15min/one hour.
+- **When drive get connected (udev)**: this schedule will start a new snapshot
+  as soon as the USB/eSATA/Firewire drive get connected. You can configure a
+  delay (hours, days or weeks like in schedule Repeatedly) so it won't start on
+  every new connection. This will add a new udev rule in
+  `/etc/udev/rules.d/99-backintime-<USER>.rules` using the partitions UUID. If
+  using KDE you need to enable auto-mount for the device in System-Settings.
+- **Every Week**: start a new snapshot on a configurable week-day/time every
+  week. If the computer is not running at the configured time there will be no
+  new snapshot for the week.
+- **Every Month**: start a new snapshot on a configurable day/time every
+  month. If the computer is not running at the configured time there will be no
+  new snapshot for the month.
 
 ## Include
 

--- a/doc/manual/src/settings.md
+++ b/doc/manual/src/settings.md
@@ -1,14 +1,12 @@
-<!--
+---
 SPDX-FileCopyrightText: © 2016 Germar Reitze
-
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2).
-See file/folder LICENSE or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>
--->
-# Settings
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
+# Manage profiles
 
 ## General
 

--- a/doc/manual/src/settings.md
+++ b/doc/manual/src/settings.md
@@ -1,13 +1,13 @@
----
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-SPDX-License-Identifier: GPL-2.0-or-later
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
 # Manage profiles
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
 
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 ## General
 
 You can choose which mode *Back in Time* should use to store snapshots.

--- a/doc/manual/src/snapshots-dialog.md
+++ b/doc/manual/src/snapshots-dialog.md
@@ -17,19 +17,24 @@ If checked only Snapshots with different file versions will be shown below.
 
 List only equal Snapshots to
 
-If checked only Snapshots with file versions equal to the Snapshot on the right will be shown below.
+If checked only Snapshots with file versions equal to the Snapshot on the right
+will be shown below.
 
 Deep check
 
-Calculate checksums to decide if file versions are equal or different with `List only different Snapshots` or `List only equal Snapshots to`. This takes a lot more time but is more accurate, too.
+Calculate checksums to decide if file versions are equal or different with
+`List only different Snapshots` or `List only equal Snapshots to`. This takes a
+lot more time but is more accurate, too.
 
 Restore
 
-Restore the file/folder from the selected Snapshot. Will be grayed out if `Now` or multiple Snapshots are selected.
+Restore the file/folder from the selected Snapshot. Will be grayed out if `Now`
+or multiple Snapshots are selected.
 
 Delete
 
-Delete the file/folder from one or multiple selected Snapshots. Will be grayed out if `Now` is selected.
+Delete the file/folder from one or multiple selected Snapshots. Will be grayed
+out if `Now` is selected.
 
 Select All
 
@@ -37,15 +42,18 @@ Select all Snapshots except `Now`.
 
 Snapshots
 
-Lists all Snapshots which contain the file/folder. Can be filtered with `List only different Snapshots` or `List only equal Snapshots to`.
+Lists all Snapshots which contain the file/folder. Can be filtered with `List
+only different Snapshots` or `List only equal Snapshots to`.
 
 Diff
 
-Open a Side-by-Side view of the file/folder in the Snapshot above and the Snapshot in the right hand selection.
+Open a Side-by-Side view of the file/folder in the Snapshot above and the
+Snapshot in the right hand selection.
 
 Diff Options
 
-Change the Program which is used for the Side-by-Side view with `Diff`. You can use `%1` and `%2` for the paths of both Snapshots.
+Change the Program which is used for the Side-by-Side view with `Diff`. You can
+use `%1` and `%2` for the paths of both Snapshots.
 
 Go To
 

--- a/doc/manual/src/snapshots-dialog.md
+++ b/doc/manual/src/snapshots-dialog.md
@@ -1,14 +1,12 @@
-<!--
+---
 SPDX-FileCopyrightText: © 2016 Germar Reitze
-
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2).
-See file/folder LICENSE or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>
--->
-# Snapshots Dialog
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
+# Snapshots dialog
 
 ![Snapshots Dialog](_images/light/snapshotsdialog.png#only-light)
 ![Snapshots Dialog](_images/dark/snapshotsdialog.png#only-dark)

--- a/doc/manual/src/snapshots-dialog.md
+++ b/doc/manual/src/snapshots-dialog.md
@@ -1,13 +1,13 @@
----
-SPDX-FileCopyrightText: © 2016 Germar Reitze
-SPDX-License-Identifier: GPL-2.0-or-later
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
 # Snapshots dialog
+<!--
+SPDX-FileCopyrightText: © 2016 Germar Reitze
 
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 ![Snapshots Dialog](_images/light/snapshotsdialog.png#only-light)
 ![Snapshots Dialog](_images/dark/snapshotsdialog.png#only-dark)
 

--- a/doc/manual/src/user-callback.md
+++ b/doc/manual/src/user-callback.md
@@ -1,15 +1,15 @@
----
+# User callback script
+<!--
 SPDX-FileCopyrightText: © 2015 Germar Reitze
 SPDX-FileCopyrightText: © 2024 Kosta Vukicevic (stcksmsh)
 SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
-SPDX-License-Identifier: GPL-2.0-or-later
-LicenseComments:
-    This file is part of the program "Back In Time" which is released under
-    GNU General Public License v2 (GPLv2). See LICENSES directory or
-    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
----
-# User callback script
 
+SPDX-License-Identifier: GPL-2.0-or-later
+
+This file is part of the program "Back In Time" which is released under GNU
+General Public License v2 (GPLv2). See LICENSES directory or go to
+<https://spdx.org/licenses/GPL-2.0-or-later.html>
+-->
 ## Introduction
 
 During the backup process, `Back In Time` can call a user defined script at

--- a/doc/manual/src/user-callback.md
+++ b/doc/manual/src/user-callback.md
@@ -1,15 +1,14 @@
-<!--
+---
 SPDX-FileCopyrightText: © 2015 Germar Reitze
 SPDX-FileCopyrightText: © 2024 Kosta Vukicevic (stcksmsh)
 SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
-
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This file is part of the program "Back In Time" which is released under GNU
-General Public License v2 (GPLv2). See LICENSES directory or
-go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
--->
-# User callback
+LicenseComments:
+    This file is part of the program "Back In Time" which is released under
+    GNU General Public License v2 (GPLv2). See LICENSES directory or
+    go to <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+---
+# User callback script
 
 ## Introduction
 


### PR DESCRIPTION
Modify format of SPDX meta data header in markdown files regarding to user manual. MkDocs now is able to recognize the first level header and use it as label in the navigation bar.

Further reading: https://github.com/mkdocs/mkdocs/issues/3908