### PR TITLE
chore: More clear and intense warning about EncFS deprecation and removal

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Changed: More clear and intense warning about EncFS deprecation and removal (#1904)
 * Doc: Remove & Retention (formally known as Auto-/Smart-Remove) with improved GUI and user manual section (#2000)
 * Changed: Updated desktop entry files
 * Changed: Move several values from config file into new introduce state file ($XDG_STATE_HOME/backintime.json)

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -520,7 +520,7 @@ def encfs_deprecation_warning():
         return
 
     logger.warning('EncFS encrypted profiles are deprecated in Back In Time. '
-                   'Removal is schedule for major release 1.7 in year 2026. '
+                   'Removal is schedule for minor release 1.7 in year 2026. '
                    'For details and alternatives '
                    f'read: {URL_ENCRYPT_TRANSITION}')
 

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -513,11 +513,11 @@ def encfs_deprecation_warning():
     fp.touch(exist_ok=True)
 
     # Calculate age of that file
-    delta = datetime.now() - datetime.fromtimestamp(fp.stat().st_mtime) 
+    delta = datetime.now() - datetime.fromtimestamp(fp.stat().st_mtime)
 
     # Don't warn if to young
-    # if delta.days < 30:
-    #     return
+    if delta.days < 30:
+        return
 
     logger.warning('EncFS encrypted profiles are deprecated in Back In Time. '
                    'Removal is schedule for major release 1.7 in year 2026. '

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -29,6 +29,7 @@ import mount
 import password
 import encfstools
 import cli
+from bitbase import URL_ENCRYPT_TRANSITION
 from diagnostics import collect_diagnostics, collect_minimal_diagnostics
 from exceptions import MountException
 from applicationinstance import ApplicationInstance
@@ -488,6 +489,42 @@ def createParsers(app_name='backintime'):
                            help=argparse.SUPPRESS)
 
 
+def encfs_deprecation_warning():
+    """Warn about encfs deprecation in syslog.
+
+    See Issue #1734 for details. This function is a workraound and will be
+    removed if #1734 is closed.
+    """
+
+    # Don't warn if EncFS isn't installed
+    if not tools.checkCommand('encfs'):
+        return
+
+    # Timestamp file
+    xdg_state = os.environ.get('XDG_STATE_HOME', None)
+    if xdg_state:
+        xdg_state = pathlib.Path(xdg_state)
+    else:
+        xdg_state = pathlib.Path.home() / '.local' / 'state'
+    fp = xdg_state / 'backintime.encfs-warning.timestamp'
+
+    # ensure existence
+    fp.parent.mkdir(parents=True, exist_ok=True)
+    fp.touch(exist_ok=True)
+
+    # Calculate age of that file
+    delta = datetime.now() - datetime.fromtimestamp(fp.stat().st_mtime) 
+
+    # Don't warn if to young
+    # if delta.days < 30:
+    #     return
+
+    logger.warning('EncFS encrypted profiles are deprecated in Back In Time. '
+                   'Removal is schedule for major release 1.7 in year 2026. '
+                   'For details and alternatives '
+                   f'read: {URL_ENCRYPT_TRANSITION}')
+
+
 def startApp(app_name='backintime'):
     """
     Start the requested command or return config if there was no command
@@ -524,6 +561,8 @@ def startApp(app_name='backintime'):
             "It looks like you're using 'sudo' to start "
             f"{config.Config.APP_NAME}. This will cause some trouble. "
             f"Please use either 'sudo -i {app_name}' or 'pkexec {app_name}'.")
+
+    encfs_deprecation_warning()
 
     # Call commands
     if 'func' in dir(args):

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -509,8 +509,9 @@ def encfs_deprecation_warning():
     fp = xdg_state / 'backintime.encfs-warning.timestamp'
 
     # ensure existence
-    fp.parent.mkdir(parents=True, exist_ok=True)
-    fp.touch(exist_ok=True)
+    if not fp.exists():
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.touch()
 
     # Calculate age of that file
     delta = datetime.now() - datetime.fromtimestamp(fp.stat().st_mtime)
@@ -523,6 +524,10 @@ def encfs_deprecation_warning():
                    'Removal is schedule for minor release 1.7 in year 2026. '
                    'For details and alternatives '
                    f'read: {URL_ENCRYPT_TRANSITION}')
+
+
+    # refresh timestamp
+    fp.touch()
 
 
 def startApp(app_name='backintime'):

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -18,6 +18,13 @@ USER_MANUAL_LOCAL_PATH = Path('/') / 'usr' / 'share' / 'doc' / \
     'backintime-common' / 'manual' / 'index.html'
 USER_MANUAL_LOCAL_AVAILABLE = USER_MANUAL_LOCAL_PATH.exists()
 
+# About transiation of encryption and removal of EncFS (see #1734)
+# The warnings and deprecation messages are gradually increased in intensity
+# and clarity. This constant is the currently desired stage of intensity. The
+# last shown intensity is stored in the state data file. If they don't fit, the
+# message is displayed.
+ENCFS_MSG_STAGE = 2
+
 
 class TimeUnit(Enum):
     """Describe time units used in context of scheduling.

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -18,7 +18,7 @@ USER_MANUAL_LOCAL_PATH = Path('/') / 'usr' / 'share' / 'doc' / \
     'backintime-common' / 'manual' / 'index.html'
 USER_MANUAL_LOCAL_AVAILABLE = USER_MANUAL_LOCAL_PATH.exists()
 
-# About transiation of encryption and removal of EncFS (see #1734)
+# About transition of encryption feature and the removal of EncFS (see #1734).
 # The warnings and deprecation messages are gradually increased in intensity
 # and clarity. This constant is the currently desired stage of intensity. The
 # last shown intensity is stored in the state data file. If they don't fit, the

--- a/qt/app.py
+++ b/qt/app.py
@@ -404,8 +404,9 @@ class MainWindow(QMainWindow):
         # BIT is presented to the users.
         state_data.decrement_manual_starts_countdown()
 
-        # If the encfs-deprecation warning was never shown before
-        if state_data.msg_encfs_global is False:
+        # If the encfs-deprecation warning in its latest stage was not shown
+        # yet.
+        if state_data.msg_encfs_global < 2:
             # Are there profiles using EncFS?
             encfs_profiles = []
             for pid in self.config.profiles():
@@ -417,7 +418,7 @@ class MainWindow(QMainWindow):
             if encfs_profiles:
                 dlg = encfsmsgbox.EncfsExistsWarning(self, encfs_profiles)
                 dlg.exec()
-                state_data.msg_encfs_global = True
+                state_data.msg_encfs_global = 2
 
         # Release Candidate
         if version.is_release_candidate():
@@ -2296,7 +2297,7 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
         data.msg_release_candidate = val
 
     # internal.msg_shown_encfs
-    val = cfg.boolValue('internal.msg_shown_encfs', None)
+    val = cfg.boolValue('internal.msg_shown_encfs', 0)
     if val:
         data.msg_encfs_global = val
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -961,12 +961,16 @@ class MainWindow(QMainWindow):
         self.updatePlaces()
         self.updateFilesView(0)
 
+        profile_id = self.config.currentProfile()
+        state_data = StateData()
+        profile_state = state_data.profile(profile_id)
+
         # EncFS deprecation warning (see #1734)
-        current_mode = self.config.snapshotsMode(self.config.currentProfile())
+        current_mode = self.config.snapshotsMode(profile_id)
         if current_mode in ('local_encfs', 'ssh_encfs'):
             # Show the profile specific warning dialog only once per profile.
-            if self.config.profileBoolValue('msg_shown_encfs') is False:
-                self.config.setProfileBoolValue('msg_shown_encfs', True)
+            if profile_state.msg_encfs is False:
+                profile_state.msg_encfs = True
                 dlg = encfsmsgbox.EncfsCreateWarning(self)
                 dlg.exec()
 
@@ -2362,9 +2366,8 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
         profile_state = data.profile(profile_id)
 
         # profile specific encfs warning
-        val = cfg.profileBoolValue('msg_shown_encfs', None, profile_id)
-        if val is not None:
-            profile_state.msg_encfs = val
+        val = cfg.profileBoolValue('msg_shown_encfs', 0, profile_id)
+        profile_state.msg_encfs = val
 
         # qt.last_path
         if cfg.hasProfileKey('qt.last_path', profile_id):

--- a/qt/app.py
+++ b/qt/app.py
@@ -33,6 +33,7 @@ import tools
 tools.initiate_translation(None)
 import qttools
 import backintime
+import bitbase
 import config
 import tools
 import logger
@@ -406,7 +407,7 @@ class MainWindow(QMainWindow):
 
         # If the encfs-deprecation warning in its latest stage was not shown
         # yet.
-        if state_data.msg_encfs_global < 2:
+        if state_data.msg_encfs_global < bitbase.ENCFS_MSG_STAGE:
             # Are there profiles using EncFS?
             encfs_profiles = []
             for pid in self.config.profiles():
@@ -418,7 +419,7 @@ class MainWindow(QMainWindow):
             if encfs_profiles:
                 dlg = encfsmsgbox.EncfsExistsWarning(self, encfs_profiles)
                 dlg.exec()
-                state_data.msg_encfs_global = 2
+                state_data.msg_encfs_global = bitbase.ENCFS_MSG_STAGE
 
         # Release Candidate
         if version.is_release_candidate():
@@ -969,8 +970,8 @@ class MainWindow(QMainWindow):
         current_mode = self.config.snapshotsMode(profile_id)
         if current_mode in ('local_encfs', 'ssh_encfs'):
             # Show the profile specific warning dialog only once per profile.
-            if profile_state.msg_encfs is False:
-                profile_state.msg_encfs = True
+            if profile_state.msg_encfs < bitbase.ENCFS_MSG_STAGE:
+                profile_state.msg_encfs = bitbase.ENCFS_MSG_STAGE
                 dlg = encfsmsgbox.EncfsCreateWarning(self)
                 dlg.exec()
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -417,9 +417,9 @@ class MainWindow(QMainWindow):
 
             # EncFS deprecation warning (#1734, #1735)
             if encfs_profiles:
+                state_data.msg_encfs_global = bitbase.ENCFS_MSG_STAGE
                 dlg = encfsmsgbox.EncfsExistsWarning(self, encfs_profiles)
                 dlg.exec()
-                state_data.msg_encfs_global = bitbase.ENCFS_MSG_STAGE
 
         # Release Candidate
         if version.is_release_candidate():
@@ -948,7 +948,8 @@ class MainWindow(QMainWindow):
 
         self.comboProfiles.clear()
 
-        qttools.update_combo_profiles(self.config, self.comboProfiles, self.config.currentProfile())
+        qttools.update_combo_profiles(
+            self.config, self.comboProfiles, self.config.currentProfile())
         profiles = self.config.profilesSortedByName()
 
         self.comboProfilesAction.setVisible(len(profiles) > 1)
@@ -969,8 +970,10 @@ class MainWindow(QMainWindow):
         # EncFS deprecation warning (see #1734)
         current_mode = self.config.snapshotsMode(profile_id)
         if current_mode in ('local_encfs', 'ssh_encfs'):
-            # Show the profile specific warning dialog only once per profile.
-            if profile_state.msg_encfs < bitbase.ENCFS_MSG_STAGE:
+            # Show the profile specific warning dialog only once per profile
+            # and only if the global warning was shown before.
+            if (state_data.msg_encfs_global == bitbase.ENCFS_MSG_STAGE
+                    and profile_state.msg_encfs < bitbase.ENCFS_MSG_STAGE):
                 profile_state.msg_encfs = bitbase.ENCFS_MSG_STAGE
                 dlg = encfsmsgbox.EncfsCreateWarning(self)
                 dlg.exec()

--- a/qt/encfsmsgbox.py
+++ b/qt/encfsmsgbox.py
@@ -39,17 +39,19 @@ class EncfsCreateWarning(_EncfsWarningBase):
     """
 
     def __init__(self, parent):
-        text = _('Support for EncFS will be discontinued in the '
-                 'foreseeable future. It is not recommended to use that '
-                 'mode for a profile furthermore.')
-        whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
-            + _('whitepaper') + '</a>'
-        informative_text = _(
-            'A decision on a replacement for continued support of encrypted '
-            'backups is still pending, depending on project resources and '
-            'contributor availability. More details are available in this '
-            '{whitepaper}.'
-        ).format(whitepaper=whitepaper)
+        text = _('EncFS profile creation will be removed in the next major '
+                 'release (1.7), scheduled for 2026.')
+        text = text + ' ' + _('It is not recommended to use that '
+                              'mode for a profile furthermore.')
+
+        informative_text = _('Support for EncFS is being discontinued due '
+                             'to security vulnerabilities.')
+        informative_text = informative_text + ' ' + _(
+            'For more details, including potential alternatives, please refer '
+            'to this {whitepaper}.').format(
+                whitepaper='<a href="{}">{}</a>'.format(
+                    URL_ENCRYPT_TRANSITION,
+                    _('whitepaper')))
 
         super().__init__(parent, text, informative_text)
 

--- a/qt/encfsmsgbox.py
+++ b/qt/encfsmsgbox.py
@@ -64,10 +64,13 @@ class EncfsExistsWarning(_EncfsWarningBase):
         # DevNote: Code looks ugly because we need to take the needs of
         # translators into account. Also the limitations of Qt's RichText
         # feature need to be considered.
+        text = ' '.join([
+            _('EncFS profile creation will be removed in the next major '
+              'release (1.7), scheduled for 2026.'),
+            _('It is not recommended to use that mode for a '
+              'profile furthermore.')
+        ])
 
-        text = _('The support for encrypted snapshot profiles is undergoing '
-                 'significant changes, and EncFS will be removed in the '
-                 'foreseeable future.')
 
         profiles = '<ul>' \
             + ''.join(f'<li>{profile}</li>' for profile in profiles) \
@@ -75,14 +78,17 @@ class EncfsExistsWarning(_EncfsWarningBase):
 
         whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
             + _('whitepaper') + '</a>'
+
         info_paragraphs = (
             _('The following profile(s) use encryption with EncFS:'),
             profiles,
-            _('A decision on a replacement for continued support of encrypted '
-              'backups is still pending, depending on project resources and '
-              'contributor availability. Users are invited to join this '
-              'discussion. Updated details on the next steps are '
-              'available in this {whitepaper}.').format(
+            ' '.join([
+                _('Support for EncFS is being discontinued due '
+                  'to security vulnerabilities.'),
+                _('A replacement is planned, but it cannot be guaranteed that '
+                  'it will arrive on time.')]),
+            _('Users are invited to join this discussion. Updated details '
+              'on the next steps are available in this {whitepaper}.').format(
                   whitepaper=whitepaper),
             _('This message will not be shown again. This dialog is '
               'available at any time via the help menu.'),

--- a/qt/encfsmsgbox.py
+++ b/qt/encfsmsgbox.py
@@ -39,7 +39,7 @@ class EncfsCreateWarning(_EncfsWarningBase):
     """
 
     def __init__(self, parent):
-        text = _('EncFS profile creation will be removed in the next major '
+        text = _('EncFS profile creation will be removed in the next minor '
                  'release (1.7), scheduled for 2026.')
         text = text + ' ' + _('It is not recommended to use that '
                               'mode for a profile furthermore.')
@@ -65,7 +65,7 @@ class EncfsExistsWarning(_EncfsWarningBase):
         # translators into account. Also the limitations of Qt's RichText
         # feature need to be considered.
         text = ' '.join([
-            _('EncFS profile creation will be removed in the next major '
+            _('EncFS profile creation will be removed in the next minor '
               'release (1.7), scheduled for 2026.'),
             _('It is not recommended to use that mode for a '
               'profile furthermore.')

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -586,7 +586,7 @@ class GeneralTab(QDialog):
         icon_label.setPixmap(pixmap)
 
         # encfs deprecation warning (see #1734, #1735)
-        txt = _('EncFS profile creation will be removed in the next major '
+        txt = _('EncFS profile creation will be removed in the next minor '
                 'release (1.7), scheduled for 2026.')
         txt = txt + ' ' + _('Support for EncFS is being discontinued due '
                             'to security vulnerabilities.')

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -593,17 +593,17 @@ class GeneralTab(QDialog):
         # icon_label.setFixedSize(pixmap.size())
 
         # encfs deprecation warning (see #1734, #1735)
-        txt_label = QLabel(
-            _('EncFS profile creation will be removed in the next major '
-              'release (1.7), scheduled for 2026. Support for EncFS is '
-              'being discontinued due to security vulnerabilities. '
-              'For more details, including potential alternatives, please '
-              'refer to this {whitepaper}.').format(
-                  whitepaper='<a href="{}">{}</a>'.format(
-                      URL_ENCRYPT_TRANSITION,
-                      _('whitepaper'))
-                  )
-        )
+        txt = _('EncFS profile creation will be removed in the next major '
+                'release (1.7), scheduled for 2026.')
+        txt = txt + ' ' + _('Support for EncFS is being discontinued due '
+                            'to security vulnerabilities.')
+        txt = txt + ' ' + _('For more details, including potential '
+                            'alternatives, please refer to this '
+                            '{whitepaper}.') \
+                            .format(whitepaper='<a href="{}">{}</a>'.format(
+                                URL_ENCRYPT_TRANSITION,
+                                _('whitepaper')))
+        txt_label = QLabel(txt)
         txt_label.setWordWrap(True)
         txt_label.setOpenExternalLinks(True)
 

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -34,11 +34,12 @@ import sshtools
 import logger
 import encfsmsgbox
 import mount
+from statedata import StateData
 from exceptions import MountException, NoPubKeyLogin, KnownHost
 from manageprofiles import combobox
 from manageprofiles import schedulewidget
 from manageprofiles.sshproxywidget import SshProxyWidget
-from bitbase import URL_ENCRYPT_TRANSITION
+from bitbase import URL_ENCRYPT_TRANSITION, ENCFS_MSG_STAGE
 
 
 class GeneralTab(QDialog):
@@ -678,7 +679,7 @@ class GeneralTab(QDialog):
         """
         active_mode = self.get_active_snapshots_mode()
 
-        state_data = StateFile()
+        state_data = StateData()
         profile_state = state_data.profile(self.config.currentProfile())
 
         # hide/show group boxes related to current mode
@@ -736,8 +737,8 @@ class GeneralTab(QDialog):
             if self._parent_dialog.isVisible():
                 # Show the profile specific warning dialog only once per
                 # profile.
-                if profile_state.msg_encfs is False:
-                    profile_state.msg_encfs = True
+                if profile_state.msg_encfs < ENCFS_MSG_STAGE:
+                    profile_state.msg_encfs = ENCFS_MSG_STAGE
                     dlg = encfsmsgbox.EncfsCreateWarning(self)
                     dlg.exec()
         else:

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -678,6 +678,9 @@ class GeneralTab(QDialog):
         """
         active_mode = self.get_active_snapshots_mode()
 
+        state_data = StateFile()
+        profile_state = state_data.profile(self.config.currentProfile())
+
         # hide/show group boxes related to current mode
         # note: self.modeLocalEncfs = self.modeLocal
         # note: self.modeSshEncfs = self.modeSsh
@@ -733,8 +736,8 @@ class GeneralTab(QDialog):
             if self._parent_dialog.isVisible():
                 # Show the profile specific warning dialog only once per
                 # profile.
-                if self.config.profileBoolValue('msg_shown_encfs') is False:
-                    self.config.setProfileBoolValue('msg_shown_encfs', True)
+                if profile_state.msg_encfs is False:
+                    profile_state.msg_encfs = True
                     dlg = encfsmsgbox.EncfsCreateWarning(self)
                     dlg.exec()
         else:

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -15,17 +15,19 @@ from pathlib import Path
 from typing import Any
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QCursor, QFont
-from PyQt6.QtWidgets import (QDialog,
-                             QVBoxLayout,
-                             QHBoxLayout,
+from PyQt6.QtWidgets import (QCheckBox,
+                             QDialog,
                              QGridLayout,
-                             QMessageBox,
                              QGroupBox,
+                             QHBoxLayout,
                              QLabel,
-                             QToolButton,
                              QLineEdit,
-                             QCheckBox,
-                             QToolTip)
+                             QMessageBox,
+                             QStyle,
+                             QToolButton,
+                             QToolTip,
+                             QVBoxLayout,
+                             QWidget)
 import config
 import tools
 import qttools
@@ -67,6 +69,7 @@ class GeneralTab(QDialog):
         # EncFS deprecation (#1734, #1735)
         self._lbl_encfs_warning = self._create_label_encfs_deprecation()
         tab_layout.addWidget(self._lbl_encfs_warning)
+        tab_layout.addWidget(qttools.HLineWidget())
 
         # Where to save snapshots
         groupBox = QGroupBox(self)
@@ -573,29 +576,49 @@ class GeneralTab(QDialog):
         return combobox.BitComboBox(self, self.config.SSH_CIPHERS)
 
     def _create_label_encfs_deprecation(self):
+        # Icon
+        # icon = self.style().standardPixmap(
+        #     QStyle.StandardPixmap.SP_MessageBoxWarning)
+        icon = self.style().standardIcon(
+            QStyle.StandardPixmap.SP_MessageBoxWarning)
+        size = self.style().pixelMetric(
+            QStyle.PixelMetric.PM_LargeIconSize)
+        # icon = icon.scaled(
+        #     icon.width(),
+        #     icon.height(),
+        #     Qt.AspectRatioMode.KeepAspectRatio)
+        icon_label = QLabel(self)
+        pixmap = icon.pixmap(size*2)
+        icon_label.setPixmap(pixmap)
+        # icon_label.setFixedSize(pixmap.size())
+
         # encfs deprecation warning (see #1734, #1735)
-        label = QLabel('<b>{}:</b> {}<br>{}'.format(
-            _('Warning'),
+        txt_label = QLabel(
             _('EncFS profile creation will be removed in the next major '
               'release (1.7), scheduled for 2026. Support for EncFS is '
-              'being discontinued due to security vulnerabilities.'),
-            _('For more details, including potential alternatives, please '
+              'being discontinued due to security vulnerabilities. '
+              'For more details, including potential alternatives, please '
               'refer to this {whitepaper}.').format(
                   whitepaper='<a href="{}">{}</a>'.format(
                       URL_ENCRYPT_TRANSITION,
-                      _('whitepaper')))
+                      _('whitepaper'))
                   )
         )
-        label.setWordWrap(True)
-        label.setOpenExternalLinks(True)
+        txt_label.setWordWrap(True)
+        txt_label.setOpenExternalLinks(True)
 
         # Show URL in tooltip without anoing http-protocol prefix.
-        label.linkHovered.connect(
+        txt_label.linkHovered.connect(
             lambda url: QToolTip.showText(
                 QCursor.pos(), url.replace('https://', ''))
         )
 
-        return label
+        wdg = QWidget()
+        layout = QHBoxLayout(wdg)
+        layout.addWidget(icon_label, stretch=0)
+        layout.addWidget(txt_label, stretch=1)
+
+        return wdg
 
     def _slot_snapshots_path_clicked(self):
         old_path = self.editSnapshotsPath.text()

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -574,18 +574,18 @@ class GeneralTab(QDialog):
 
     def _create_label_encfs_deprecation(self):
         # encfs deprecation warning (see #1734, #1735)
-        label = QLabel('<b>{}:</b> {}'.format(
+        label = QLabel('<b>{}:</b> {}<br>{}'.format(
             _('Warning'),
-            _('Support for EncFS will be discontinued in the foreseeable '
-              'future. A decision on a replacement for continued support of '
-              'encrypted backups is still pending, depending on project '
-              'resources and contributor availability. More details are '
-              'available in this {whitepaper}.').format(
+            _('EncFS profile creation will be removed in the next major '
+              'release (1.7), scheduled for 2026. Support for EncFS is '
+              'being discontinued due to security vulnerabilities.'),
+            _('For more details, including potential alternatives, please '
+              'refer to this {whitepaper}.').format(
                   whitepaper='<a href="{}">{}</a>'.format(
                       URL_ENCRYPT_TRANSITION,
-                      _('whitepaper'))
+                      _('whitepaper')))
                   )
-        ))
+        )
         label.setWordWrap(True)
         label.setOpenExternalLinks(True)
 

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -577,20 +577,13 @@ class GeneralTab(QDialog):
 
     def _create_label_encfs_deprecation(self):
         # Icon
-        # icon = self.style().standardPixmap(
-        #     QStyle.StandardPixmap.SP_MessageBoxWarning)
         icon = self.style().standardIcon(
             QStyle.StandardPixmap.SP_MessageBoxWarning)
         size = self.style().pixelMetric(
             QStyle.PixelMetric.PM_LargeIconSize)
-        # icon = icon.scaled(
-        #     icon.width(),
-        #     icon.height(),
-        #     Qt.AspectRatioMode.KeepAspectRatio)
         icon_label = QLabel(self)
         pixmap = icon.pixmap(size*2)
         icon_label.setPixmap(pixmap)
-        # icon_label.setFixedSize(pixmap.size())
 
         # encfs deprecation warning (see #1734, #1735)
         txt = _('EncFS profile creation will be removed in the next major '

--- a/qt/statedata.py
+++ b/qt/statedata.py
@@ -134,8 +134,12 @@ class StateData(dict, metaclass=singleton.Singleton):
     @staticmethod
     def file_path() -> Path:
         """Returns the state file path."""
-        xdg_state = os.environ.get('XDG_STATE_HOME',
-                                   Path.home() / '.local' / 'state')
+        xdg_state = os.environ.get('XDG_STATE_HOME', None)
+        if xdg_state:
+            xdg_state = Path(xdg_state)
+        else:
+            xdg_state = Path.home() / '.local' / 'state'
+
         fp = xdg_state / 'backintime-qt.json'
 
         logger.debug(f'State file path: {fp}')

--- a/qt/statedata.py
+++ b/qt/statedata.py
@@ -222,16 +222,16 @@ class StateData(dict, metaclass=singleton.Singleton):
         self['message']['release_candidate'] = val
 
     @property
-    def msg_encfs_global(self) -> bool:
-        """If global EncFS deprecation message box was displayed already."""
+    def msg_encfs_global(self) -> int:
+        """Last stage of global EncFS deprecation message that was shown."""
         try:
             return self['message']['encfs']['global']
         except KeyError:
-            self.msg_encfs_global = False
+            self.msg_encfs_global = 0
             return self.msg_encfs_global
 
     @msg_encfs_global.setter
-    def msg_encfs_global(self, val: bool) -> None:
+    def msg_encfs_global(self, val: int) -> None:
         self['message']['encfs']['global'] = val
 
     @property

--- a/qt/statedata.py
+++ b/qt/statedata.py
@@ -59,12 +59,12 @@ class StateData(dict, metaclass=singleton.Singleton):
             self._profile_id = profile_id
 
         @property
-        def msg_encfs(self) -> bool:
-            """If message box about EncFS deprecation was shown already."""
+        def msg_encfs(self) -> int:
+            """Stage of EncFS deprecation warning shown as last."""
             return self._state['message']['encfs'][self._profile_id]
 
         @msg_encfs.setter
-        def msg_encfs(self, val: bool) -> None:
+        def msg_encfs(self, val: int) -> None:
             self._state['message']['encfs'][self._profile_id] = val
 
         @property

--- a/qt/statedata.py
+++ b/qt/statedata.py
@@ -61,7 +61,11 @@ class StateData(dict, metaclass=singleton.Singleton):
         @property
         def msg_encfs(self) -> int:
             """Stage of EncFS deprecation warning shown as last."""
-            return self._state['message']['encfs'][self._profile_id]
+            try:
+                return self._state['message']['encfs'][self._profile_id]
+            except KeyError:
+                self.msg_encfs = 0
+                return self.msg_encfs
 
         @msg_encfs.setter
         def msg_encfs(self, val: int) -> None:

--- a/qt/test/test_statedata.py
+++ b/qt/test/test_statedata.py
@@ -8,14 +8,9 @@
 """Tests about statefile module."""
 # pylint: disable=wrong-import-position,wrong-import-order
 import unittest
-import inspect
-from pathlib import Path
-import pyfakefs.fake_filesystem_unittest as pyfakefs_ut
 from qttools_path import registerBackintimePath
 registerBackintimePath('common')
-import config  # noqa: E402
 import statedata  # noqa: E402
-import app  # noqa: E402
 
 
 class IsSingleton(unittest.TestCase):
@@ -101,51 +96,3 @@ class Properties(unittest.TestCase):
         with self.assertRaises(KeyError):
             # pylint: disable=pointless-statement
             profile.last_path
-
-    @pyfakefs_ut.patchfs(allow_root_user=False)
-    def test_read_non_existing_profile(self, _fake_fs):
-        """Read state value from non existing profile."""
-        cfg_content = inspect.cleandoc('''
-        ''')  # pylint: disable=R0801
-
-        # config file location
-        config_fp = Path.home() / '.config' / 'backintime' / 'config'
-        config_fp.parent.mkdir(parents=True)
-        config_fp.write_text(cfg_content, 'utf-8')
-
-        cfg = config.Config(config_fp)
-        # pylint: disable-next=protected-access
-        sut = app._get_state_data_from_config(cfg)
-
-        # empty profile
-        profile = sut.profile('1')
-
-        with self.assertRaises(KeyError) as exc:
-            # pylint: disable=pointless-statement
-            profile.msg_encfs
-
-        # Profile 1 does not exist
-        self.assertEqual(exc.exception.args[0], '1')
-
-    @pyfakefs_ut.patchfs(allow_root_user=False)
-    def test_write_non_existing_profile(self, _fake_fs):
-        """Write state value to non existing profile."""
-        cfg_content = inspect.cleandoc('''
-        ''')  # pylint: disable=R0801
-
-        # config file location
-        config_fp = Path.home() / '.config' / 'backintime' / 'config'
-        config_fp.parent.mkdir(parents=True)
-        config_fp.write_text(cfg_content, 'utf-8')
-
-        cfg = config.Config(config_fp)
-        # pylint: disable-next=protected-access
-        sut = app._get_state_data_from_config(cfg)
-
-        # empty profile
-        profile = sut.profile('1')
-
-        # nothing raised
-        profile.msg_encfs = True
-
-        self.assertEqual(profile.msg_encfs, True)


### PR DESCRIPTION
Close #1904

- An application wide warning dialog pops up one time.
- A profile specific dialog pops up one time.
- The Manage profiles dialog will always have a warning label.
- Terminal and syslog will get a Warning entry every 30 days. This is for headless system not having the GUI installed.

Screenshots are soon out-dated. :rofl:  "major relesae" -> "minor release"

![bit_encfs_global](https://github.com/user-attachments/assets/89759597-2917-4ba1-bf0c-acee9c73ac97)

![bit_encfs_profile](https://github.com/user-attachments/assets/0a026ea1-a668-4d4d-b1bc-3fb8375be79d)

![bit_encfs_label](https://github.com/user-attachments/assets/b5da83db-69ae-47a3-ad5c-00459537737c)
