### PR TITLE
fix(gui): Modify strings in Shortcut pane respecting root mode

### DIFF
--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -6,6 +6,7 @@
 # General Public License v2 (GPLv2). See file/folder LICENSE or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Basic constants used in multiple modules."""
+import os
 from enum import Enum
 from pathlib import Path
 
@@ -25,6 +26,9 @@ COPYRIGHT = 'Copyright © 2008-2024 ' \
 RETURN_OK = 0
 RETURN_ERR = 1
 RETURN_NO_CFG = 2
+
+# Indicator if BIT is running in root mode
+IS_IN_ROOT_MODE = os.geteuid() == 0
 
 # Used in about dialog to add language independent translator credits
 TRANSLATION_CREDITS_MISC = (

--- a/qt/app.py
+++ b/qt/app.py
@@ -1247,9 +1247,10 @@ class MainWindow(QMainWindow):
     def updatePlaces(self):
         self.places.clear()
         # name, path, icon
-        self.addPlace(_('Global'), '', '')
+        self.addPlace(_('Places'), '', '')
         self.addPlace(_('File System'), '/', 'computer')
-        self.addPlace(_('Home'), os.path.expanduser('~'), 'user-home')
+        fp_home = pathlib.Path.home()
+        self.addPlace(fp_home.name, str(fp_home), 'user-home')
 
         # "Now" or a specific snapshot selected?
         if self.sid.isRoot:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1250,7 +1250,11 @@ class MainWindow(QMainWindow):
         self.addPlace(_('Places'), '', '')
         self.addPlace(_('File System'), '/', 'computer')
         fp_home = pathlib.Path.home()
-        self.addPlace(fp_home.name, str(fp_home), 'user-home')
+        self.addPlace(
+            # Use full path in root mode ("/root") otherwise users name only
+            str(fp_home) if bitbase.IS_IN_ROOT_MODE else fp_home.name,
+            str(fp_home),
+            'user-home')
 
         # "Now" or a specific snapshot selected?
         if self.sid.isRoot:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1246,8 +1246,9 @@ class MainWindow(QMainWindow):
 
     def updatePlaces(self):
         self.places.clear()
+        # name, path, icon
         self.addPlace(_('Global'), '', '')
-        self.addPlace(_('Root'), '/', 'computer')
+        self.addPlace(_('File System'), '/', 'computer')
         self.addPlace(_('Home'), os.path.expanduser('~'), 'user-home')
 
         # "Now" or a specific snapshot selected?

--- a/qt/app.py
+++ b/qt/app.py
@@ -1907,7 +1907,7 @@ class MainWindow(QMainWindow):
             # workaround to a visual issue where the last character was
             # cutoff. Not sure if this is DE and/or theme related.
             # Wasn't able to reproduc in an MWE. Remove after refactoring.
-            text = '{}: {}   '.format(_('Backup'), name)
+            text = '{} {}   '.format(_('Backup:'), name)
 
         self.filesWidget.setTitle(text)
 

--- a/qt/statusbar.py
+++ b/qt/statusbar.py
@@ -11,7 +11,6 @@
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """A module offering a status bar widget
 """
-import os
 from PyQt6.QtWidgets import (QFrame,
                              QHBoxLayout,
                              QLabel,

--- a/qt/statusbar.py
+++ b/qt/statusbar.py
@@ -23,6 +23,7 @@ from PyQt6.QtWidgets import (QFrame,
                              )
 from PyQt6.QtCore import QEvent
 from PyQt6.QtGui import QPalette, QColor
+import bitbase
 
 _DARK_MODE_THRESHOLD = 128
 _PROGRESS_BAR_WIDTH_FX = 10
@@ -79,7 +80,7 @@ class StatusBar(QStatusBar):
         event.accept()
 
     def _root_mode_indicator(self) -> QLabel:
-        if os.geteuid() != 0:
+        if not bitbase.IS_IN_ROOT_MODE:
             return None
 
         root = QLabel(_('Root mode'))


### PR DESCRIPTION
Modified several labels in the shortcuts pane.
- "Global" is now "Places"
- Label of file systems root now is "File System"
- Label of the current users home folder is the users name. But in root mode it is the full path ("/root").

This is the shortcut pane in user mode.
![image](https://github.com/user-attachments/assets/a922eac8-c97e-407e-95e6-091876fadebc)

...and in root mode
![image](https://github.com/user-attachments/assets/5e7b175d-21ad-41b8-928e-67a01befb245)

Close #1964