### PR TITLE
build!: Remove test-targets from Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   # run unit tests - ensure that functionality is correct
   - cd common
   - ./configure
-  - make unittest-v
+  - pytest --verbose
   - cd ..
   - cd qt
   - ./configure

--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,10 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Changed: **Breaking** A "snapshot" now is a "backup" (#1929)
+* Changed: **Breaking** Deprecated and removed make targets: "test", "test-v", "unittest", "unittest-v"
 * Changed: Stop passing window ID when inhibiting suspend via D-Bus power manager (#2084)
 * Changed: Reorder DBUS service provider list for suspend mode inhibition (#2084)
-* Changed!: A "snapshot" now is a "backup" (#1929)
 * Added: "ETA" value in status bar (#2101)
 * Removed: Stop using QWindow.winId() (#2084)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,14 +103,11 @@ pull request being accepted.
   (see our own [HOWTO about doc generation](doc/maintain/1_doc_howto.md)).
 - Avoid the use of automatic formatters like `black` but mention the use of
   them when opening a pull request.
-- Run unit tests before you open a pull request. You can run them via
-  `make`-system with `cd common && ./configure && make && make test` or using a
-  regular unittest runner of your choice (e.g. `pytest`). See section
-  [Build and install via `make` system](#build-and-install-via-make-system-recommended)
+- Run unit tests before you open a pull request. Read [Testing](#testing)
   for further details.
 - Try to create new unit tests if appropriate. Use the style of regular Python
-  `unittest` rather than `pytest`. If you know the difference, please try to follow
-  the _Classical (aka Detroit) school_ instead of _London (aka mockist)
+  `unittest` rather than `pytest`. If you know the difference, please try to
+  follow the _Classical (aka Detroit) school_ instead of _London (aka mockist)
   school_.
 - See recommendations about [how to handle translatable strings](doc/maintain/2_localization.md#instructions-for-the-translation-process).
 
@@ -206,13 +203,13 @@ and installed separately accordingly.
 * Command line tool
    1. `cd common`
    2. `./configure && make`
-   3. Run unit tests via `make test`
+   3. Run unit tests via `python -m unittest` or `pytest`.
    4. `sudo make install`
 
 * Qt GUI
    1. `cd qt`
    2. `./configure && make`
-   3. Run unit tests via `make test`
+   3. Run unit tests via `python -m unittest` or `pytest`.
    4. `sudo make install`
 
 You can use optional arguments to `./configure` for creating a Makefile.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,21 +225,23 @@ See `common/configure --help` and `qt/configure --help` for details.
 > [Manual testing](doc/maintain/BiT_release_process.md#manual-testing---recommendations)
 > about recommendations how to perform such tests.
 
-After [building and installing](#build--install), `make` can be used to run the
-test suite. Since _Back In Time_ consists of two components, `common` and `qt`,
+After [building and installing](#build--install), run the test suite. Feel free
+to use Python's own `unittest` module or `pytest` as a test runer.
+Since _Back In Time_ consists of two components, `common` and `qt`,
 the tests are segregated accordingly.
 
     $ cd common
-    $ make test
+    $ pytest
 
 Or
 
     $ cd qt
-    $ make test
+    $ pytest
 
-Alternatively use `make test-v` for a more verbose output. The `make` system
-will use `pytest` as test runner if available otherwise Python's own `unittest`
-module.
+> [!IMPORTANT]
+> Even if `pytest` is used as test runner, don't write tests in
+> `pytest`-style. Stick to the good old `unittest`-style. This is a project
+> rule, taking maintainability into account.
 
 ## SSH
 

--- a/common/configure
+++ b/common/configure
@@ -300,6 +300,7 @@ for target in test test-v unittest unittest-v; do
     printf "\t@echo \"Target '%s' not available anymore. " "$target">> ${MAKEFILE}
     printf "Use a test runner of your own choice " >> ${MAKEFILE}
     printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
+    printf "\n\t@false" >> ${MAKEFILE}
 done
 
 # Copy Makefile

--- a/common/configure
+++ b/common/configure
@@ -171,6 +171,8 @@ for langfile in `ls po/*.po`; do
 done
 
 # Start Makefile
+printf ".PHONY: test test-v\n" >> ${MAKEFILE}
+
 printf "LANGS=$langs\n\n" >> ${MAKEFILE}
 
 printf "PREFIX=/usr\n" >> ${MAKEFILE}
@@ -293,34 +295,16 @@ cat ${UNINSTALL_FILES} >> ${MAKEFILE}
 printf "uninstall_dirs:\n" >> ${MAKEFILE}
 cat ${UNINSTALL_DIRS} >> ${MAKEFILE}
 
-# test
-for i in "pytest" "py.test-3" "py.test-3.6" "py.test-3.5" "py.test-3.4"; do
-    PYTEST=$(which $i 2>/dev/null)
-    if [ -n "${PYTEST}" ]; then
-        break
-    fi
-done
+printf "test:\n" >> ${MAKEFILE}
+printf "\t@echo \"Target 'test' not available anymore. " >> ${MAKEFILE}
+printf "Use a test runner of your own choice " >> ${MAKEFILE}
+printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
 
-# Use "python", "python3" or if available "py.test-3"
-CMD="${PYTHON}"
+printf "\n\ntest-v:\n" >> ${MAKEFILE}
+printf "\t@echo \"Target 'test-v' not available anymore. " >> ${MAKEFILE}
+printf "Use a test runner of your own choice " >> ${MAKEFILE}
+printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
 
-printf "test:\tunittest\n\n" >> ${MAKEFILE}
-printf "test-v:\tunittest-v\n\n" >> ${MAKEFILE}
-for v in "" "-v"; do
-    # Provide unittests with and without verbosity -v
-    printf "unittest${v}:\n" >> ${MAKEFILE}
-
-    # Use pytest if available
-    if [ -n "${PYTEST}" ]; then
-        printf "\t${PYTEST} ${v}\n" >> ${MAKEFILE}
-    # Fallback to unittest module
-    else
-        for i in $(ls -1 test/test_*.py); do
-            printf "\t${CMD} -m unittest ${v} -b $i\n" >> ${MAKEFILE}
-        done
-    fi
-    printf "\n" >> ${MAKEFILE}
-done
 
 # Copy Makefile
 mv ${MAKEFILE} Makefile
@@ -343,6 +327,7 @@ if [ "$(printf '%s\n' "$PYTHON_VERSION_REQUIRED" "$PYTHON_VERSION_CURRENT" | sor
     printf "But minimal version ${PYTHON_VERSION_REQUIRED} required.\n"
     exit 1
 fi
+
 
 printf "All OK. Now run:\n"
 printf "    make\n"

--- a/common/configure
+++ b/common/configure
@@ -171,7 +171,7 @@ for langfile in `ls po/*.po`; do
 done
 
 # Start Makefile
-printf ".PHONY: test test-v\n" >> ${MAKEFILE}
+printf ".PHONY: test test-v unittest unittest-v\n" >> ${MAKEFILE}
 
 printf "LANGS=$langs\n\n" >> ${MAKEFILE}
 
@@ -295,16 +295,12 @@ cat ${UNINSTALL_FILES} >> ${MAKEFILE}
 printf "uninstall_dirs:\n" >> ${MAKEFILE}
 cat ${UNINSTALL_DIRS} >> ${MAKEFILE}
 
-printf "test:\n" >> ${MAKEFILE}
-printf "\t@echo \"Target 'test' not available anymore. " >> ${MAKEFILE}
-printf "Use a test runner of your own choice " >> ${MAKEFILE}
-printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
-
-printf "\n\ntest-v:\n" >> ${MAKEFILE}
-printf "\t@echo \"Target 'test-v' not available anymore. " >> ${MAKEFILE}
-printf "Use a test runner of your own choice " >> ${MAKEFILE}
-printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
-
+for target in test test-v unittest unittest-v; do
+    printf "\n\n%s:\n" "$target" >> ${MAKEFILE}
+    printf "\t@echo \"Target '%s' not available anymore. " "$target">> ${MAKEFILE}
+    printf "Use a test runner of your own choice " >> ${MAKEFILE}
+    printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
+done
 
 # Copy Makefile
 mv ${MAKEFILE} Makefile

--- a/doc/maintain/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md
+++ b/doc/maintain/3_How_to_set_up_openssh_server_for_ssh_unit_tests.md
@@ -21,19 +21,16 @@ General Public License v2 (GPLv2). See file/folder LICENSE or go to
 
 # Motivation
 
-`ssh`-based unit tests are skipped in `make test` when no local ssh server
-is configured and running.
-
-In order to execute also run all ssh unit tests in the `common` folder
-via `make test` the `openssh` server must be **installed on your local machine**
-and a public/private key must be set up for password-less connections.
-
-This document describes the required steps.
+SSH-based unit tests are skipped when no local SSH server configured and
+running.  In order to execute all tests, the `openssh` server must be
+**installed on your local machine** and a public/private key must be set up for
+password-less connections. This document describes the required steps.
 
 # How the unit tests access the ssh server
 
-`ssh`-based unit tests use the [`common/test/generic.py`](https://github.com/bit-team/backintime/blob/f801b14a98f9a442008a5f514eec98e1b2d7e29a/common/test/generic.py)
-to check and establish a ssh connection to the ssh server via this code:
+SSH-based unit tests use the
+[`common/test/generic.py`](https://github.com/bit-team/backintime/blob/f801b14a98f9a442008a5f514eec98e1b2d7e29a/common/test/generic.py)
+to check and establish a SSH connection to the SSH server via this code:
 
 https://github.com/bit-team/backintime/blob/f801b14a98f9a442008a5f514eec98e1b2d7e29a/common/test/generic.py#L43-L72
 
@@ -46,7 +43,7 @@ The code implements the following logic:
 5. Check that the ssh port 22 at localhost is available (= ssh server running at the standard IP port)
 
 If all checks succeed the global variable `LOCAL_SSH` is set to `True`
-(and this variable us used then to skip ssh-based unit tests).
+(and this variable us used then to skip SSH-based unit tests).
 
 
 # Installation
@@ -120,7 +117,7 @@ required changes.
 
    ```commandline
    cd common
-   make test
+   pytest --verbose
    ```
    
    You shouldn't see skipped ssh tests now (indicated with an "s" instead of a dot).
@@ -206,16 +203,16 @@ To                         Action      From
 ```
 
 Finally run the unit tests again to make sure the firewall is working correctly
-(= not blocking ssh traffic to localhost):
+(= not blocking SSH traffic to localhost):
 
    ```commandline
    cd common
-   make test
+   pytest --verbose
    ```
 
 # FAQ
 
-## How can I temporarily disable the ssh unit tests since they consume too much time
+## How can I temporarily disable the SSH unit tests since they consume too much time
 
 Just kill the sshd process (works until you restart your computer):
 

--- a/doc/maintain/BiT_release_process.md
+++ b/doc/maintain/BiT_release_process.md
@@ -116,7 +116,7 @@ After the PR is merged:
   cd common
   ./configure
   make
-  make test
+  pytest --verbose
   cd ../qt
   ./configure
   make

--- a/qt/configure
+++ b/qt/configure
@@ -148,7 +148,9 @@ else
     echo "WARNING: Replacement of python path with \"${PYTHON}\" FAILED. Maybe you ran configure more than once?"
 fi
 
-#start Makefile
+# Start Makefile
+printf ".PHONY: test test-v\n" >> ${MAKEFILE}
+
 printf "PREFIX=/usr\n" >> ${MAKEFILE}
 printf "DEST=\$(DESTDIR)\$(PREFIX)\n\n" >> ${MAKEFILE}
 
@@ -250,7 +252,7 @@ addUninstallDir                                             "/share/icons"
 addUninstallDir                                             "/share"
 addNewline
 
-#compress
+# compress
 printf "compress:\n" >> ${MAKEFILE}
 printf "\t# Man pages\n" >> ${MAKEFILE}
 printf "\tfor i in \$\$(ls -1 man/C/); do case \$\$i in *.gz|*~) continue;; *) gzip -n --best -c man/C/\$\$i > man/C/\$\${i}.gz;; esac; done\n\n" >> ${MAKEFILE}
@@ -262,11 +264,21 @@ cat ${UNINSTALL_FILES} >> ${MAKEFILE}
 printf "uninstall_dirs:\n" >> ${MAKEFILE}
 cat ${UNINSTALL_DIRS} >> ${MAKEFILE}
 
-#copy Makefile
+printf "test:\n" >> ${MAKEFILE}
+printf "\t@echo \"Target 'test' not available anymore. " >> ${MAKEFILE}
+printf "Use a test runner of your own choice " >> ${MAKEFILE}
+printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
+
+printf "\n\ntest-v:\n" >> ${MAKEFILE}
+printf "\t@echo \"Target 'test-v' not available anymore. " >> ${MAKEFILE}
+printf "Use a test runner of your own choice " >> ${MAKEFILE}
+printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
+
+# copy Makefile
 mv ${MAKEFILE} Makefile
 chmod 644 Makefile
 
-#clean up
+# clean up
 for i in "${UNINSTALL_FILES}" "${UNINSTALL_DIRS}"; do
     if [ -e "$i" ]; then
         rm "$i"

--- a/qt/configure
+++ b/qt/configure
@@ -149,7 +149,7 @@ else
 fi
 
 # Start Makefile
-printf ".PHONY: test test-v\n" >> ${MAKEFILE}
+printf ".PHONY: test test-v unitest unittest-v\n" >> ${MAKEFILE}
 
 printf "PREFIX=/usr\n" >> ${MAKEFILE}
 printf "DEST=\$(DESTDIR)\$(PREFIX)\n\n" >> ${MAKEFILE}
@@ -264,15 +264,12 @@ cat ${UNINSTALL_FILES} >> ${MAKEFILE}
 printf "uninstall_dirs:\n" >> ${MAKEFILE}
 cat ${UNINSTALL_DIRS} >> ${MAKEFILE}
 
-printf "test:\n" >> ${MAKEFILE}
-printf "\t@echo \"Target 'test' not available anymore. " >> ${MAKEFILE}
-printf "Use a test runner of your own choice " >> ${MAKEFILE}
-printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
-
-printf "\n\ntest-v:\n" >> ${MAKEFILE}
-printf "\t@echo \"Target 'test-v' not available anymore. " >> ${MAKEFILE}
-printf "Use a test runner of your own choice " >> ${MAKEFILE}
-printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
+for target in test test-v unittest unittest-v; do
+    printf "\n\n%s:\n" "$target" >> ${MAKEFILE}
+    printf "\t@echo \"Target '%s' not available anymore. " "$target">> ${MAKEFILE}
+    printf "Use a test runner of your own choice " >> ${MAKEFILE}
+    printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
+done
 
 # copy Makefile
 mv ${MAKEFILE} Makefile

--- a/qt/configure
+++ b/qt/configure
@@ -269,6 +269,7 @@ for target in test test-v unittest unittest-v; do
     printf "\t@echo \"Target '%s' not available anymore. " "$target">> ${MAKEFILE}
     printf "Use a test runner of your own choice " >> ${MAKEFILE}
     printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
+    printf "\n\t@false" >> ${MAKEFILE}
 done
 
 # copy Makefile


### PR DESCRIPTION
The make targets "test", "test-v", "unittest" and "unittest-v" are removed from the Makefiles in both components and replaced with deprecation messages.