### PR TITLE
Test ssh password unlock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ script:
   - cd common
   - ./configure
   - make
+  # Install to ensure that backintime-askpass is on $PATH
+  - sudo make install
   - pytest --verbose
   - cd ..
   - cd qt

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ Back In Time
 Version 1.6.0-dev (development of upcoming release)
 * Changed: **Breaking** A "snapshot" now is a "backup" (#1929)
 * Changed: **Breaking** Deprecated and removed make targets: "test", "test-v", "unittest", "unittest-v"
+* Changed: Unlocking ssh-agent use "force" instead of "prefer" for SSH_ASKPASS_REQUIRE (#2170) (@daviewales)
 * Changed: Stop passing window ID when inhibiting suspend via D-Bus power manager (#2084)
 * Changed: Reorder DBUS service provider list for suspend mode inhibition (#2084)
 * Changed: Man pages generated from AsciiDoc, except backintime-config (#2085)

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -426,6 +426,7 @@ class SSH(MountControl):
 
                 # if backintime-askpass supplied an invalid cached password
                 if proc.returncode > 0:
+                    logger.debug('Cached SSH password invalid')
                     pw = password.Password()
 
                     # pw_id = 1 corresponds to the SSH password

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -347,6 +347,8 @@ class SSH(MountControl):
 
         env = os.environ.copy()
         env['SSH_ASKPASS'] = 'backintime-askpass'
+        # Ensure ssh uses backintime-askpass
+        env['SSH_ASKPASS_REQUIRE'] = 'force'
         env['ASKPASS_PROFILE_ID'] = self.profile_id
         env['ASKPASS_MODE'] = self.mode
 
@@ -415,11 +417,11 @@ class SSH(MountControl):
                 # ssh-add below. See Issue #1852.
 
                 # Validate cached SSH key password:
+                logger.debug('Check if password is valid for private key')
                 proc = subprocess.run(
                         ['ssh-keygen', '-y', '-f', self.private_key_file],
                         capture_output=True,
-                        # Ensure ssh-keygen uses backintime-askpass
-                        env=env | {'SSH_ASKPASS_REQUIRE': 'prefer'}
+                        env=env,
                 )
 
                 # if backintime-askpass supplied an invalid cached password

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -90,7 +90,7 @@ class SSH(MountControl):
     def __init__(self, *args, **kwargs):
 
         # init MountControl
-        super(SSH, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         # Workaround for linters
         self.user = None

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -66,6 +66,43 @@ class General(generic.SSHTestCase):
         with self.assertRaisesRegex(MountException, r"Could not unlock ssh private key\. Wrong password or password not available for cron\."):
             ssh.unlockSshAgent(force = True)
 
+    def test_unlockSshAgentKeyWithPassword(self):
+        subprocess.run(
+            ['ssh-add', '-D'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        private_key = os.path.join(
+            self.tmpDir.name,
+            'test_private_key'
+        )
+        private_key_password = 'test_private_key_password'
+
+        # generate temporary test key
+        subprocess.run(
+            [
+                'ssh-keygen',
+                '-f', private_key,
+                '-N', private_key_password
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        ssh = sshtools.SSH(
+            cfg=self.cfg,
+            private_key_file=private_key,
+            password=private_key_password,
+        )
+        ssh.unlockSshAgent(force=True)
+        ssh_add = subprocess.run(
+            ['ssh-add', '-l'],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn(ssh.private_key_fingerprint, ssh_add.stdout)
+
     def test_checkLogin(self):
         ssh = sshtools.SSH(cfg = self.cfg)
         ssh.checkLogin()


### PR DESCRIPTION
Add a test for #2164.

I've confirmed that this test correctly fails before #2163, and correctly passes after.

I also updated the `super()` call in `sshtools.SSH` to use the more modern `super()` form, rather than `super(SSH, self)`.