### PR TITLE
fix: Unlocking SSHkey with passphrase on new created SSH profiles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Fixed: Stop waking up monitor when inhibit suspend on backup starts (#714, #1090)
 * Fixed: Avoid shutdown confirmation dialog on Budgie and Cinnamon desktop environments (#788)
 * Fixed: Crash in "Manage profiles" dialog when using "qt6ct" (#2128)
+* Fixed: Unlocking SSH keys with passphrases on new created profiles (#2164) (@davidfjoh)
 
 Version 1.5.4 (2025-03-24)
 * Breaking Change: Auto-remove rules "Free inodes" and "Free space" disabled by default in new created profiles (#1976)

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2012-2022 Germar Reitze
+L# SPDX-FileCopyrightText: © 2012-2022 Germar Reitze
 # SPDX-FileCopyrightText: © 2012-2022 Taylor Raack
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
@@ -436,6 +436,13 @@ class SSH(MountControl):
                         pw_id=1,
                         refresh=True,
                     )
+
+                if self.password:
+                    thread.stop()
+                    logger.debug('Provide password through temp FIFO', self)
+                    thread = password_ipc.TempPasswordThread(self.password)
+                    env['ASKPASS_TEMP'] = thread.temp_file
+                    thread.start()
 
                 proc = subprocess.Popen(['ssh-add', self.private_key_file],
                                         stdin=subprocess.PIPE,

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -1,4 +1,4 @@
-L# SPDX-FileCopyrightText: © 2012-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2012-2022 Germar Reitze
 # SPDX-FileCopyrightText: © 2012-2022 Taylor Raack
 #
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/doc/maintain/BiT_release_process.md
+++ b/doc/maintain/BiT_release_process.md
@@ -328,6 +328,8 @@ expected. The following list suggests several actions and scenarios.
   - Always start from terminal to catch silent errors and warnings.
   - Create backup profils in all available flavors (Local, SSH, each with and
     without encryption).
+    * Keep the variants of that flavors in mind and test them: SSH key with and
+      without passphrase, cached, in keyring, ...
   - Take backup.
   - Restore backup.
   - Delete backup.


### PR DESCRIPTION
Issue: 
In commit:
Commit https://github.com/bit-team/backintime/commit/1ecedfa5016d597463c2cd80c5c12ba5a4665e83, 
a change was made to run ssh-keygen with 'SSH_ASKPASS_REQUIRE': 'prefer'.
However, this used up the password placed in the FIFO that was put there for the use in the following invocation of ssh-add.
This caused the ssh-add to not have a waiting password in the FIFO, resulting in a failure.  
Specifically as a new user I was not able to create my first profile with a mode of SSH. 

Fix:  Refill the FIFO after the ssh-keygen check.

Close #2164