### PR TITLE
fix: Show again ETA in statusbar

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -258,7 +258,6 @@ class Config(configfile.ConfigFileWithProfiles):
         self.default_profile_name = _('Main profile')
 
         # ToDo Those hidden labels exist to speed up their translation.
-        # Unhide them after the upcoming release (1.5.0).
         # See: https://github.com/bit-team/backintime/issues/
         # 1735#issuecomment-2197646518
         _HIDDEN_NEW_MODE_LABELS = (
@@ -428,6 +427,10 @@ class Config(configfile.ConfigFileWithProfiles):
             profile_id = self.currentProfile()
 
         self.setProfileStrValue('snapshots.path', value, profile_id)
+
+    def is_mode_encrypted(self, profile_id=None):
+        mode = self.snapshotsMode(profile_id)
+        return mode in ('local_encfs', 'ssh_encfs')
 
     def snapshotsMode(self, profile_id=None):
         #? Use mode (or backend) for this snapshot. Look at 'man backintime'

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1011,8 +1011,6 @@ class Snapshots:
         for l in line.split('\n'):
             m = self.reRsyncProgress.match(l)
             if m:
-                print('X'*100)
-                print(f'{m.groups()=}')
                 # if m.group(5).strip():
                 #     return
                 pg = progress.ProgressFile(self.config)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -844,11 +844,11 @@ class Snapshots:
                                     + self.config.snapshotsFullPath(profile_id)
                                     + '\n'
                                     + _('If it is on a removable drive, '
-                                        'please plug it in. Then press OK.')
+                                        'please plug it in.')
                                     + '\n'
-                                    + gettext.ngettext('Waiting %s second.',
-                                                       'Waiting %s seconds.',
-                                                       30) % 30
+                                    + gettext.ngettext('Waiting {n} second.',
+                                                       'Waiting {n} seconds.',
+                                                       30).format(n=30)
                                 )
 
                                 self.setTakeSnapshotMessage(

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -66,17 +66,25 @@ class Snapshots:
         self.clearIdCache()
         self.clearNameCache()
 
-        #rsync --info=progress2 output
-        #search for:     517.38K  26%   14.46MB/s    0:02:36
-        #or:             497.84M   4% -449.39kB/s   ??:??:??
-        #but filter out: 517.38K  26%   14.46MB/s    0:00:53 (xfr#53, to-chk=169/452)
-        #                because this shows current run time
-        self.reRsyncProgress = re.compile(r'.*?'                            #trash at start
-                                          r'(\d*[,\.]?\d+[KkMGT]?)\s+'      #bytes sent
-                                          r'(\d*)%\s+'                      #percent done
-                                          r'(-?\d*[,\.]?\d*[KkMGT]?B/s)\s+' #speed
-                                          r'([\d\?]+:[\d\?]{2}:[\d\?]{2})'  #estimated time of arrival
-                                          r'(.*$)')                         #trash at the end
+        # rsync --info=progress2 output
+        # search for:     517.38K  26%   14.46MB/s    0:02:36
+        # or:             497.84M   4% -449.39kB/s   ??:??:??
+        # but filter out: 517.38K  26%   14.46MB/s    0:00:53 (xfr#53, to-chk=169/452)
+        #                 because this shows current run time
+        self.reRsyncProgress = re.compile(
+            # trash at start
+            r'.*?'
+            # bytes sent
+            r'(\d*[,\.]?\d+[KkMGT]?)\s+'
+            # percent done
+            r'(\d*)%\s+'
+            # speed
+            r'(-?\d*[,\.]?\d*[KkMGT]?B/s)\s+'
+            # estimated time of arrival
+            r'([\d\?]+:[\d\?]{2}:[\d\?]{2})'
+            # trash at the end
+            r'(.*$)'
+        )
 
         self.lastBusyCheck = datetime.datetime(1, 1, 1)
         self.restorePermissionFailed = False
@@ -1003,6 +1011,8 @@ class Snapshots:
         for l in line.split('\n'):
             m = self.reRsyncProgress.match(l)
             if m:
+                print('X'*100)
+                print(f'{m.groups()=}')
                 # if m.group(5).strip():
                 #     return
                 pg = progress.ProgressFile(self.config)
@@ -1010,7 +1020,7 @@ class Snapshots:
                 pg.setStrValue('sent', m.group(1))
                 pg.setIntValue('percent', int(m.group(2)))
                 pg.setStrValue('speed', m.group(3))
-                #pg.setStrValue('eta', m.group(4))
+                pg.setStrValue('eta', m.group(4))
                 pg.save()
                 del pg
             else:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1160,11 +1160,30 @@ class MainWindow(QMainWindow):
         #	self.lastTakeSnapshotMessage = None
 
     def getProgressBarFormat(self, pg, message):
+        """Generates formatted components of a progress bar display.
+
+        This generator yields individual parts of a progress message, including
+        the percentage completed, optionally the amount sent, current
+        speed, estimated time remaining (ETA), and a custom message.
+        Values are extracted from the provided progress object `pg`.
+
+        Args:
+            pg (progress.ProgressFile): An object that provides progress
+                information through methods like `intValue` and `strValue`.
+                Expected keys include 'percent', 'sent', 'speed', and 'eta'.
+            message (str): A custom message to append at the end of the
+                progress bar.
+
+        Yields:
+            str: Formatted strings representing different segments of the
+                progress bar.
+        """
         d = (
             ('sent', '{}:'.format(_('Sent'))),
             ('speed', '{}:'.format(_('Speed'))),
             ('eta', '{}:'.format(_('ETA')))
         )
+
         yield '{}%'.format(pg.intValue('percent'))
 
         for key, txt in d:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1179,9 +1179,9 @@ class MainWindow(QMainWindow):
                 progress bar.
         """
         d = (
-            ('sent', '{}:'.format(_('Sent'))),
-            ('speed', '{}:'.format(_('Speed'))),
-            ('eta', '{}:'.format(_('ETA')))
+            ('sent', _('Sent:')),
+            ('speed', _('Speed:')),
+            ('eta',    _('ETA:'))
         )
 
         yield '{}%'.format(pg.intValue('percent'))

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -709,10 +709,10 @@ class SettingsDialog(QDialog):
 
         active_mode = self._tab_general.get_active_snapshots_mode()
 
-        enabled = active_mode in ('ssh', 'ssh_encfs')
-
         self.updateExcludeItems()
+        self.lblSshEncfsExcludeWarning.setVisible(active_mode == 'ssh_encfs')
 
+        enabled = active_mode in ('ssh', 'ssh_encfs')
         self._tab_retention.update_items_state(enabled)
         self._tab_expert_options.update_items_state(enabled)
 

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -198,6 +198,10 @@ class QtSysTrayIcon:
             self.menuProgress.setVisible(False)
 
     def getMenuProgress(self, pg):
+        """See common/app.py::MainWindow.getProgressBarFormat().
+
+        The code is a near duplicate.
+        """
         data = (
             ('sent', _('Sent:')),
             ('speed', _('Speed:')),


### PR DESCRIPTION
"ETA" value in the statusbar was disabled for a long time for a reason unknown. It was enabled again.

Additionally the info message in "Exclude" tab is related to SSH encrypted mode and now shown in that mode only.