### PR TITLE
build! Drop support Python version 3.9 & 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@
 # TravisCI (https://travis-ci.org) configuration file
 os: linux
  
-# Support End of "Focal" (20.04 LTS) is April 2025
+# Support End of "Focal" (20.04 LTS) was April 2025
 # dist: focal
 # Support End of "Jammy" (22.04 LTS) is April 2027
 # dist: jammy
@@ -22,11 +22,10 @@ arch:
  - amd64
 
 python:
-  - "3.9"
-  - "3.10"
   - "3.11"
   - "3.12"
   - "3.13"
+  - "nightly"
  
 addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
@@ -48,10 +47,9 @@ before_install:
 
 jobs:
   exclude:
-    - python: "3.9"
-    - python: "3.10"
     - python: "3.11"
     - python: "3.12"
+    # - python: "nightly"
 
 install:
   - pip install -U pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ python:
   - "3.11"
   - "3.12"
   - "3.13"
-  - "3.14-dev"
  
 addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ python:
   - "3.11"
   - "3.12"
   - "3.13"
-  - "nightly"
+  - "3.14-dev"
  
 addons:
   # add localhost to known_hosts to prevent ssh unknown host prompt during unit tests
@@ -49,7 +49,6 @@ jobs:
   exclude:
     - python: "3.11"
     - python: "3.12"
-    # - python: "nightly"
 
 install:
   - pip install -U pip

--- a/CHANGES
+++ b/CHANGES
@@ -10,7 +10,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Added: Shutdown confirmation dialog (#2102) (Huaide Jiang @LatiosInAltoMare)
 * Added: Check and warn if include list entries do not exists in backup source (#1586) (@rafaelhdr)
 * Added: Asciidoctor as build dependence (#2085)
-* Removed: **Breaking** Drop Python support for version 3.10 & 3.11
+* Removed: **Breaking** Drop Python support for version 3.9 & 3.10
 * Removed: Stop using QWindow.winId() (#2084)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file

--- a/CHANGES
+++ b/CHANGES
@@ -10,7 +10,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Added: Shutdown confirmation dialog (#2102) (Huaide Jiang @LatiosInAltoMare)
 * Added: Check and warn if include list entries do not exists in backup source (#1586) (@rafaelhdr)
 * Added: Asciidoctor as build dependence (#2085)
-* Removed: **Breaking** Drop Python support for version 3.9 & 3.10
+* Removed: **Breaking** Drop Python support for version 3.9 & 3.10 (#2129)
 * Removed: Stop using QWindow.winId() (#2084)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Added: Shutdown confirmation dialog (#2102) (Huaide Jiang @LatiosInAltoMare)
 * Added: Check and warn if include list entries do not exists in backup source (#1586) (@rafaelhdr)
 * Added: Asciidoctor as build dependence (#2085)
+* Removed: **Breaking** Drop Python support for version 3.10 & 3.11
 * Removed: Stop using QWindow.winId() (#2084)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ distribution.
 
 * Runtime dependencies for the CLI
 
-  - `python3` (>= 3.9)
+  - `python3` (>= 3.11)
   - `rsync`
   - `cron-daemon`
   - `openssh-client`


### PR DESCRIPTION
At Python upstream, oldest version with active support is 3.12. Version 3.11, 3.10 and 3.9 do get security fixes only. 3.9. will be dead in October this year.

In autumn, when Debian release version 13 "Trixie", it will support Python 3.13. Debian 12 (oldstable then) will support Python 3.11.