### PR TITLE
fix: Prevent name conflict in config method

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -750,7 +750,7 @@ class Config(configfile.ConfigFileWithProfiles):
         return self.pw.password(
             parent, profile_id, mode, pw_id, only_from_keyring)
 
-    def setPassword(self, password, profile_id=None, mode=None, pw_id=1):
+    def setPassword(self, password_value, profile_id=None, mode=None, pw_id=1):
         if self.pw is None:
             self.pw = password.Password(self)
 
@@ -760,7 +760,7 @@ class Config(configfile.ConfigFileWithProfiles):
         if mode is None:
             mode = self.snapshotsMode(profile_id)
 
-        self.pw.setPassword(password, profile_id, mode, pw_id)
+        self.pw.setPassword(password_value, profile_id, mode, pw_id)
 
     def modeNeedPassword(self, mode, pw_id = 1):
         need_pw = self.SNAPSHOT_MODES[mode][pw_id + 1]


### PR DESCRIPTION
The config module imports `password`. Previously, the `setPassword` method used the conflicting argument name `password`, which shadowed the name of the imported module. It also attemptd to _use_ the shadowed module name if `self.pw` was None, which means that sometimes the method would work, and sometimes it wouldn't.

I've resolved this by renaming the argument name to `password_value`.

(Needed by #2039)