### PR TITLE
refactor: Separate code of Include-/Exclude tab, Exclude tab #2167

### DIFF
--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -139,8 +139,8 @@ class SettingsDialog(QDialog):
             parent=self)
         btnRestore = buttonBox.addButton(
             _('Restore Config'), QDialogButtonBox.ButtonRole.ResetRole)
-        btnUserCallback = buttonBox.addButton(
-            _('Edit user-callback'), QDialogButtonBox.ButtonRole.ResetRole)
+        # btnUserCallback = buttonBox.addButton(
+        #     _('Edit user-callback'), QDialogButtonBox.ButtonRole.ResetRole)
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
         btnRestore.clicked.connect(self.restoreConfig)
@@ -150,12 +150,23 @@ class SettingsDialog(QDialog):
         self.updateProfiles()
         self.slot_combo_modes_changed()
 
+        self._restore_dims_and_coods()
+
         # enable tabs scroll buttons again but keep dialog size
-        size = self.sizeHint()
-        self.tabs.setUsesScrollButtons(scrollButtonDefault)
-        self.resize(size)
+        # size = self.sizeHint()
+        # self.tabs.setUsesScrollButtons(scrollButtonDefault)
+        # self.resize(size)
 
         self.finished.connect(self._slot_finished)
+
+        # Observe other widgets values:
+        # "Warn free space" (Options tab) and "Remove at min free space"
+        # (Retention & Remove tab). Both widgets/tabs will be informed if
+        # the value of the other has changed.
+        self._tab_retention.event_remove_free_space_value_changed.register(
+            self._tab_options.remove_free_space_value_changed)
+        self._tab_options.event_warn_free_space_value_changed.register(
+            self._tab_retention.warn_free_space_value_changed)
 
     def addProfile(self):
         ret_val = QInputDialog.getText(self, _('New profile'), str())
@@ -210,6 +221,21 @@ class SettingsDialog(QDialog):
             self.saveProfile()
             self.config.setCurrentProfile(current_profile_id)
             self.updateProfile()
+
+    def _restore_dims_and_coords(self, move=True):
+        active_mode = self._tab_general.get_active_snapshots_mode()
+
+        try:
+            dims, coords = self.state_data.get_manageprofiles_dims_coords(
+                active_mode)
+
+        except KeyError:
+            pass
+
+        else:
+            if move:
+                self.move(*coords)
+            self.resize(*dims)
 
     def updateProfiles(self, reloadSettings=True):
         if reloadSettings:
@@ -280,13 +306,6 @@ class SettingsDialog(QDialog):
         answer = messagebox.warningYesNo(self, message)
 
         return answer == QMessageBox.StandardButton.Yes
-
-    # def fillCombo(self, combo, d):
-    #     keys = list(d.keys())
-    #     keys.sort()
-
-    #     for key in keys:
-    #         combo.addItem(QIcon(), d[key], key)
 
     def setComboValue(self, combo, value, t='int'):
         for i in range(combo.count()):

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -11,10 +11,8 @@
 # This file is part of the program "Back In Time" which is released under GNU
 # General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
-import os
 import re
 import copy
-from PyQt6.QtGui import QPalette, QBrush
 from PyQt6.QtWidgets import (QDialog,
                              QVBoxLayout,
                              QHBoxLayout,
@@ -26,15 +24,7 @@ from PyQt6.QtWidgets import (QDialog,
                              QWidget,
                              QTabWidget,
                              QLabel,
-                             QPushButton,
-                             QSpinBox,
-                             QTreeWidget,
-                             QTreeWidgetItem,
-                             QAbstractItemView,
-                             QHeaderView,
-                             QCheckBox)
-from PyQt6.QtCore import Qt
-import tools
+                             QPushButton)
 import qttools
 import messagebox
 from statedata import StateData
@@ -43,18 +33,15 @@ from manageprofiles.tab_remove_retention import RemoveRetentionTab
 from manageprofiles.tab_options import OptionsTab
 from manageprofiles.tab_expert_options import ExpertOptionsTab
 from manageprofiles.tab_include import IncludeTab
+from manageprofiles.tab_exclude import ExcludeTab
 from restoreconfigdialog import RestoreConfigDialog
 from bitwidgets import ProfileCombo
-
-
-MATCH_FLAGS = Qt.MatchFlag.MatchFixedString | Qt.MatchFlag.MatchCaseSensitive
 
 
 class SettingsDialog(QDialog):
     def __init__(self, parent):
         super(SettingsDialog, self).__init__(parent)
 
-        self.state_data = StateData()
         self.parent = parent
         self.config = parent.config
         self.snapshots = parent.snapshots
@@ -118,106 +105,10 @@ class SettingsDialog(QDialog):
         # TAB: Include
         self._tab_include = IncludeTab(self)
         _add_tab(self._tab_include, _('&Include'))
-        # For backward compatibility with existing logic below
-        self.listInclude = self._tab_include.list_include
 
         # TAB: Exclude
-        tabWidget = QWidget(self)
-        self.tabs.addTab(tabWidget, _('&Exclude'))
-        layout = QVBoxLayout(tabWidget)
-
-        self.lblSshEncfsExcludeWarning = QLabel(_(
-            "{BOLD}Info{ENDBOLD}: "
-            "In 'SSH encrypted' mode, only single or double asterisks are "
-            "functional (e.g. {example2}). Other types of wildcards and "
-            "patterns will be ignored (e.g. {example1}). Filenames are "
-            "unpredictable in this mode due to encryption by EncFS.").format(
-                BOLD='<strong>',
-                ENDBOLD='</strong>',
-                example1="<code>'foo*'</code>, "
-                         "<code>'[fF]oo'</code>, "
-                         "<code>'fo?'</code>",
-                example2="<code>'foo/*'</code>, "
-                         "<code>'foo/**/bar'</code>"
-            ),
-            self
-        )
-        self.lblSshEncfsExcludeWarning.setWordWrap(True)
-        layout.addWidget(self.lblSshEncfsExcludeWarning)
-
-        self.listExclude = QTreeWidget(self)
-        self.listExclude.setSelectionMode(
-            QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.listExclude.setRootIsDecorated(False)
-        self.listExclude.setHeaderLabels(
-            [_('Exclude patterns, files or directories'), 'Count'])
-
-        self.listExclude.header().setSectionResizeMode(
-            0, QHeaderView.ResizeMode.Stretch)
-        self.listExclude.header().setSectionsClickable(True)
-        self.listExclude.header().setSortIndicatorShown(True)
-        self.listExclude.header().setSectionHidden(1, True)
-        self.listExcludeSortLoop = False
-        self.listExclude.header().sortIndicatorChanged \
-            .connect(self.excludeCustomSortOrder)
-
-        layout.addWidget(self.listExclude)
-
-        self._label_exclude_recommend = QLabel('', self)
-        self._label_exclude_recommend.setWordWrap(True)
-        layout.addWidget(self._label_exclude_recommend)
-
-        buttonsLayout = QHBoxLayout()
-        layout.addLayout(buttonsLayout)
-
-        self.btnExcludeAdd = QPushButton(icon.ADD, _('Add'), self)
-        buttonsLayout.addWidget(self.btnExcludeAdd)
-        self.btnExcludeAdd.clicked.connect(self.btnExcludeAddClicked)
-
-        self.btnExcludeFile = QPushButton(icon.ADD, _('Add file'), self)
-        buttonsLayout.addWidget(self.btnExcludeFile)
-        self.btnExcludeFile.clicked.connect(self.btnExcludeFileClicked)
-
-        self.btnExcludeFolder = QPushButton(icon.ADD, _('Add directory'), self)
-        buttonsLayout.addWidget(self.btnExcludeFolder)
-        self.btnExcludeFolder.clicked.connect(self.btnExcludeFolderClicked)
-
-        self.btnExcludeDefault = QPushButton(icon.DEFAULT_EXCLUDE,
-                                             _('Add default'),
-                                             self)
-        buttonsLayout.addWidget(self.btnExcludeDefault)
-        self.btnExcludeDefault.clicked.connect(self.btnExcludeDefaultClicked)
-
-        self.btnExcludeRemove = QPushButton(icon.REMOVE, _('Remove'), self)
-        buttonsLayout.addWidget(self.btnExcludeRemove)
-        self.btnExcludeRemove.clicked.connect(self.btnExcludeRemoveClicked)
-
-        # exclude files by size
-        hlayout = QHBoxLayout()
-        layout.addLayout(hlayout)
-        self.cbExcludeBySize = QCheckBox(
-            _('Exclude files bigger than:'), self)
-        qttools.set_wrapped_tooltip(
-            self.cbExcludeBySize,
-            [
-                _('Exclude files bigger than value in {size_unit}.')
-                .format(size_unit='MiB'),
-                _("With 'Full rsync mode' disabled, this setting affects only "
-                  "newly created files, as rsync treats it as transfer option "
-                  "rather than an exclusion rule. Consequently, large files "
-                  "that have already been backed up will remain in backups "
-                  "even if they are modified.")
-            ]
-        )
-        hlayout.addWidget(self.cbExcludeBySize)
-        self.spbExcludeBySize = QSpinBox(self)
-        self.spbExcludeBySize.setSuffix(' MiB')
-        self.spbExcludeBySize.setRange(0, 100000000)
-        hlayout.addWidget(self.spbExcludeBySize)
-        hlayout.addStretch()
-        enabled = lambda state: self.spbExcludeBySize.setEnabled(state)
-        enabled(False)
-        self.cbExcludeBySize.stateChanged.connect(enabled)
+        self._tab_exclude = ExcludeTab(self)
+        _add_tab(self._tab_exclude, _('&Exclude'))
 
         # TAB: Auto-remove
         self._tab_retention = RemoveRetentionTab(self)
@@ -248,34 +139,23 @@ class SettingsDialog(QDialog):
             parent=self)
         btnRestore = buttonBox.addButton(
             _('Restore Config'), QDialogButtonBox.ButtonRole.ResetRole)
-        # btnUserCallback = buttonBox.addButton(
-        #     _('Edit user-callback'), QDialogButtonBox.ButtonRole.ResetRole)
+        btnUserCallback = buttonBox.addButton(
+            _('Edit user-callback'), QDialogButtonBox.ButtonRole.ResetRole)
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
         btnRestore.clicked.connect(self.restoreConfig)
-        # btnUserCallback.clicked.connect(self.editUserCallback)
+        btnUserCallback.clicked.connect(self.editUserCallback)
         self.mainLayout.addWidget(buttonBox)
 
         self.updateProfiles()
         self.slot_combo_modes_changed()
 
-        self._restore_dims_and_coords()
-
-        # # enable tabs scroll buttons again but keep dialog size
-        # size = self.sizeHint()
-        # self.tabs.setUsesScrollButtons(scrollButtonDefault)
-        # self.resize(size)
+        # enable tabs scroll buttons again but keep dialog size
+        size = self.sizeHint()
+        self.tabs.setUsesScrollButtons(scrollButtonDefault)
+        self.resize(size)
 
         self.finished.connect(self._slot_finished)
-
-        # Observe other widgets values:
-        # "Warn free space" (Options tab) and "Remove at min free space"
-        # (Retention & Remove tab). Both widgets/tabs will be informed if
-        # the value of the other has changed.
-        self._tab_retention.event_remove_free_space_value_changed.register(
-            self._tab_options.remove_free_space_value_changed)
-        self._tab_options.event_warn_free_space_value_changed.register(
-            self._tab_retention.warn_free_space_value_changed)
 
     def addProfile(self):
         ret_val = QInputDialog.getText(self, _('New profile'), str())
@@ -331,21 +211,6 @@ class SettingsDialog(QDialog):
             self.config.setCurrentProfile(current_profile_id)
             self.updateProfile()
 
-    def _restore_dims_and_coords(self, move=True):
-        active_mode = self._tab_general.get_active_snapshots_mode()
-
-        try:
-            dims, coords = self.state_data.get_manageprofiles_dims_coords(
-                active_mode)
-
-        except KeyError:
-            pass
-
-        else:
-            if move:
-                self.move(*coords)
-            self.resize(*dims)
-
     def updateProfiles(self, reloadSettings=True):
         if reloadSettings:
             self.updateProfile()
@@ -361,28 +226,6 @@ class SettingsDialog(QDialog):
 
         self.disableProfileChanged = False
 
-    def _update_exclude_recommend_label(self):
-        """Update the label about recommended exclude patterns."""
-
-        # Default patterns that are not still in the list widget
-        recommend = list(filter(
-            lambda val: not self.listExclude.findItems(val, MATCH_FLAGS),
-            self.config.DEFAULT_EXCLUDE
-        ))
-
-        if not recommend:
-            text = _('{BOLD}Highly recommended{ENDBOLD}: (All recommendations '
-                     'already included.)').format(
-                        BOLD='<strong>', ENDBOLD='</strong>')
-
-        else:
-            text = _('{BOLD}Highly recommended{ENDBOLD}: {files}').format(
-                BOLD='<strong>',
-                ENDBOLD='</strong>',
-                files=', '.join(sorted(recommend)))
-
-        self._label_exclude_recommend.setText(text)
-
     def updateProfile(self):
         if self.config.currentProfile() == '1':
             self.btnEditProfile.setEnabled(False)
@@ -392,34 +235,16 @@ class SettingsDialog(QDialog):
             self.btnRemoveProfile.setEnabled(True)
         self.btnAddProfile.setEnabled(self.config.isConfigured('1'))
 
-        profile_state = self.state_data.profile(self.config.currentProfile())
+        profile_state = StateData().profile(self.config.currentProfile())
 
         # TAB: General
         self._tab_general.load_values()
 
         # TAB: Include
-        self._tab_include.load_includes()
+        self._tab_include.load_values(profile_state)
 
         # TAB: Exclude
-        self.listExclude.clear()
-
-        for exclude in self.config.exclude():
-            self._add_exclude_pattern(exclude)
-        self.cbExcludeBySize.setChecked(self.config.excludeBySizeEnabled())
-        self.spbExcludeBySize.setValue(self.config.excludeBySize())
-
-        try:
-            incl_sort = profile_state.include_sorting
-            excl_sort = profile_state.exclude_sorting
-            self.listInclude.sortItems(
-                incl_sort[0], Qt.SortOrder(incl_sort[1])
-            )
-            self.listExclude.sortItems(
-                excl_sort[0], Qt.SortOrder(excl_sort[1]))
-        except KeyError:
-            pass
-
-        self._update_exclude_recommend_label()
+        self._tab_exclude.load_values(profile_state)
 
         self._tab_retention.load_values()
         self._tab_options.load_values()
@@ -442,40 +267,11 @@ class SettingsDialog(QDialog):
 
         profile_state = StateData().profile(self.config.currentProfile())
 
-        # include list
-        profile_state.include_sorting = (
-            self.listInclude.header().sortIndicatorSection(),
-            self.listInclude.header().sortIndicatorOrder().value
-        )
-        # Why?
-        self.listInclude.sortItems(1, Qt.SortOrder.AscendingOrder)
+        # TAB: Include
+        self._tab_include.store_values(profile_state)
 
-        include_list = []
-        for index in range(self.listInclude.topLevelItemCount()):
-            item = self.listInclude.topLevelItem(index)
-            include_list.append(
-                (item.text(0), item.data(0, Qt.ItemDataRole.UserRole)))
-
-        self.config.setInclude(include_list)
-
-        # exclude patterns
-        profile_state.exclude_sorting = (
-            self.listExclude.header().sortIndicatorSection(),
-            self.listExclude.header().sortIndicatorOrder().value
-        )
-        # Why?
-        self.listExclude.sortItems(1, Qt.SortOrder.AscendingOrder)
-
-        exclude_list = []
-        for index in range(self.listExclude.topLevelItemCount()):
-            item = self.listExclude.topLevelItem(index)
-            exclude_list.append(item.text(0))
-
-        self.config.setExclude(exclude_list)
-        self.config.setExcludeBySize(self.cbExcludeBySize.isChecked(),
-                                     self.spbExcludeBySize.value())
-
-        return True
+        # TAB: Exclude
+        self._tab_exclude.store_values(profile_state)
 
     def errorHandler(self, message):
         messagebox.critical(self, message)
@@ -485,16 +281,12 @@ class SettingsDialog(QDialog):
 
         return answer == QMessageBox.StandardButton.Yes
 
-    def _add_exclude_pattern(self, pattern):
-        item = QTreeWidgetItem()
-        item.setText(0, pattern)
-        item.setData(0, Qt.ItemDataRole.UserRole, pattern)
-        self._formatExcludeItem(item)
+    # def fillCombo(self, combo, d):
+    #     keys = list(d.keys())
+    #     keys.sort()
 
-        # Add item to the widget
-        self.listExclude.addTopLevelItem(item)
-
-        return item
+    #     for key in keys:
+    #         combo.addItem(QIcon(), d[key], key)
 
     def setComboValue(self, combo, value, t='int'):
         for i in range(combo.count()):
@@ -519,71 +311,6 @@ class SettingsDialog(QDialog):
 
         return self.config.save()
 
-    def btnExcludeRemoveClicked(self):
-        for item in self.listExclude.selectedItems():
-            index = self.listExclude.indexOfTopLevelItem(item)
-            if index < 0:
-                continue
-
-            self.listExclude.takeTopLevelItem(index)
-
-        if self.listExclude.topLevelItemCount() > 0:
-            self.listExclude.setCurrentItem(self.listExclude.topLevelItem(0))
-
-        self._update_exclude_recommend_label()
-
-    def addExclude(self, pattern):
-        """Initiate adding a new exclude pattern to the list widget.
-
-        See `_add_exclude_pattern()` also.
-        """
-        if not pattern:
-            return
-
-        # Duplicate?
-        duplicates = self.listExclude.findItems(pattern, MATCH_FLAGS)
-
-        if duplicates:
-            # TODO notify user about duplicates
-            self.listExclude.setCurrentItem(duplicates[0])
-            return
-
-        # Create new entry and add it to the list widget.
-        item = self._add_exclude_pattern(pattern)
-
-        # Select/highlight that entry.
-        self.listExclude.setCurrentItem(item)
-
-        self._update_exclude_recommend_label()
-
-    def btnExcludeAddClicked(self):
-        dlg = QInputDialog(self)
-        dlg.setInputMode(QInputDialog.InputMode.TextInput)
-        dlg.setWindowTitle(_('Exclude pattern'))
-        dlg.setLabelText('')
-        dlg.resize(400, 0)
-        if not dlg.exec():
-            return
-        pattern = dlg.textValue().strip()
-
-        if not pattern:
-            return
-
-        self.addExclude(pattern)
-
-    def btnExcludeFileClicked(self):
-        for path in qttools.getOpenFileNames(self, _('Exclude file')):
-            self.addExclude(path)
-
-    def btnExcludeFolderClicked(self):
-        for path in qttools.getExistingDirectories(self, _('Exclude directory')):
-            self.addExclude(path)
-
-    def btnExcludeDefaultClicked(self):
-        for path in self.config.DEFAULT_EXCLUDE:
-            self.addExclude(path)
-
-
     def _ask_include_symlinks_target(self, path):
         question_msg = _(
             '"{path}" is a symlink. The linked target will not be backed up '
@@ -605,94 +332,22 @@ class SettingsDialog(QDialog):
 
         active_mode = self._tab_general.get_active_snapshots_mode()
 
-        self.updateExcludeItems()
-        self.lblSshEncfsExcludeWarning.setVisible(active_mode == 'ssh_encfs')
+        self._tab_exclude.mode = active_mode
+        self._tab_exclude.update_exclude_items()
+        self._tab_exclude.lbl_ssh_encfs_exclude_warning.setVisible(
+        active_mode == 'ssh_encfs'
+    )
 
         enabled = active_mode in ('ssh', 'ssh_encfs')
         self._tab_retention.update_items_state(enabled)
         self._tab_expert_options.update_items_state(enabled)
 
-        # Resize (but not move) window based on backup mode
-        self._restore_dims_and_coords(move=False)
-
-    def updateExcludeItems(self):
-        for index in range(self.listExclude.topLevelItemCount()):
-            item = self.listExclude.topLevelItem(index)
-            self._formatExcludeItem(item)
-
-    def _format_exclude_item_encfs_invalid(self, item):
-        """Modify visual appearance of an item in the exclude list widget to
-        express that the item is invalid.
-
-        See :py:func:`_formatExcludeItem` for details.
-        """
-        # Icon
-        item.setIcon(0, self.icon.INVALID_EXCLUDE)
-
-        # ToolTip
-        item.setData(
-            0,
-            Qt.ItemDataRole.ToolTipRole,
-            _("Disabled because this pattern is not functional in "
-              "mode 'SSH encrypted'.")
-        )
-
-        # Fore- and Backgroundcolor (as disabled)
-        item.setBackground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
-                                               QPalette.ColorRole.Window))
-        item.setForeground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
-                                               QPalette.ColorRole.Text))
-
-    def _formatExcludeItem(self, item):
-        """Modify visual appearance of an item in the exclude list widget.
-        """
-        if (self.mode == 'ssh_encfs'
-                and tools.patternHasNotEncryptableWildcard(item.text(0))):
-            # Invalid item (because of encfs restrictions)
-            self._format_exclude_item_encfs_invalid(item)
-
-        else:
-            # default background color
-            item.setBackground(0, QBrush())
-            item.setForeground(0, QBrush())
-
-            # Remove items tooltip
-            item.setData(0, Qt.ItemDataRole.ToolTipRole, None)
-
-            # Icon: default exclude item
-            if item.text(0) in self.config.DEFAULT_EXCLUDE:
-                item.setIcon(0, self.icon.DEFAULT_EXCLUDE)
-
-            else:
-                # Icon: user defined
-                item.setIcon(0, self.icon.EXCLUDE)
-
-    def customSortOrder(self, header, loop, newColumn, newOrder):
-
-        if newColumn == 0 and newOrder == Qt.SortOrder.AscendingOrder:
-
-            if loop:
-                newColumn, newOrder = 1, Qt.SortOrder.AscendingOrder
-                header.setSortIndicator(newColumn, newOrder)
-                loop = False
-
-            else:
-                loop = True
-
-        header.model().sort(newColumn, newOrder)
-
-        return loop
-
-    def excludeCustomSortOrder(self, *args):
-        self.listExcludeSortLoop = self.customSortOrder(
-            self.listExclude.header(), self.listExcludeSortLoop, *args)
-
     def restoreConfig(self, *args):
         RestoreConfigDialog(self).exec()
         self.updateProfiles()
 
-    # def editUserCallback(self, *args):
-    #     EditUserCallback(self).exec()
+    def editUserCallback(self, *args):
+        EditUserCallback(self).exec()
 
     def accept(self):
         if self.validate():
@@ -711,11 +366,3 @@ class SettingsDialog(QDialog):
             self.parent.remount(self.originalCurrentProfile,
                                 self.originalCurrentProfile)
             self.parent.updateProfiles()
-
-        # store windows position and size
-        state_data = StateData()
-        state_data.set_manageprofiles_dims_coords(
-            self._tab_general.get_active_snapshots_mode(),
-            (self.width(), self.height()),
-            (self.x(), self.y())
-        )

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -144,7 +144,7 @@ class SettingsDialog(QDialog):
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
         btnRestore.clicked.connect(self.restoreConfig)
-        btnUserCallback.clicked.connect(self.editUserCallback)
+        # btnUserCallback.clicked.connect(self.editUserCallback)
         self.mainLayout.addWidget(buttonBox)
 
         self.updateProfiles()
@@ -346,8 +346,8 @@ class SettingsDialog(QDialog):
         RestoreConfigDialog(self).exec()
         self.updateProfiles()
 
-    def editUserCallback(self, *args):
-        EditUserCallback(self).exec()
+    # def editUserCallback(self, *args):
+    #     EditUserCallback(self).exec()
 
     def accept(self):
         if self.validate():

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -42,6 +42,7 @@ class SettingsDialog(QDialog):
     def __init__(self, parent):
         super(SettingsDialog, self).__init__(parent)
 
+        self.state_data = StateData()
         self.parent = parent
         self.config = parent.config
         self.snapshots = parent.snapshots
@@ -150,7 +151,7 @@ class SettingsDialog(QDialog):
         self.updateProfiles()
         self.slot_combo_modes_changed()
 
-        self._restore_dims_and_coods()
+        self._restore_dims_and_coords()
 
         # enable tabs scroll buttons again but keep dialog size
         # size = self.sizeHint()

--- a/qt/manageprofiles/tab_exclude.py
+++ b/qt/manageprofiles/tab_exclude.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: © 2008-2022 Oprea Dan
+# SPDX-FileCopyrightText: © 2008-2022 Bart de Koning
+# SPDX-FileCopyrightText: © 2008-2022 Richard Bailey
+# SPDX-FileCopyrightText: © 2008-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2008-2022 Taylor Raak
+# SPDX-FileCopyrightText: © 2024 Christian BUHTZ <c.buhtz@posteo.jp>
+# SPDX-FileCopyrightText: © 2025 Devin Black
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+
+from PyQt6.QtWidgets import (QWidget,
+                             QVBoxLayout,
+                             QLabel,
+                             QTreeWidget,
+                             QTreeWidgetItem,
+                             QPushButton,
+                             QHBoxLayout,
+                             QCheckBox,
+                             QSpinBox,
+                             QInputDialog,
+                             QHeaderView,
+                             QAbstractItemView)
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPalette, QBrush
+import tools
+import qttools
+from qttools import custom_sort_order
+
+MATCH_FLAGS = Qt.MatchFlag.MatchFixedString | Qt.MatchFlag.MatchCaseSensitive
+
+class ExcludeTab(QWidget):
+    """Create the 'Exclude' tab."""
+    def __init__(self, parent):
+        super().__init__(parent=parent)
+
+        self._parent_dialog = parent
+        self.icon = parent.icon
+        self.config = parent.config
+
+        # Snapshot mode
+        self.mode = None
+
+        layout = QVBoxLayout(self)
+
+        self.lbl_ssh_encfs_exclude_warning = QLabel(_(
+            "{BOLD}Info{ENDBOLD}: "
+            "In 'SSH encrypted' mode, only single or double asterisks are "
+            "functional (e.g. {example2}). Other types of wildcards and "
+            "patterns will be ignored (e.g. {example1}). Filenames are "
+            "unpredictable in this mode due to encryption by EncFS.").format(
+                BOLD='<strong>',
+                ENDBOLD='</strong>',
+                example1="<code>'foo*'</code>, "
+                         "<code>'[fF]oo'</code>, "
+                         "<code>'fo?'</code>",
+                example2="<code>'foo/*'</code>, "
+                         "<code>'foo/**/bar'</code>"
+            ),
+            self
+        )
+        self.lbl_ssh_encfs_exclude_warning.setWordWrap(True)
+        layout.addWidget(self.lbl_ssh_encfs_exclude_warning)
+
+        self.list_exclude = QTreeWidget(self)
+        self.list_exclude.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection)
+        self.list_exclude.setRootIsDecorated(False)
+        self.list_exclude.setHeaderLabels(
+            [_('Exclude patterns, files or directories'), 'Count'])
+
+        self.list_exclude.header().setSectionResizeMode(
+            0, QHeaderView.ResizeMode.Stretch)
+        self.list_exclude.header().setSectionsClickable(True)
+        self.list_exclude.header().setSortIndicatorShown(True)
+        self.list_exclude.header().setSectionHidden(1, True)
+        self.list_exclude_sort_loop = False
+        self.list_exclude.header().sortIndicatorChanged \
+            .connect(self.exclude_custom_sort_order)
+
+        layout.addWidget(self.list_exclude)
+
+        self._label_exclude_recommend = QLabel('', self)
+        self._label_exclude_recommend.setWordWrap(True)
+        layout.addWidget(self._label_exclude_recommend)
+
+        buttons_layout = QHBoxLayout()
+        layout.addLayout(buttons_layout)
+
+        self.btn_exclude_add = QPushButton(self.icon.ADD, _('Add'), self)
+        buttons_layout.addWidget(self.btn_exclude_add)
+        self.btn_exclude_add.clicked.connect(self.btn_exclude_add_clicked)
+
+        self.btn_exclude_file = QPushButton(self.icon.ADD, _('Add file'), self)
+        buttons_layout.addWidget(self.btn_exclude_file)
+        self.btn_exclude_file.clicked.connect(self.btn_exclude_file_clicked)
+
+        self.btn_exclude_folder = QPushButton(self.icon.ADD, _('Add directory'), self)
+        buttons_layout.addWidget(self.btn_exclude_folder)
+        self.btn_exclude_folder.clicked.connect(self.btn_exclude_folder_clicked)
+
+        self.btn_exclude_default = QPushButton(self.icon.DEFAULT_EXCLUDE,
+                                             _('Add default'),
+                                             self)
+        buttons_layout.addWidget(self.btn_exclude_default)
+        self.btn_exclude_default.clicked.connect(self.btn_exclude_default_clicked)
+
+        self.btn_exclude_remove = QPushButton(self.icon.REMOVE, _('Remove'), self)
+        buttons_layout.addWidget(self.btn_exclude_remove)
+        self.btn_exclude_remove.clicked.connect(self.btn_exclude_remove_clicked)
+
+        # exclude files by size
+        hlayout = QHBoxLayout()
+        layout.addLayout(hlayout)
+        self.cb_exclude_by_size = QCheckBox(
+            _('Exclude files bigger than:'), self)
+        qttools.set_wrapped_tooltip(
+            self.cb_exclude_by_size,
+            [
+                _('Exclude files bigger than value in {size_unit}.')
+                .format(size_unit='MiB'),
+                _("With 'Full rsync mode' disabled, this setting affects only "
+                  "newly created files, as rsync treats it as transfer option "
+                  "rather than an exclusion rule. Consequently, large files "
+                  "that have already been backed up will remain in backups "
+                  "even if they are modified.")
+            ]
+        )
+        hlayout.addWidget(self.cb_exclude_by_size)
+        self.spb_exclude_by_size = QSpinBox(self)
+        self.spb_exclude_by_size.setSuffix(' MiB')
+        self.spb_exclude_by_size.setRange(0, 100000000)
+        hlayout.addWidget(self.spb_exclude_by_size)
+        hlayout.addStretch()
+        enabled = lambda state: self.spb_exclude_by_size.setEnabled(state)
+        enabled(False)
+        self.cb_exclude_by_size.stateChanged.connect(enabled)
+
+    def load_values(self, profile_state):
+        self.list_exclude.clear()
+
+        for exclude in self.config.exclude():
+            self._add_exclude_pattern(exclude)
+        self.cb_exclude_by_size.setChecked(self.config.excludeBySizeEnabled())
+        self.spb_exclude_by_size.setValue(self.config.excludeBySize())
+        self._update_exclude_recommend_label()
+
+        try:
+            excl_sort = profile_state.exclude_sorting
+            self.list_exclude.sortItems(
+                excl_sort[0], Qt.SortOrder(excl_sort[1])
+            )
+        except KeyError:
+            pass
+
+    def store_values(self,profile_state):
+        # exclude patterns
+        profile_state.exclude_sorting = (
+            self.list_exclude.header().sortIndicatorSection(),
+            self.list_exclude.header().sortIndicatorOrder().value
+        )
+        # Sort (optional: replicates original behavior)
+        self.list_exclude.sortItems(1, Qt.SortOrder.AscendingOrder)
+
+        # Store exclude list
+        exclude_list = []
+        for index in range(self.list_exclude.topLevelItemCount()):
+            item = self.list_exclude.topLevelItem(index)
+            exclude_list.append(item.text(0))
+        self.config.setExclude(exclude_list)
+
+        # Store "exclude by size" settings
+        self.config.setExcludeBySize(
+            self.cb_exclude_by_size.isChecked(),
+            self.spb_exclude_by_size.value()
+        )
+
+        return True
+
+    def _update_exclude_recommend_label(self):
+        """Update the label about recommended exclude patterns."""
+
+        # Default patterns that are not still in the list widget
+        recommend = list(filter(
+            lambda val: not self.list_exclude.findItems(val, MATCH_FLAGS),
+            self.config.DEFAULT_EXCLUDE
+        ))
+
+        if not recommend:
+            text = _('{BOLD}Highly recommended{ENDBOLD}: (All recommendations '
+                     'already included.)').format(
+                        BOLD='<strong>', ENDBOLD='</strong>')
+
+        else:
+            text = _('{BOLD}Highly recommended{ENDBOLD}: {files}').format(
+                BOLD='<strong>',
+                ENDBOLD='</strong>',
+                files=', '.join(sorted(recommend)))
+
+        self._label_exclude_recommend.setText(text)
+
+    def _add_exclude_pattern(self, pattern):
+        item = QTreeWidgetItem()
+        item.setText(0, pattern)
+        item.setData(0, Qt.ItemDataRole.UserRole, pattern)
+        self._format_exclude_item(item)
+
+        # Add item to the widget
+        self.list_exclude.addTopLevelItem(item)
+
+        return item
+
+    def btn_exclude_remove_clicked(self):
+        for item in self.list_exclude.selectedItems():
+            index = self.list_exclude.indexOfTopLevelItem(item)
+            if index < 0:
+                continue
+
+            self.list_exclude.takeTopLevelItem(index)
+
+        if self.list_exclude.topLevelItemCount() > 0:
+            self.list_exclude.setCurrentItem(self.list_exclude.topLevelItem(0))
+
+        self._update_exclude_recommend_label()
+
+    def add_exclude(self, pattern):
+        """Initiate adding a new exclude pattern to the list widget.
+
+        See `_add_exclude_pattern()` also.
+        """
+        if not pattern:
+            return
+
+        # Duplicate?
+        duplicates = self.list_exclude.findItems(pattern, MATCH_FLAGS)
+
+        if duplicates:
+            # TODO notify user about duplicates
+            self.list_exclude.setCurrentItem(duplicates[0])
+            return
+
+        # Create new entry and add it to the list widget.
+        item = self._add_exclude_pattern(pattern)
+
+        # Select/highlight that entry.
+        self.list_exclude.setCurrentItem(item)
+
+        self._update_exclude_recommend_label()
+
+    def btn_exclude_add_clicked(self):
+        dlg = QInputDialog(self)
+        dlg.setInputMode(QInputDialog.InputMode.TextInput)
+        dlg.setWindowTitle(_('Exclude pattern'))
+        dlg.setLabelText('')
+        dlg.resize(400, 0)
+        if not dlg.exec():
+            return
+        pattern = dlg.textValue().strip()
+
+        if not pattern:
+            return
+
+        self.add_exclude(pattern)
+
+    def btn_exclude_file_clicked(self):
+        for path in qttools.getOpenFileNames(self, _('Exclude file')):
+            self.add_exclude(path)
+
+    def btn_exclude_folder_clicked(self):
+        for path in qttools.getExistingDirectories(self, _('Exclude directory')):
+            self.add_exclude(path)
+
+    def btn_exclude_default_clicked(self):
+        for path in self.config.DEFAULT_EXCLUDE:
+            self.add_exclude(path)
+
+    def update_exclude_items(self):
+        for index in range(self.list_exclude.topLevelItemCount()):
+            item = self.list_exclude.topLevelItem(index)
+            self._format_exclude_item(item)
+
+    def _format_exclude_item_encfs_invalid(self, item):
+        """Modify visual appearance of an item in the exclude list widget to
+        express that the item is invalid.
+
+        See :py:func:`_format_exclude_item` for details.
+        """
+        # Icon
+        item.setIcon(0, self.icon.INVALID_EXCLUDE)
+
+        # ToolTip
+        item.setData(
+            0,
+            Qt.ItemDataRole.ToolTipRole,
+            _("Disabled because this pattern is not functional in "
+              "mode 'SSH encrypted'.")
+        )
+
+        # Fore- and Backgroundcolor (as disabled)
+        item.setBackground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
+                                               QPalette.ColorRole.Window))
+        item.setForeground(0, QPalette().brush(QPalette.ColorGroup.Disabled,
+                                               QPalette.ColorRole.Text))
+
+    def _format_exclude_item(self, item):
+        """Modify visual appearance of an item in the exclude list widget.
+        """
+        if (self.mode == 'ssh_encfs'
+                and tools.patternHasNotEncryptableWildcard(item.text(0))):
+            # Invalid item (because of encfs restrictions)
+            self._format_exclude_item_encfs_invalid(item)
+
+        else:
+            # default background color
+            item.setBackground(0, QBrush())
+            item.setForeground(0, QBrush())
+
+            # Remove items tooltip
+            item.setData(0, Qt.ItemDataRole.ToolTipRole, None)
+
+            # Icon: default exclude item
+            if item.text(0) in self.config.DEFAULT_EXCLUDE:
+                item.setIcon(0, self.icon.DEFAULT_EXCLUDE)
+
+            else:
+                # Icon: user defined
+                item.setIcon(0, self.icon.EXCLUDE)
+
+    def exclude_custom_sort_order(self, *args):
+        self.list_exclude_sort_loop = custom_sort_order(
+            self.list_exclude.header(), self.list_exclude_sort_loop, *args)

--- a/qt/manageprofiles/tab_include.py
+++ b/qt/manageprofiles/tab_include.py
@@ -23,6 +23,7 @@ from PyQt6.QtWidgets import (QWidget,
                              QHeaderView,
                              QAbstractItemView)
 import qttools
+from qttools import custom_sort_order
 
 
 class IncludeTab(QWidget):
@@ -79,11 +80,36 @@ class IncludeTab(QWidget):
             self.btn_include_remove_clicked
         )
 
-    def load_includes(self):
+    def load_values(self,profile_state):
 
         self.list_include.clear()
         for include in self.config.include():
             self.add_include(include)
+
+        try:
+            incl_sort = profile_state.include_sorting
+            self.list_include.sortItems(
+                incl_sort[0], Qt.SortOrder(incl_sort[1])
+            )
+        except KeyError:
+            pass
+
+    def store_values(self, profile_state):
+        profile_state.include_sorting = (
+            self.list_include.header().sortIndicatorSection(),
+            self.list_include.header().sortIndicatorOrder().value
+        )
+
+        self.list_include.sortItems(1, Qt.SortOrder.AscendingOrder)
+
+        include_list = []
+        for index in range(self.list_include.topLevelItemCount()):
+            item = self.list_include.topLevelItem(index)
+            include_list.append(
+                (item.text(0), item.data(0, Qt.ItemDataRole.UserRole))
+            )
+
+        self.config.setInclude(include_list)
 
     def add_include(self, data):
         """Add a file or directory to the list."""
@@ -146,18 +172,6 @@ class IncludeTab(QWidget):
 
     def include_custom_sort_order(self, *args):
         """Trigger custom sort order when header is clicked."""
-        self.list_include_sort_loop = self._custom_sort_order(
+        self.list_include_sort_loop = custom_sort_order(
             self.list_include.header(), self.list_include_sort_loop, *args
         )
-
-    def _custom_sort_order(self, header, loop, new_column, new_order):
-        """Implements custom sort toggle behavior.Private"""
-        if new_column == 0 and new_order == Qt.SortOrder.AscendingOrder:
-            if loop:
-                new_column, new_order = 1, Qt.SortOrder.AscendingOrder
-                header.setSortIndicator(new_column, new_order)
-                loop = False
-            else:
-                loop = True
-        header.model().sort(new_column, new_order)
-        return loop

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -243,6 +243,18 @@ def create_icon_label_warning(
         fixed_size_widget=fixed_size_widget)
 
 
+def custom_sort_order(header, loop, new_column, new_order):
+    """Provides a toggled sort order across two columns for QTreeWidget."""
+    if new_column == 0 and new_order == Qt.SortOrder.AscendingOrder:
+        if loop:
+            new_column, new_order = 1, Qt.SortOrder.AscendingOrder
+            header.setSortIndicator(new_column, new_order)
+            loop = False
+        else:
+            loop = True
+    header.model().sort(new_column, new_order)
+    return loop
+
 # |---------------------|
 # | Misc / Uncatgorized |
 # |---------------------|


### PR DESCRIPTION
#### Functions removed from [Init.py](http://init.py/) and moved them to tab_exclude.py

- _update_exclude_recommend_label
- _add_exclude_pattern
- btnExcludeRemoveClicked
- addExclude
- btnExcludeAddClicked
- btnExcludeFileClicked
- btnExcludeFolderClicked
- btnExcludeDefaultClicked
- updateExcludeItems
- _format_exclude_item_encfs_invalid
- _formatExcludeItem
- excludeCustomSortOrder

#### Functions Created from [Init.py](http://init.py/) code and moved them to tab_exclude.py
Load_values
Store_values
Shortened the code in saveProfile() using the code from this I created the store_values functions.
#### Changes that I made to tab_include.py
Changed the name of load_includes to load_values to match the naming scheme of other functions similar to it.
Created Store_values
#### Changes that I made to [qttools.py](http://qttools.py/)
Moved CustomSortOrder so that code was not duplicated and so that it was out of [init.py](http://init.py/). Will need a maintainer to look over this and make sure that it was alright I put this here and I understood what was supposed to go into qttools. From my understanding custom_sort_order is a widget so I placed it there.
