### PR TITLE
Release Candidate 1.5.4-rc2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 Back In Time
 
-IN DEVELOPMENT - Version 1.5.4-rc2 (Release Candidate 2)
+Version 1.5.4-rc2 (Release Candidate 2)
 * Fix: Exclude patterns are now case-sensitive when added (#2040)
 
 Version 1.5.4-rc1 (Release Candidate 1)

--- a/common/man/C/backintime-askpass.1
+++ b/common/man/C/backintime-askpass.1
@@ -1,4 +1,4 @@
-.TH backintime-askpass 1 "February 2025" "version 1.5.4-rc1" "USER COMMANDS"
+.TH backintime-askpass 1 "February 2025" "version 1.5.4-rc2" "USER COMMANDS"
 .SH NAME
 backintime-askpass \- a simple backup tool for Linux.
 .PP

--- a/common/man/C/backintime-config.1
+++ b/common/man/C/backintime-config.1
@@ -1,4 +1,4 @@
-.TH backintime-config 1 "November 2024" "version 1.5.4-rc1" "USER COMMANDS"
+.TH backintime-config 1 "November 2024" "version 1.5.4-rc2" "USER COMMANDS"
 .SH NAME
 config \- BackInTime configuration files.
 .SH SYNOPSIS

--- a/common/man/C/backintime.1
+++ b/common/man/C/backintime.1
@@ -1,4 +1,4 @@
-.TH backintime 1 "February 2025" "version 1.5.4-rc1" "USER COMMANDS"
+.TH backintime 1 "February 2025" "version 1.5.4-rc2" "USER COMMANDS"
 .SH NAME
 backintime \- a simple backup tool for Linux.
 .PP

--- a/common/version.py
+++ b/common/version.py
@@ -13,7 +13,7 @@ See Issue #1575 for details about that migration.
 import re
 
 # Version string regularyly used by the application and presented to users.
-__version__ = '1.5.4-rc1'
+__version__ = '1.5.4-rc2'
 
 
 def is_release_candidate() -> bool:

--- a/doc/maintain/BiT_release_process.md
+++ b/doc/maintain/BiT_release_process.md
@@ -69,8 +69,12 @@ using a "feature" branch and sending a pull request asking for a review.
 - Commit the changes.
 - Open a new pull request (PR) for review by other developers.
 
-When the PR is merged:
+Before the PR is merged:
 - Create a new tar archive (eg. `backintime-1.4.0.tar.gz`) with `./make-tarball.sh`.
+- Test the tar archive.
+- Merge.
+
+After the PR is merged:
 - Create a new release in Github (attaching above tar archive).
 - Update `VERSION` and `CHANGES` for the `dev` branch.
 

--- a/make-tarball.sh
+++ b/make-tarball.sh
@@ -12,12 +12,22 @@ CURRENT=$(pwd)
 NEW="backintime-$VER"
 
 cd ..
-if [[ -n "$(which git)" ]] && [[ -x "$(which git)" ]]; then
-    git clone ${CURRENT} ${NEW}
-else
-    cp -aR ${CURRENT} ${NEW}
-fi
+
+# if [[ -n "$(which git)" ]] && [[ -x "$(which git)" ]]; then
+#     git clone ${CURRENT} ${NEW}
+# else
+#     cp -aR ${CURRENT} ${NEW}
+# fi
+
+cp -aR ${CURRENT} ${NEW}
+
+rm backintime-$VER.tar.gz
+
 tar cfz backintime-$VER.tar.gz \
+    --exclude="*/__pycache__" \
+    --exclude="*/.pytest_cache" \
+    --exclude="*/.ruff_cache" \
+    --exclude="*/po/*.mo" \
     ${NEW}/AUTHORS \
     ${NEW}/CHANGES \
     ${NEW}/LICENSE \
@@ -38,5 +48,5 @@ echo ""
 echo "RESULT:"
 realpath backintime-$VER.tar.gz
 
-rm -rf backintime-$VER
+# rm -rf backintime-$VER
 

--- a/make-tarball.sh
+++ b/make-tarball.sh
@@ -33,5 +33,10 @@ tar cfz backintime-$VER.tar.gz \
     ${NEW}/LICENSES \
     ${NEW}/doc
 
+tar -tzf backintime-$VER.tar.gz
+echo ""
+echo "RESULT:"
+realpath backintime-$VER.tar.gz
+
 rm -rf backintime-$VER
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -318,6 +318,13 @@ class MainWindow(QMainWindow):
             for idx, width in enumerate(files_view_col_widths):
                 self.filesView.header().resizeSection(idx, width)
 
+        # Release Candidate
+        if version.is_release_candidate():
+            last_vers = state_data.msg_release_candidate
+            if last_vers != version.__version__:
+                state_data.msg_release_candidate = version.__version__
+                self._open_release_candidate_dialog()
+
         # Force dialog to import old configuration
         if not config.isConfigured():
             message = _(
@@ -420,13 +427,6 @@ class MainWindow(QMainWindow):
                 state_data.msg_encfs_global = bitbase.ENCFS_MSG_STAGE
                 dlg = encfsmsgbox.EncfsExistsWarning(self, encfs_profiles)
                 dlg.exec()
-
-        # Release Candidate
-        if version.is_release_candidate():
-            last_vers = state_data.msg_release_candidate
-            if last_vers != version.__version__:
-                state_data.msg_release_candidate = version.__version__
-                self._open_release_candidate_dialog()
 
     @property
     def showHiddenFiles(self):

--- a/qt/man/C/backintime-qt.1
+++ b/qt/man/C/backintime-qt.1
@@ -1,4 +1,4 @@
-.TH backintime-qt 1 "November 2024" "version 1.5.4-rc1" "USER COMMANDS"
+.TH backintime-qt 1 "November 2024" "version 1.5.4-rc2" "USER COMMANDS"
 .SH NAME
 backintime-qt \- a simple backup tool.
 .SH SYNOPSIS


### PR DESCRIPTION
# Summary
This is the second release candidate preparing for version 1.5.4. Please report if you use it even if there are no new problems.

Fix: Exclude patterns are now case-sensitive when added (#2040)
Fix(build): LICENSE folder included in tar archive
Fix: Desktop files typos

More details in previous release candidate 6441aa11de02354cf80965cd133b7337475e6ded.