### PR TITLE
Refactor include from __init__.py and created tab_include.py

### DIFF
--- a/common/version.py
+++ b/common/version.py
@@ -13,7 +13,7 @@ See Issue #1575 for details about that migration.
 import re
 
 # Version string regularyly used by the application and presented to users.
-__version__ = '1.6.0-dev.0927479b'
+__version__ = '1.6.0-dev.4182e888'
 
 # Version string ends with lower case ``rc`` and optionally with a number.
 # e.g. "1.6.0rc", "1.6.0-rc", "1.6.0-rc2"

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -41,6 +41,7 @@ from manageprofiles.tab_general import GeneralTab
 from manageprofiles.tab_remove_retention import RemoveRetentionTab
 from manageprofiles.tab_options import OptionsTab
 from manageprofiles.tab_expert_options import ExpertOptionsTab
+from manageprofiles.tab_include import IncludeTab
 from editusercallback import EditUserCallback
 from restoreconfigdialog import RestoreConfigDialog
 from bitwidgets import ProfileCombo
@@ -114,43 +115,10 @@ class SettingsDialog(QDialog):
         _add_tab(self._tab_general, _('&General'))
 
         # TAB: Include
-        tabWidget = QWidget(self)
-        self.tabs.addTab(tabWidget, _('&Include'))
-        layout = QVBoxLayout(tabWidget)
-
-        self.listInclude = QTreeWidget(self)
-        self.listInclude.setSelectionMode(
-            QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.listInclude.setRootIsDecorated(False)
-        self.listInclude.setHeaderLabels(
-            [_('Include files and directories'), 'Count'])
-
-        self.listInclude.header().setSectionResizeMode(
-            0, QHeaderView.ResizeMode.Stretch)
-        self.listInclude.header().setSectionsClickable(True)
-        self.listInclude.header().setSortIndicatorShown(True)
-        self.listInclude.header().setSectionHidden(1, True)
-        self.listIncludeSortLoop = False
-        self.listInclude.header().sortIndicatorChanged \
-            .connect(self.includeCustomSortOrder)
-
-        layout.addWidget(self.listInclude)
-        self.listIncludeCount = 0
-
-        buttonsLayout = QHBoxLayout()
-        layout.addLayout(buttonsLayout)
-
-        self.btnIncludeFile = QPushButton(icon.ADD, _('Add file'), self)
-        buttonsLayout.addWidget(self.btnIncludeFile)
-        self.btnIncludeFile.clicked.connect(self.btnIncludeFileClicked)
-
-        self.btnIncludeAdd = QPushButton(icon.ADD, _('Add directory'), self)
-        buttonsLayout.addWidget(self.btnIncludeAdd)
-        self.btnIncludeAdd.clicked.connect(self.btnIncludeAddClicked)
-
-        self.btnIncludeRemove = QPushButton(icon.REMOVE, _('Remove'), self)
-        buttonsLayout.addWidget(self.btnIncludeRemove)
-        self.btnIncludeRemove.clicked.connect(self.btnIncludeRemoveClicked)
+        self._tab_include = IncludeTab(self)
+        _add_tab(self._tab_include, _('&Include'))
+        # For backward compatibility with existing logic below
+        self.listInclude = self._tab_include.listInclude
 
         # TAB: Exclude
         tabWidget = QWidget(self)
@@ -493,37 +461,6 @@ class SettingsDialog(QDialog):
 
         return answer == QMessageBox.StandardButton.Yes
 
-    def addInclude(self, data):
-        item = QTreeWidgetItem()
-
-        # Directory(0) or file(1)?
-        if data[1] == 0:
-            item.setIcon(0, self.icon.FOLDER)
-        else:
-            item.setIcon(0, self.icon.FILE)
-
-        # Prevent duplicates
-        duplicates = self.listInclude.findItems(data[0], MATCH_FLAGS)
-
-        if duplicates:
-            self.listInclude.setCurrentItem(duplicates[0])
-            return
-
-        # First column
-        item.setText(0, data[0])
-        item.setData(0, Qt.ItemDataRole.UserRole, data[1])
-        self.listIncludeCount += 1
-
-        # Second (hidden!) column.
-        # Don't know why we need it.
-        item.setText(1, str(self.listIncludeCount).zfill(6))
-        item.setData(1, Qt.ItemDataRole.UserRole, self.listIncludeCount)
-
-        self.listInclude.addTopLevelItem(item)
-
-        # Select/highlight that entry.
-        self.listInclude.setCurrentItem(item)
-
     def _add_exclude_pattern(self, pattern):
         item = QTreeWidgetItem()
         item.setText(0, pattern)
@@ -629,41 +566,6 @@ class SettingsDialog(QDialog):
         for path in self.config.DEFAULT_EXCLUDE:
             self.addExclude(path)
 
-    def btnIncludeRemoveClicked(self):
-        for item in self.listInclude.selectedItems():
-            index = self.listInclude.indexOfTopLevelItem(item)
-            if index < 0:
-                continue
-
-            self.listInclude.takeTopLevelItem(index)
-
-        if self.listInclude.topLevelItemCount() > 0:
-            self.listInclude.setCurrentItem(self.listInclude.topLevelItem(0))
-
-    def btnIncludeFileClicked(self):
-        """Development Note (buhtz 2023-12):
-        This is a candidate for refactoring. See btnIncludeAddClicked() with
-        much duplicated code.
-        """
-
-        for path in qttools.getOpenFileNames(self, _('Include file')):
-            if not path:
-                continue
-
-            if os.path.islink(path) \
-                and not (self.cbCopyUnsafeLinks.isChecked()
-                         or self.cbCopyLinks.isChecked()):
-
-                if self._ask_include_symlinks_target(path):
-                    path = os.path.realpath(path)
-
-            path = self.config.preparePath(path)
-
-            for index in range(self.listInclude.topLevelItemCount()):
-                if path == self.listInclude.topLevelItem(index).text(0):
-                    continue
-
-            self.addInclude((path, 1))
 
     def _ask_include_symlinks_target(self, path):
         question_msg = _(
@@ -675,29 +577,6 @@ class SettingsDialog(QDialog):
 
         return self.questionHandler(question_msg)
 
-    def btnIncludeAddClicked(self):
-        """Development Note (buhtz 2023-12):
-        This is a candidate for refactoring. See btnIncludeFileClicked() with
-        much duplicated code.
-        """
-        for path in qttools.getExistingDirectories(self, _('Include directory')):
-            if not path:
-                continue
-
-            if os.path.islink(path) \
-                and not (self.cbCopyUnsafeLinks.isChecked()
-                         or self.cbCopyLinks.isChecked()):
-
-                if self._ask_include_symlinks_target(path):
-                    path = os.path.realpath(path)
-
-            path = self.config.preparePath(path)
-
-            for index in range(self.listInclude.topLevelItemCount()):
-                if path == self.listInclude.topLevelItem(index).text(0):
-                    continue
-
-            self.addInclude((path, 0))
 
     def slot_combo_modes_changed(self, *params):
         """Hide/show widget elements related to one of
@@ -783,10 +662,6 @@ class SettingsDialog(QDialog):
         header.model().sort(newColumn, newOrder)
 
         return loop
-
-    def includeCustomSortOrder(self, *args):
-        self.listIncludeSortLoop = self.customSortOrder(
-            self.listInclude.header(), self.listIncludeSortLoop, *args)
 
     def excludeCustomSortOrder(self, *args):
         self.listExcludeSortLoop = self.customSortOrder(

--- a/qt/manageprofiles/tab_include.py
+++ b/qt/manageprofiles/tab_include.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Taylor Raak
+# SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+"""The IncludeTab class for managing include paths"""
+import os
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (QWidget,
+                             QVBoxLayout,
+                             QHBoxLayout,
+                             QTreeWidget,
+                             QTreeWidgetItem,
+                             QPushButton,
+                             QHeaderView,
+                             QAbstractItemView)
+import qttools
+
+
+class IncludeTab(QWidget):
+    """Tab for managing include files and directories."""
+    def __init__(self, parent):
+        super().__init__(parent=parent)
+
+        self._parent_dialog = parent
+        self.icon = parent.icon
+        self.config = parent.config
+
+        layout = QVBoxLayout(self)
+
+        self.list_include = QTreeWidget(self)
+        self.list_include.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.list_include.setRootIsDecorated(False)
+        self.list_include.setHeaderLabels([
+            _('Include files and directories'), 'Count'
+        ])
+        self.list_include.header().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch
+        )
+        self.list_include.header().setSectionsClickable(True)
+        self.list_include.header().setSortIndicatorShown(True)
+        self.list_include.header().setSectionHidden(1, True)
+        layout.addWidget(self.list_include)
+
+        self.list_include_count = 0
+        self.list_include_sort_loop = False
+        self.list_include.header().sortIndicatorChanged.connect(
+            self.include_custom_sort_order
+        )
+
+        buttons_layout = QHBoxLayout()
+        layout.addLayout(buttons_layout)
+
+        self.btn_include_file = QPushButton(self.icon.ADD, _('Add file'), self)
+        buttons_layout.addWidget(self.btn_include_file)
+        self.btn_include_file.clicked.connect(self.btn_include_file_clicked)
+
+        self.btn_include_add = QPushButton(
+            self.icon.ADD, _('Add directory'), self
+        )
+        buttons_layout.addWidget(self.btn_include_add)
+        self.btn_include_add.clicked.connect(self.btn_include_add_clicked)
+
+        self.btn_include_remove = QPushButton(
+            self.icon.REMOVE, _('Remove'), self
+        )
+        buttons_layout.addWidget(self.btn_include_remove)
+        self.btn_include_remove.clicked.connect(
+            self.btn_include_remove_clicked
+        )
+
+    def add_include(self, data):
+        """Add a file or directory to the list."""
+        item = QTreeWidgetItem()
+        icon = self.icon.FOLDER if data[1] == 0 else self.icon.FILE
+        item.setIcon(0, icon)
+        duplicates = self.list_include.findItems(
+            data[0],
+            Qt.MatchFlag.MatchFixedString | Qt.MatchFlag.MatchCaseSensitive
+        )
+        if duplicates:
+            self.list_include.setCurrentItem(duplicates[0])
+            return
+        item.setText(0, data[0])
+        item.setData(0, Qt.ItemDataRole.UserRole, data[1])
+        self.list_include_count += 1
+        item.setText(1, str(self.list_include_count).zfill(6))
+        item.setData(1, Qt.ItemDataRole.UserRole, self.list_include_count)
+        self.list_include.addTopLevelItem(item)
+        self.list_include.setCurrentItem(item)
+
+    def btn_include_remove_clicked(self):
+        """Handle removal of selected include entries."""
+        for item in self.list_include.selectedItems():
+            index = self.list_include.indexOfTopLevelItem(item)
+            if index >= 0:
+                self.list_include.takeTopLevelItem(index)
+        if self.list_include.topLevelItemCount() > 0:
+            self.list_include.setCurrentItem(self.list_include.topLevelItem(0))
+
+    def btn_include_file_clicked(self):
+        """Handle file-adding button click."""
+        for path in qttools.getOpenFileNames(self, _('Include file')):
+            if not path:
+                continue
+            if os.path.islink(path) and not (
+                self._parent_dialog.cbCopyUnsafeLinks.isChecked() or
+                self._parent_dialog.cbCopyLinks.isChecked()
+            ):
+                if self._parent_dialog._ask_include_symlinks_target(path):
+                    path = os.path.realpath(path)
+            path = self.config.preparePath(path)
+            self.add_include((path, 1))
+
+    def btn_include_add_clicked(self):
+        """Handle directory-adding button click."""
+        for path in qttools.getExistingDirectories(
+            self, _('Include directory')
+        ):
+            if not path:
+                continue
+            if os.path.islink(path) and not (
+                self._parent_dialog.cbCopyUnsafeLinks.isChecked() or
+                self._parent_dialog.cbCopyLinks.isChecked()
+            ):
+                if self._parent_dialog._ask_include_symlinks_target(path):
+                    path = os.path.realpath(path)
+            path = self.config.preparePath(path)
+            self.add_include((path, 0))
+
+    def include_custom_sort_order(self, *args):
+        """Trigger custom sort order when header is clicked."""
+        self.list_include_sort_loop = self._custom_sort_order(
+            self.list_include.header(), self.list_include_sort_loop, *args
+        )
+
+    def _custom_sort_order(self, header, loop, new_column, new_order):
+        """Implements custom sort toggle behavior."""
+        if new_column == 0 and new_order == Qt.SortOrder.AscendingOrder:
+            if loop:
+                new_column, new_order = 1, Qt.SortOrder.AscendingOrder
+                header.setSortIndicator(new_column, new_order)
+                loop = False
+            else:
+                loop = True
+        header.model().sort(new_column, new_order)
+        return loop

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -46,6 +46,7 @@ full_test_files = [_base_dir / fp for fp in (
     'manageprofiles/statebindcheckbox.py',
     'manageprofiles/schedulewidget.py',
     'manageprofiles/sshproxywidget.py',
+    'manageprofiles/tab_include.py',
     'plugins/notifyplugin.py',
     'shutdowndlg.py',
     'statedata.py',


### PR DESCRIPTION
Refactored __init__.py by relocating most of the code that has to do with include to the tab_include.py file. 

There was not a lot of changes to be made other than linting and making sure that the class was set up correctly in the tab_include.py. So reviewing that and making sure that those are up to par would be greatly appreciated.

In the __init__.py I removed then relocated most of the code that had to do with include as well as changed how it is called and made sure that it still worked with the code that had to remain in the __init__.py.
