### PR TITLE
Supply all arguments to Generator annotation

### DIFF
--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -172,7 +172,7 @@ class SnapshotLog:
     def get(self,
             mode: int = None,
             decode: encfstools.Decode = None,
-            skipLines: int = 0) -> Generator[str]:
+            skipLines: int = 0) -> Generator[str, None, None]:
         """Read the log, filter and decode it and yield its lines.
 
         Args:


### PR DESCRIPTION
The single argument form is only valid from Python 3.13.