### PR TITLE
feat(gui): ScheduleWidget disable Udev entry in SSH modes

### DIFF
--- a/qt/manageprofiles/combobox.py
+++ b/qt/manageprofiles/combobox.py
@@ -50,12 +50,19 @@ class BitComboBox(QComboBox):
         """Data linked to the current selected entry."""
         return self.itemData(self.currentIndex())
 
-    def select_by_data(self, data: Any):
-        """Select an entry in the combo box by its underlying data."""
+    def _idx_by_data(self, data: Any) -> int:
         for idx in range(self.count()):
             if self.itemData(idx) == data:
-                self.setCurrentIndex(idx)
-                return
+                return idx
 
-        raise ValueError('Unable to select combo box entry because data not '
+        raise ValueError('Unable to find combo box entry because data not '
                          f'found in it. Data is: {data} (type: {type(data)})')
+
+    def enable_by_data(self, data: Any, enable: bool = True):
+        """Enable or disable an entry based on its underlying data."""
+        idx = self._idx_by_data(data)
+        self.model().item(idx).setEnabled(enable)
+
+    def select_by_data(self, data: Any):
+        """Select an entry in the combo box by its underlying data."""
+        self.setCurrentIndex(self._idx_by_data(data))

--- a/qt/manageprofiles/schedulewidget.py
+++ b/qt/manageprofiles/schedulewidget.py
@@ -12,14 +12,14 @@
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """The widget to setup scheduling backup jobs."""
 import datetime
-from PyQt6.QtWidgets import (QHBoxLayout,
+from PyQt6.QtWidgets import (QCheckBox,
                              QFormLayout,
                              QGroupBox,
-                             QWidget,
+                             QHBoxLayout,
                              QLabel,
                              QLineEdit,
                              QSpinBox,
-                             QCheckBox)
+                             QWidget)
 import config
 import tools
 import qttools
@@ -33,7 +33,7 @@ class ScheduleWidget(QGroupBox):
     """
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, parent):
+    def __init__(self, parent: QWidget, allow_udev: bool = True):
         super().__init__(title=_('Schedule'), parent=parent)
 
         main_layout = QFormLayout(self)
@@ -123,6 +123,9 @@ class ScheduleWidget(QGroupBox):
         self._rowidx_debug = main_layout.rowCount()
         main_layout.addRow(self._check_debug)
 
+        if not allow_udev:
+            self.allow_udev(False)
+
         # Signal
         self._combo_schedule_mode.currentIndexChanged.connect(
             self._slot_schedule_mode_changed)
@@ -166,6 +169,16 @@ class ScheduleWidget(QGroupBox):
         }
 
         return combobox.BitComboBox(self, schedule_modes)
+
+    def allow_udev(self, allow: bool):
+        """Enable or disable the udev-schedule entry."""
+        # If "Udev" is selected but not allowed anymore set scheduling back to
+        # "Disabled"
+        if (self._combo_schedule_mode.current_data == config.Config.UDEV
+                and not allow):
+            self._combo_schedule_mode.select_by_data(config.Config.NONE)
+
+        self._combo_schedule_mode.enable_by_data(config.Config.UDEV, allow)
 
     def _time_combobox(self) -> combobox.BitComboBox:
         """Combobox with time/hours (e.g. 03:00).

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -715,6 +715,9 @@ class GeneralTab(QDialog):
             # self.modeLocalEncfs = self.modeLocal
             # self.modeSshEncfs = self.modeSsh
 
+            self._wdg_schedule.allow_udev(
+                active_mode in ('local', 'local_encfs'))
+
         if self.config.modeNeedPassword(active_mode):
 
             self.lblPassword1.setText(


### PR DESCRIPTION
Scheduling widget in Manage profiles dialog now reflects the behavior that UDev scheduling rules not allowed in profiles of mode SSH and SSH (encrypted).