### PR TITLE
fix!: Smart remove rule ""Keep one snapshots per week or the last week"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Fix: Crash (KeyError) opening language setup dialog with unknown locale/language
 * Changed: Completed license information to conform the REUSE.software and SPDX standards.
 * Breaking Change: Auto-remove rules "Free inodes" and "Free space" disabled by default (#1976)
+* Fix!: Smart-remove rule "Keep one snapshots per week or the last week" use calendar weeks
 * Feature: Toolbar context menu to display the buttons in different combinations with icons and text (#1105, #2002) (Samuel Moore @s4moore)
 
 Version 1.5.3 (2024-11-13)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1580,7 +1580,7 @@ class Snapshots:
                 logger.debug(f'Do not keep failed snapshot {sid}', self)
                 continue
 
-            if sid.date.date() >= min_id and sid.date.date() < max_id:
+            if sid.date.date() >= min_date and sid.date.date() < max_date:
                 return set([sid])
 
         # if all snapshots failed return the first snapshot
@@ -1692,13 +1692,14 @@ class Snapshots:
 
         # keep one per week for the last keep_one_per_week weeks
         if keep_one_per_week > 0:
-            d = now - datetime.timedelta(days=now.weekday() + 1)
+            # always Monday
+            d = now - datetime.timedelta(days=now.weekday())
 
             for i in range(0, keep_one_per_week):
                 keep |= self.smartRemoveKeepFirst(
                     snapshots,
                     d,
-                    d + datetime.timedelta(days=8),
+                    d + datetime.timedelta(days=7),
                     keep_healthy=True)
                 d -= datetime.timedelta(days=7)
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1572,23 +1572,15 @@ class Snapshots:
 
         TODO: It should compare datest not SIDs because of their tag.
         """
-        # print(f'smartRemoveKeepFirst() :: {min_date=} {max_date=}')  # DEBUG
-        min_id = SID(min_date, self.config)
-        max_id = SID(max_date, self.config)
-
-        logger.debug("Keep first >= %s and < %s" % (min_id, max_id), self)
+        logger.debug(f'Keep first >= {min_date} and < {max_date}', self)
 
         for sid in snapshots:
             # try to keep the first healthy snapshot
             if keep_healthy and sid.failed:
-                logger.debug("Do not keep failed snapshot %s" % sid, self)
+                logger.debug(f'Do not keep failed snapshot {sid}', self)
                 continue
 
-            # DEBUG
-            # print(f'smartRemoveKeepFirst() :: for sid ... sid={str(sid)}')
-
-            if sid >= min_id and sid < max_id:
-                # print(f'  return {str(sid)}')
+            if sid.date.date() >= min_id and sid.date.date() < max_id:
                 return set([sid])
 
         # if all snapshots failed return the first snapshot

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1572,7 +1572,8 @@ class Snapshots:
 
         TODO: It should compare datest not SIDs because of their tag.
         """
-        logger.debug(f'Keep first >= {min_date} and < {max_date}', self)
+        logger.debug('Keep first >= {} and < {}'.format(
+            min_date.strftime('%c'), max_date.strftime('%c')), self)
 
         for sid in snapshots:
             # try to keep the first healthy snapshot
@@ -1692,15 +1693,19 @@ class Snapshots:
 
         # keep one per week for the last keep_one_per_week weeks
         if keep_one_per_week > 0:
-            # always Monday
+            # Make sure the period always starts on Monday
+            # Step back in time to the last Monday
             d = now - datetime.timedelta(days=now.weekday())
 
             for i in range(0, keep_one_per_week):
                 keep |= self.smartRemoveKeepFirst(
                     snapshots,
+                    # Monday
                     d,
+                    # Step one week into the future
                     d + datetime.timedelta(days=7),
                     keep_healthy=True)
+                # One week back in time
                 d -= datetime.timedelta(days=7)
 
         # keep one per month for the last keep_one_per_month months


### PR DESCRIPTION
The smart remove rule "Keep one snapshots per week or the last week" now use full calendar weeks without losing snapshots in between.

The previous behavior was confuse and not clear.

Replace PR
- #1819

That PR is in preparation for meta issue
- #1945

Will merge it soon to go further with
- #2000

Might fix
- #1094 