### PR TITLE
Add offset minutes for schedules that run on the hour

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Changed: Completed license information to conform the REUSE.software and SPDX standards.
 * Breaking Change: Auto-remove rules "Free inodes" and "Free space" disabled by default (#1976)
 * Feature: Toolbar context menu to display the buttons in different combinations with icons and text (#1105, #2002) (Samuel Moore @s4moore)
+* Feature: Add offset minutes to hourly schedules (David Gibbs @fallingrock)
 
 Version 1.5.3 (2024-11-13)
 * Doc: User manual (build with MkDocs) (#1838) (Kosta Vukicevic @stcksmsh)

--- a/common/config.py
+++ b/common/config.py
@@ -123,6 +123,7 @@ class Config(configfile.ConfigFileWithProfiles):
     DEFAULT_SSH_PREFIX = 'PATH=/opt/bin:/opt/sbin:\\$PATH'
     DEFAULT_REDIRECT_STDOUT_IN_CRON = True
     DEFAULT_REDIRECT_STDERR_IN_CRON = False
+    DEFAULT_OFFSET = 0
 
     ENCODE = encfstools.Bounce()
     PLUGIN_MANAGER = pluginmanager.PluginManager()
@@ -849,6 +850,12 @@ class Config(configfile.ConfigFileWithProfiles):
     def setScheduleMode(self, value, profile_id = None):
         self.setProfileIntValue('schedule.mode', value, profile_id)
 
+    def schedule_offset(self, profile_id = None):
+        return self.profileIntValue('schedule.offset', Config.DEFAULT_OFFSET, profile_id)
+
+    def set_schedule_offset(self, value, profile_id = None):
+        self.setProfileIntValue('schedule.offset', value, profile_id)
+
     def scheduleDebug(self, profile_id = None):
         #?Enable debug output to system log for schedule mode.
         return self.profileBoolValue('schedule.debug', False, profile_id)
@@ -1511,6 +1518,7 @@ class Config(configfile.ConfigFileWithProfiles):
         minute = self.scheduleTime(profile_id) % 100
         day = self.scheduleDay(profile_id)
         weekday = self.scheduleWeekday(profile_id)
+        offset = str(self.schedule_offset(profile_id))
 
         if self.AT_EVERY_BOOT == backup_mode:
             cron_line = '@reboot {cmd}'
@@ -1521,17 +1529,17 @@ class Config(configfile.ConfigFileWithProfiles):
         elif self._30_MIN == backup_mode:
             cron_line = '*/30 * * * * {cmd}'
         elif self._1_HOUR == backup_mode:
-            cron_line = '0 * * * * {cmd}'
+            cron_line = offset + ' * * * * {cmd}'
         elif self._2_HOURS == backup_mode:
-            cron_line = '0 */2 * * * {cmd}'
+            cron_line = offset + ' */2 * * * {cmd}'
         elif self._4_HOURS == backup_mode:
-            cron_line = '0 */4 * * * {cmd}'
+            cron_line = offset + ' */4 * * * {cmd}'
         elif self._6_HOURS == backup_mode:
-            cron_line = '0 */6 * * * {cmd}'
+            cron_line = offset + ' */6 * * * {cmd}'
         elif self._12_HOURS == backup_mode:
-            cron_line = '0 */12 * * * {cmd}'
+            cron_line = offset + ' */12 * * * {cmd}'
         elif self.CUSTOM_HOUR == backup_mode:
-            cron_line = '0 ' + self.customBackupTime(profile_id) + ' * * * {cmd}'
+            cron_line = offset + ' ' + self.customBackupTime(profile_id) + ' * * * {cmd}'
         elif self.DAY == backup_mode:
             cron_line = '%s %s * * * {cmd}' % (minute, hour)
         elif self.REPEATEDLY == backup_mode:

--- a/common/config.py
+++ b/common/config.py
@@ -80,6 +80,13 @@ class Config(configfile.ConfigFileWithProfiles):
     MONTH = 40
     YEAR = 80
 
+    HOURLY_BACKUPS = (HOUR,
+                      _2_HOURS,
+                      _4_HOURS,
+                      _6_HOURS,
+                      _12_HOURS,
+                      CUSTOM_HOUR)
+
     DISK_UNIT_MB = 10
     DISK_UNIT_GB = 20
 

--- a/qt/manageprofiles/schedulewidget.py
+++ b/qt/manageprofiles/schedulewidget.py
@@ -247,7 +247,7 @@ class ScheduleWidget(QGroupBox):
 
         layout.setRowVisible(
             self._rowidx_offset,
-            config.Config.HOUR <= backup_mode_id <= config.Config.CUSTOM_HOUR
+            backup_mode_id in config.Config.HOURLY_BACKUPS
         )
 
         vis = config.Config.REPEATEDLY <= backup_mode_id <= config.Config.UDEV
@@ -318,8 +318,7 @@ class ScheduleWidget(QGroupBox):
         cfg.setScheduleMode(self._combo_schedule_mode.current_data)
         cfg.setScheduleTime(self._combo_time.current_data)
 
-        if cfg.scheduleMode() in range(config.Config.HOUR,
-                                       config.Config.CUSTOM_HOUR):
+        if cfg.scheduleMode() in config.Config.HOURLY_BACKUPS:
             cfg.set_schedule_offset(self._spin_offset.value())
         else:
             cfg.set_schedule_offset(config.Config.DEFAULT_OFFSET)

--- a/qt/manageprofiles/schedulewidget.py
+++ b/qt/manageprofiles/schedulewidget.py
@@ -318,7 +318,8 @@ class ScheduleWidget(QGroupBox):
         cfg.setScheduleMode(self._combo_schedule_mode.current_data)
         cfg.setScheduleTime(self._combo_time.current_data)
 
-        if config.Config.HOUR <= self._combo_schedule_mode.current_data <= config.Config.CUSTOM_HOUR:
+        if cfg.scheduleMode() in range(config.Config.HOUR,
+                                       config.Config.CUSTOM_HOUR):
             cfg.set_schedule_offset(self._spin_offset.value())
         else:
             cfg.set_schedule_offset(config.Config.DEFAULT_OFFSET)

--- a/qt/manageprofiles/schedulewidget.py
+++ b/qt/manageprofiles/schedulewidget.py
@@ -77,6 +77,16 @@ class ScheduleWidget(QGroupBox):
         self._rowidx_cronpattern = _create_form_entry(
             _('Hours:'), self._edit_cronpattern)
 
+        # Offset
+        self._spin_offset = QSpinBox(self)
+        self._spin_offset.setSingleStep(1)
+        self._spin_offset.setRange(0, 59)
+        hlayout = QHBoxLayout()
+        hlayout.addWidget(self._spin_offset)
+        hlayout.addWidget(QLabel(_('after the hour'), self))
+        hlayout.addStretch()
+        self._rowidx_offset = _create_form_entry(_('Minutes:'), hlayout)
+
         # Udev
         self._rowidx_udev = _create_form_entry(
             _('Run Back In Time as soon as the drive is connected (only once'
@@ -235,6 +245,11 @@ class ScheduleWidget(QGroupBox):
             self._rowidx_time,
             backup_mode_id >= config.Config.DAY)
 
+        layout.setRowVisible(
+            self._rowidx_offset,
+            config.Config.HOUR <= backup_mode_id <= config.Config.CUSTOM_HOUR
+        )
+
         vis = config.Config.REPEATEDLY <= backup_mode_id <= config.Config.UDEV
         layout.setRowVisible(
             self._rowidx_period,
@@ -259,6 +274,7 @@ class ScheduleWidget(QGroupBox):
         self._combo_time.select_by_data(cfg.scheduleTime())
         self._combo_day.select_by_data(cfg.scheduleDay())
         self._combo_weekday.select_by_data(cfg.scheduleWeekday())
+        self._spin_offset.setValue(cfg.schedule_offset())
 
         self._edit_cronpattern.setText(cfg.customBackupTime())
 
@@ -301,6 +317,12 @@ class ScheduleWidget(QGroupBox):
 
         cfg.setScheduleMode(self._combo_schedule_mode.current_data)
         cfg.setScheduleTime(self._combo_time.current_data)
+
+        if config.Config.HOUR <= self._combo_schedule_mode.current_data <= config.Config.CUSTOM_HOUR:
+            cfg.set_schedule_offset(self._spin_offset.value())
+        else:
+            cfg.set_schedule_offset(config.Config.DEFAULT_OFFSET)
+
         cfg.setScheduleWeekday(self._combo_weekday.current_data)
         cfg.setScheduleDay(self._combo_day.current_data)
         cfg.setCustomBackupTime(self._edit_cronpattern.text())


### PR DESCRIPTION
Added offset minutes for schedules that run on the hour, so backups that are run hourly won't collide with 
other backups.