### PR TITLE
refactor: Tools module and license text handling

### DIFF
--- a/common/backintime.py
+++ b/common/backintime.py
@@ -139,7 +139,7 @@ def startApp(app_name='backintime'):
         tools.addSourceToPathEnviron()
 
     # Warn about sudo
-    if (tools.usingSudo()
+    if (os.getenv('SUDO_USER')  # exists only if sudo was used
             and os.getenv('BIT_SUDO_WARNING_PRINTED', 'false') == 'false'):
 
         os.putenv('BIT_SUDO_WARNING_PRINTED', 'true')

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -2,10 +2,12 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
-# This file is part of the program "Back In time" which is released under GNU
-# General Public License v2 (GPLv2). See file/folder LICENSE or go to
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
-"""Basic constants used in multiple modules."""
+"""Basic constants used in multiple modules.
+
+See also license.py for additional constants and logic."""
 import os
 from enum import Enum
 from pathlib import Path
@@ -26,11 +28,6 @@ PACKAGE_NAME_GUI = f'{BINARY_NAME_BASE}-qt'
 # | Several strings |
 # |-----------------|
 
-COPYRIGHT = 'Copyright © 2008-2024 ' \
-            'Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze\n' \
-            'Copyright © 2022 ' \
-            'Christian Buhtz, Michael Büker, Jürgen Altfeld'
-
 # Used in about dialog to add language independent translator credits
 TRANSLATION_CREDITS_MISC = (
     'Launchpad translators <https://translations.launchpad.net/backintime/'
@@ -39,6 +36,7 @@ TRANSLATION_CREDITS_MISC = (
     'Several mailing lists in Debian (@lists.debian.org) & Ubuntu '
     '(@lists.ubuntu.com) especially the user related lists',
 )
+
 
 # |-------------------------------|
 # | Online resources & references |
@@ -54,7 +52,6 @@ URL_ISSUES = f'{URL_WEBSITE}/issues'
 URL_ISSUES_CREATE_NEW = f'{URL_ISSUES}/new'
 URL_CHANGELOG = f'{URL_WEBSITE}/blob/dev/CHANGES'
 URL_TRANSLATION = 'https://translate.codeberg.org/engage/backintime'
-URL_GPL_TWO = 'https://spdx.org/licenses/GPL-2.0-or-later.html'
 URL_USER_MANUAL = 'https://backintime.readthedocs.io'
 
 # |---------------------|
@@ -83,22 +80,6 @@ DIR_NAME_NEWSNAPSHOT = 'new_snapshot'
 DIR_NAME_SAVETOCONTINUE = 'save_to_continue'
 
 
-def _determine_licenses_dir():
-    for pkg in (PACKAGE_NAME_GUI,
-                PACKAGE_NAME_CLI,
-                BINARY_NAME_GUI,
-                BINARY_NAME_CLI,
-                BINARY_NAME_BASE):
-        for path in (Path('/usr/share/doc'), Path('/usr/share/licenses')):
-
-            fp = path / pkg / 'LICENSES'
-            if fp.is_dir():
-                return fp
-
-    return None
-
-
-DIR_LICENSES = _determine_licenses_dir()
 DIR_SSH_KEYS = Path.home() / '.ssh'
 
 # |-------------------|

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -7,7 +7,7 @@
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Basic constants used in multiple modules.
 
-See also license.py for additional constants and logic."""
+See also bitlicense.py for additional constants and logic."""
 import os
 from enum import Enum
 from pathlib import Path

--- a/common/bitlicense.py
+++ b/common/bitlicense.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2025 Christian BUHTZ <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+"""Constants and logic related to license and copyright information.
+
+That module is separated from bitbase.py because it contain translatable
+strings but bitbase is not able to provide it."""
+from pathlib import Path
+import bitbase
+
+COPYRIGHT = 'Copyright © 2008-2024 ' \
+            'Oprea Dan, Bart de Koning, Richard Bailey, Germar Reitze\n' \
+            'Copyright © 2022 ' \
+            'Christian Buhtz, Michael Büker, Jürgen Altfeld'
+
+
+URL_GPL_TWO = 'https://spdx.org/licenses/GPL-2.0-or-later.html'
+
+def get_gpl_short_text(href: str=None) -> str:
+    """Short description of primary license.
+   
+    The string is used in the AboutDialog and when using --license on shell.
+   
+    Dev note (buhtz, 2025-03): That string is untranslated on purpose.
+    It is legally relevant, and no one should be given the opportunity
+    to change the string—whether intentionally or accidentally.
+    """
+
+    gpl = 'GNU General Public License v2.0 or later (GPL-2.0-or-later)'
+
+    if href:
+        gpl = f'<a href="{href}">{gpl}</a>'
+
+    return f'The application is released under {gpl}.'
+
+
+TXT_LICENSES = _(
+    'All licenses used in this project are located in the {dir_link} '
+    'directory. To extract per-file license and copyright information '
+    'using SPDX metadata, refer to {readme_link}.')
+
+
+def _determine_licenses_dir():
+    for pkg in (bitbase.PACKAGE_NAME_GUI,
+                bitbase.PACKAGE_NAME_CLI,
+                bitbase.BINARY_NAME_GUI,
+                bitbase.BINARY_NAME_CLI,
+                bitbase.BINARY_NAME_BASE):
+        for path in (Path('/usr/share/doc'), Path('/usr/share/licenses')):
+
+            fp = path / pkg / 'LICENSES'
+            if fp.is_dir():
+                return fp
+
+    return None
+
+
+DIR_LICENSES = _determine_licenses_dir()

--- a/common/bitlicense.py
+++ b/common/bitlicense.py
@@ -20,11 +20,12 @@ COPYRIGHT = 'Copyright © 2008-2024 ' \
 
 URL_GPL_TWO = 'https://spdx.org/licenses/GPL-2.0-or-later.html'
 
-def get_gpl_short_text(href: str=None) -> str:
+
+def get_gpl_short_text(href: str = None) -> str:
     """Short description of primary license.
-   
+
     The string is used in the AboutDialog and when using --license on shell.
-   
+
     Dev note (buhtz, 2025-03): That string is untranslated on purpose.
     It is legally relevant, and no one should be given the opportunity
     to change the string—whether intentionally or accidentally.
@@ -44,7 +45,7 @@ TXT_LICENSES = _(
     'using SPDX metadata, refer to {readme_link}.')
 
 
-def _determine_licenses_dir():
+def _determine_licenses_dir() -> str | None:
     for pkg in (bitbase.PACKAGE_NAME_GUI,
                 bitbase.PACKAGE_NAME_CLI,
                 bitbase.BINARY_NAME_GUI,

--- a/common/cliarguments.py
+++ b/common/cliarguments.py
@@ -34,6 +34,7 @@ import tools
 # E.g. when using --diagnostics and other argparse.Action
 tools.initiate_translation(None)
 import bitbase  # noqa: E402
+import bitlicense  # noqa: E402
 import diagnostics  # noqa: E402
 import logger  # noqa: E402
 import clicommands  # noqa: E402
@@ -71,9 +72,9 @@ def _license_info() -> tuple[str, str]:
 
     # all used licenses
     licenses = None
-    if bitbase.DIR_LICENSES:
+    if bitlicense.DIR_LICENSES:
         licenses = [
-            f.with_suffix('').name for f in bitbase.DIR_LICENSES.iterdir()]
+            f.with_suffix('').name for f in bitlicense.DIR_LICENSES.iterdir()]
 
         if result:
             licenses.remove(result)
@@ -93,7 +94,7 @@ def _license_info() -> tuple[str, str]:
         result = (
             result[0],
             'Unable to extract licenses from LICENSES '
-            f'directory "{bitbase.DIR_LICENSES}".')
+            f'directory "{bitlicense.DIR_LICENSES}".')
         logger.error(result[1])
 
     return result
@@ -214,13 +215,13 @@ class ParserAgent:
             '-v', '--version',
             action='version',
             version='%(prog)s ' + __version__,
-            help="show %(prog)s's version number.")
+            help="show %(prog)s's version number")
 
         parser.add_argument(
             '--license',
             action=ActionPrintLicense,
             nargs=0,
-            help="show %(prog)s's license")
+            help="show %(prog)s's license details")
 
         parser.add_argument(
             '--diagnostics',
@@ -1004,17 +1005,19 @@ def parse_arguments(args: Namespace,
 
 
 class ActionPrintLicense(argparse.Action):
-    """Print license text."""
+    """Print license details."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def __call__(self, *args, **kwargs):
-        license_path = Path(tools.docPath()) / 'LICENSE'
-        # Dev note (buhtz, 2025-05): ToDo
-        # display aboutdlg license text (see bitbase)
-        # and show path of all license files in LICENSES dir
-        print(license_path.read_text('utf-8'))
+        text_gpl = bitlicense.get_gpl_short_text()
+        text_licenses = bitlicense.TXT_LICENSES.format(
+                dir_link=bitlicense.DIR_LICENSES,
+                readme_link=bitlicense.DIR_LICENSES.parent / 'LICENSES.md')
+
+        print(f'{text_gpl}\n{text_licenses}')
+
         sys.exit(bitbase.RETURN_OK)
 
 

--- a/common/config.py
+++ b/common/config.py
@@ -54,7 +54,6 @@ from exceptions import PermissionDeniedByPolicy
 
 class Config(configfile.ConfigFileWithProfiles):
     APP_NAME = bitbase.APP_NAME
-    COPYRIGHT = bitlicense.COPYRIGHT
 
     CONFIG_VERSION = 6
     """Latest or highest possible version of Back in Time's config file."""

--- a/common/config.py
+++ b/common/config.py
@@ -39,7 +39,6 @@ except NameError:
     _ = lambda val: val
 
 import bitbase
-import bitlicense
 import tools
 import configfile
 import logger

--- a/common/config.py
+++ b/common/config.py
@@ -39,6 +39,7 @@ except NameError:
     _ = lambda val: val
 
 import bitbase
+import bitlicense
 import tools
 import configfile
 import logger
@@ -53,7 +54,7 @@ from exceptions import PermissionDeniedByPolicy
 
 class Config(configfile.ConfigFileWithProfiles):
     APP_NAME = bitbase.APP_NAME
-    COPYRIGHT = bitbase.COPYRIGHT
+    COPYRIGHT = bitlicense.COPYRIGHT
 
     CONFIG_VERSION = 6
     """Latest or highest possible version of Back in Time's config file."""

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -318,7 +318,7 @@ def _get_rsync_info():
         )
 
     elif isinstance(info, dict):
-        # Rsync (>= 3.2.7)provided its information in JSON format.
+        # Rsync (>= 3.2.7) provide its information in JSON format.
         # Remove some irrelevant information.
         for key in ['program', 'copyright', 'url', 'license', 'caveat']:
             try:

--- a/common/inhibitsuspend.py
+++ b/common/inhibitsuspend.py
@@ -14,6 +14,7 @@ import os
 import sys
 import dbus
 import logger
+import bitbase
 
 
 class InhibitSuspend:
@@ -51,7 +52,7 @@ class InhibitSuspend:
         # Side effect: In BiT <= 1.4.1 root still tried to connect to the dbus
         # user session and it may have worked sometimes (without logging we
         # don't know) so as root suspend can no longer inhibited.
-        if os.geteuid() == 0:  # is root
+        if bitbase.IS_IN_ROOT_MODE:
             # Dev note (buhtz, 2025-04): But does this need to be a "Fail"?
             logger.debug(
                 'Inhibit Suspend aborted because BIT was started as root.')
@@ -63,8 +64,10 @@ class InhibitSuspend:
         try:
             self.bus = dbus.bus.BusConnection(
                 os.environ['DBUS_SESSION_BUS_ADDRESS'])
+
         except KeyError:
             pass
+
         except dbus.exceptions.DBusException as exc:
             logger.error(f'Unable to open DBus session bus. {exc}')
 
@@ -75,6 +78,7 @@ class InhibitSuspend:
             # This code may hang forever (if BIT is run as root via cron
             # job and no user is logged in). See #1592
             self.bus = dbus.SessionBus()
+
         except dbus.exceptions.DBusException as exc:
             logger.error(f'Unable to open DBus session bus. {exc}')
 

--- a/common/shutdownagent.py
+++ b/common/shutdownagent.py
@@ -13,6 +13,7 @@ import os
 import subprocess
 import dbus
 import logger
+import bitbase
 
 
 class ShutdownAgent:
@@ -118,7 +119,7 @@ class ShutdownAgent:
     }
 
     def __init__(self):
-        if self._am_i_root():
+        if bitbase.IS_IN_ROOT_MODE:
             self.proxy, self.args = None, None
         else:
             self.proxy, self.args = self._prepair()
@@ -127,9 +128,6 @@ class ShutdownAgent:
         # and who sets it.
         self.activate_shutdown = False
         self.started = False
-
-    def _am_i_root(self) -> bool:
-        return os.geteuid() == 0
 
     def _prepair(self):
         """Try to connect to the given dbus services. If successful it will
@@ -184,7 +182,7 @@ class ShutdownAgent:
     def can_shutdown(self):
         """Indicate if a valid dbus service is available to shutdown system.
         """
-        return self.proxy is not None or self._am_i_root()
+        return self.proxy is not None or bitbase.IS_IN_ROOT_MODE
 
     def ask_before_quit(self):
         """
@@ -217,7 +215,7 @@ class ShutdownAgent:
         """
 
         # As root
-        if self._am_i_root():
+        if bitbase.IS_IN_ROOT_MODE:
             return self._shutdown_via_shell()
 
         # As user

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -427,9 +427,6 @@ def create_test_files(path):
 
 @contextmanager
 def mockPermissions(path, mode=0o000):
-    """
-    """
-
     st = os.stat(path)
     os.chmod(path, mode)
     yield

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -45,6 +45,7 @@ full_test_files = [_base_dir / fp for fp in (
     'status.py',
     'askpass.py',
     'bitbase.py',
+    'bitlicense.py',
     # 'cliarguments.py',
     # 'clicommands.py',
     'daemon.py',

--- a/common/test/test_sshtools.py
+++ b/common/test/test_sshtools.py
@@ -24,6 +24,11 @@ import sshtools
 import tools
 from exceptions import MountException
 
+try:
+    _('Warning')
+except NameError:
+    _ = lambda val: val
+
 
 @unittest.skipIf(not generic.LOCAL_SSH, generic.SKIP_SSH_TEST_MESSAGE)
 class General(generic.SSHTestCase):

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -16,7 +16,6 @@ import sys
 import subprocess
 import random
 import pathlib
-import gzip
 import stat
 import signal
 import unittest
@@ -53,6 +52,42 @@ class Basics(unittest.TestCase):
 
         self.assertIn(path, sys.path)
         sys.path.remove(path)
+
+    def test_which(self):
+        self.assertRegex(tools.which('ls'), r'/.*/ls')
+
+        self.assertEqual(tools.which('backintime'),
+                         os.path.join(os.getcwd(), 'backintime'))
+
+        self.assertIsNone(tools.which('notExistedCommand'))
+
+    def test_makeDirs(self):
+        self.assertFalse(tools.makeDirs('/'))
+        self.assertTrue(tools.makeDirs(os.getcwd()))
+        with TemporaryDirectory() as d:
+            path = os.path.join(d, 'foo', 'bar')
+            self.assertTrue(tools.makeDirs(path))
+
+    def test_makeDirs_not_writable(self):
+        with TemporaryDirectory() as d:
+            os.chmod(d, stat.S_IRUSR)
+            path = os.path.join(
+                d, 'foobar{}'.format(random.randrange(100, 999)))
+            self.assertFalse(tools.makeDirs(path))
+
+    def test_mkdir(self):
+        self.assertFalse(tools.mkdir('/'))
+        with TemporaryDirectory() as d:
+            path = os.path.join(d, 'foo')
+            self.assertTrue(tools.mkdir(path))
+            for mode in (0o700, 0o644, 0o777):
+                msg = 'new path should have octal permissions {0:#o}' \
+                      .format(mode)
+                path = os.path.join(d, '{0:#o}'.format(mode))
+                self.assertTrue(tools.mkdir(path, mode), msg)
+                self.assertEqual(
+                    '{0:o}'.format(os.stat(path).st_mode & 0o777),
+                    '{0:o}'.format(mode), msg)
 
 
 class General(generic.TestCase):
@@ -92,101 +127,6 @@ class General(generic.TestCase):
 
         tools.addSourceToPathEnviron()
         self.assertIn(source, os.environ['PATH'])
-
-    def test_readFile(self):
-        """
-        Test the function readFile
-        """
-        test_tools_file = os.path.abspath(__file__)
-        test_directory = os.path.dirname(test_tools_file)
-        non_existing_file = os.path.join(test_directory, "nonExistingFile")
-
-        self.assertIsInstance(tools.readFile(test_tools_file), str)
-        self.assertIsNone(tools.readFile(non_existing_file))
-
-        with NamedTemporaryFile('wt') as tmp:
-            tmp.write('foo\nbar')
-            tmp.flush()
-            self.assertIsInstance(tools.readFile(tmp.name), str)
-            self.assertEqual(tools.readFile(tmp.name), 'foo\nbar')
-
-        tmp_gz = NamedTemporaryFile().name
-        with gzip.open(tmp_gz + '.gz', 'wt') as f:
-            f.write('foo\nbar')
-            f.flush()
-        self.assertIsInstance(tools.readFile(tmp_gz), str)
-        self.assertEqual(tools.readFile(tmp_gz), 'foo\nbar')
-        os.remove(tmp_gz + '.gz')
-
-    def test_readFileLines(self):
-        """
-        Test the function readFileLines
-        """
-        test_tools_file = os.path.abspath(__file__)
-        test_directory = os.path.dirname(test_tools_file)
-        non_existing_file = os.path.join(test_directory, "nonExistingFile")
-
-        output = tools.readFileLines(test_tools_file)
-        self.assertIsInstance(output, list)
-        self.assertGreaterEqual(len(output), 1)
-        self.assertIsInstance(output[0], str)
-        self.assertIsNone(tools.readFileLines(non_existing_file))
-
-        with NamedTemporaryFile('wt') as tmp:
-            tmp.write('foo\nbar')
-            tmp.flush()
-            self.assertIsInstance(tools.readFileLines(tmp.name), list)
-            self.assertListEqual(tools.readFileLines(tmp.name), ['foo', 'bar'])
-
-        tmp_gz = NamedTemporaryFile().name
-        with gzip.open(tmp_gz + '.gz', 'wt') as f:
-            f.write('foo\nbar')
-            f.flush()
-        self.assertIsInstance(tools.readFileLines(tmp_gz), list)
-        self.assertEqual(tools.readFileLines(tmp_gz), ['foo', 'bar'])
-        os.remove(tmp_gz + '.gz')
-
-    def test_which(self):
-        """
-        Test the function which
-        """
-        self.assertRegex(tools.which("ls"), r'/.*/ls')
-        self.assertEqual(tools.which('backintime'),
-                         os.path.join(os.getcwd(), 'backintime'))
-        self.assertIsNone(tools.which("notExistedCommand"))
-
-    def test_makeDirs(self):
-        self.assertFalse(tools.makeDirs('/'))
-        self.assertTrue(tools.makeDirs(os.getcwd()))
-        with TemporaryDirectory() as d:
-            path = os.path.join(d, 'foo', 'bar')
-            self.assertTrue(tools.makeDirs(path))
-
-    def test_makeDirs_not_writable(self):
-        with TemporaryDirectory() as d:
-            os.chmod(d, stat.S_IRUSR)
-            path = os.path.join(
-                d, 'foobar{}'.format(random.randrange(100, 999)))
-            self.assertFalse(tools.makeDirs(path))
-
-    def test_mkdir(self):
-        self.assertFalse(tools.mkdir('/'))
-        with TemporaryDirectory() as d:
-            path = os.path.join(d, 'foo')
-            self.assertTrue(tools.mkdir(path))
-            for mode in (0o700, 0o644, 0o777):
-                msg = 'new path should have octal permissions {0:#o}' \
-                      .format(mode)
-                path = os.path.join(d, '{0:#o}'.format(mode))
-                self.assertTrue(tools.mkdir(path, mode), msg)
-                self.assertEqual(
-                    '{0:o}'.format(os.stat(path).st_mode & 0o777),
-                    '{0:o}'.format(mode), msg)
-
-    def test_pids(self):
-        pids = tools.pids()
-        self.assertGreater(len(pids), 0)
-        self.assertIn(os.getpid(), pids)
 
     def test_processStat(self):
         pid = self._create_process()
@@ -370,7 +310,8 @@ class CheckCronPattern(unittest.TestCase):
             '*/6'
         )
 
-        self.assertTrue(tools.checkCronPattern(sut))
+        for sut in to_test:
+            self.assertTrue(tools.checkCronPattern(sut))
 
     def test_not_valid(self):
         to_test = (
@@ -382,8 +323,8 @@ class CheckCronPattern(unittest.TestCase):
             '*/6 a'
         )
 
-        self.assertFalse(tools.checkCronPattern(sut))
-
+        for sut in to_test:
+            self.assertFalse(tools.checkCronPattern(sut))
 
 
 class CheckCommand(unittest.TestCase):
@@ -451,7 +392,7 @@ class EncryptableWildcards(unittest.TestCase):
             self.assertTrue(tools.patternHasNotEncryptableWildcard(sut))
 
 
-class EscapeIPv6(generic.TestCase):
+class EscapeIPv6(unittest.TestCase):
     def test_escaped(self):
         values_and_expected = (
             ('fd00:0::5', '[fd00:0::5]'),
@@ -577,26 +518,31 @@ class Environ(generic.TestCase):
                 self.assertEqual(test_env.strValue(k), str(i), msg)
 
 
-class ExecuteSubprocess(generic.TestCase):
-    # new method with subprocess
+class ExecuteSubprocess(unittest.TestCase):
+    def setUp(self):
+        self.run = False
+
+    def _callback(self, func, *args):
+        func(*args)
+        self.run = True
+
     def test_returncode(self):
         self.assertEqual(tools.Execute(['true']).run(), 0)
         self.assertEqual(tools.Execute(['false']).run(), 1)
 
-    def test_callback(self):
-        c = lambda x, y: self.callback(self.assertEqual, x, 'foo')
+    def test_callback_simple(self):
+        c = lambda x, y: self._callback(self.assertEqual, x, 'foo')
         tools.Execute(['echo', 'foo'], callback=c).run()
         self.assertTrue(self.run)
-        self.run = False
 
-        # give extra user_data for callback
-        c = lambda x, y: self.callback(self.assertEqual, x, y)
+    def test_callback_extra_user_data(self):
+        c = lambda x, y: self._callback(self.assertEqual, x, y)
         tools.Execute(['echo', 'foo'], callback=c, user_data='foo').run()
         self.assertTrue(self.run)
         self.run = False
 
-        # no output
-        c = lambda x, y: self.callback(self.fail,
+    def test_callback_no_output(self):
+        c = lambda x, y: self._callback(self.fail,
                                        'callback was called unexpectedly')
         tools.Execute(['true'], callback=c).run()
         self.assertFalse(self.run)

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -41,34 +41,6 @@ UDEVADM_HAS_UUID = subprocess.Popen(
     stdout=subprocess.PIPE,
     stderr=subprocess.DEVNULL).communicate()[0].find(b'ID_FS_UUID=') > 0
 
-RSYNC_INSTALLED = tools.checkCommand('rsync')
-
-RSYNC_307_VERSION = """rsync  version 3.0.7  protocol version 30
-Copyright (C) 1996-2009 by Andrew Tridgell, Wayne Davison, and others.
-Web site: http://rsync.samba.org/
-Capabilities:
-    64-bit files, 64-bit inums, 32-bit timestamps, 64-bit long ints,
-    socketpairs, hardlinks, symlinks, IPv6, batchfiles, inplace,
-    append, ACLs, xattrs, iconv, symtimes
-
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
-are welcome to redistribute it under certain conditions.  See the GNU
-General Public License for details.
-"""
-
-RSYNC_310_VERSION = """rsync  version 3.1.0  protocol version 31
-Copyright (C) 1996-2013 by Andrew Tridgell, Wayne Davison, and others.
-Web site: http://rsync.samba.org/
-Capabilities:
-    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
-    socketpairs, hardlinks, symlinks, IPv6, batchfiles, inplace,
-    append, ACLs, xattrs, iconv, symtimes, prealloc
-
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
-are welcome to redistribute it under certain conditions.  See the GNU
-General Public License for details.
-"""
-
 
 class Basics(unittest.TestCase):
     def test_as_backintime_path(self):
@@ -173,15 +145,6 @@ class General(generic.TestCase):
         self.assertIsInstance(tools.readFileLines(tmp_gz), list)
         self.assertEqual(tools.readFileLines(tmp_gz), ['foo', 'bar'])
         os.remove(tmp_gz + '.gz')
-
-    def test_checkCommand(self):
-        """
-        Test the function checkCommand
-        """
-        self.assertFalse(tools.checkCommand(''))
-        self.assertFalse(tools.checkCommand("notExistedCommand"))
-        self.assertTrue(tools.checkCommand("ls"))
-        self.assertTrue(tools.checkCommand('backintime'))
 
     def test_which(self):
         """
@@ -325,48 +288,6 @@ class General(generic.TestCase):
             self.assertFalse(tools.powerStatusAvailable())
         self.assertIsInstance(tools.onBattery(), bool)
 
-    def test_rsyncCaps(self):
-        if RSYNC_INSTALLED:
-            caps = tools.rsyncCaps()
-            self.assertIsInstance(caps, list)
-            self.assertGreaterEqual(len(caps), 1)
-
-        self.assertListEqual(tools.rsyncCaps(data=RSYNC_307_VERSION),
-                             ['64-bit files',
-                              '64-bit inums',
-                              '32-bit timestamps',
-                              '64-bit long ints',
-                              'socketpairs',
-                              'hardlinks',
-                              'symlinks',
-                              'IPv6',
-                              'batchfiles',
-                              'inplace',
-                              'append',
-                              'ACLs',
-                              'xattrs',
-                              'iconv',
-                              'symtimes'])
-
-        self.assertListEqual(tools.rsyncCaps(data=RSYNC_310_VERSION),
-                             ['progress2',
-                              '64-bit files',
-                              '64-bit inums',
-                              '64-bit timestamps',
-                              '64-bit long ints',
-                              'socketpairs',
-                              'hardlinks',
-                              'symlinks',
-                              'IPv6',
-                              'batchfiles',
-                              'inplace',
-                              'append',
-                              'ACLs',
-                              'xattrs',
-                              'iconv',
-                              'symtimes',
-                              'prealloc'])
-
     def test_md5sum(self):
         with NamedTemporaryFile() as f:
             f.write(b'foo')
@@ -374,17 +295,6 @@ class General(generic.TestCase):
 
             self.assertEqual(tools.md5sum(f.name),
                              'acbd18db4cc2f85cedef654fccc4a4d8')
-
-    def test_checkCronPattern(self):
-        self.assertTrue(tools.checkCronPattern('0'))
-        self.assertTrue(tools.checkCronPattern('0,10,13,15,17,20,23'))
-        self.assertTrue(tools.checkCronPattern('*/6'))
-        self.assertFalse(tools.checkCronPattern('a'))
-        self.assertFalse(tools.checkCronPattern(' 1'))
-        self.assertFalse(tools.checkCronPattern('0,10,13,1a,17,20,23'))
-        self.assertFalse(tools.checkCronPattern('0,10,13, 15,17,20,23'))
-        self.assertFalse(tools.checkCronPattern('*/6,8'))
-        self.assertFalse(tools.checkCronPattern('*/6 a'))
 
     def test_mountpoint(self):
         self.assertEqual(tools.mountpoint('/nonExistingFolder/foo/bar'), '/')
@@ -397,49 +307,6 @@ class General(generic.TestCase):
         self.assertEqual(
             tools.decodeOctalEscape('/mnt/path\\040with\\040space'),
             '/mnt/path with space')
-
-    def test_mountArgs(self):
-        rootArgs = tools.mountArgs('/')
-        self.assertIsInstance(rootArgs, list)
-        self.assertGreaterEqual(len(rootArgs), 3)
-        self.assertEqual(rootArgs[1], '/')
-
-        procArgs = tools.mountArgs('/proc')
-        self.assertGreaterEqual(len(procArgs), 3)
-        self.assertEqual(procArgs[0], 'proc')
-        self.assertEqual(procArgs[1], '/proc')
-        self.assertEqual(procArgs[2], 'proc')
-
-    def test_isRoot(self):
-        self.assertIsInstance(tools.isRoot(), bool)
-
-    def test_usingSudo(self):
-        self.assertIsInstance(tools.usingSudo(), bool)
-
-    def test_patternHasNotEncryptableWildcard(self):
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('foo'))
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('/foo'))
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('foo/*/bar'))
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('foo/**/bar'))
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('*/foo'))
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('**/foo'))
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('foo/*'))
-        self.assertFalse(tools.patternHasNotEncryptableWildcard('foo/**'))
-
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo?'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo[1-2]'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo*'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('*foo'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('**foo'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('*.foo'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo*bar'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo**bar'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo*/bar'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo**/bar'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo/*bar'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo/**bar'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('foo/*/bar*'))
-        self.assertTrue(tools.patternHasNotEncryptableWildcard('*foo/*/bar'))
 
     def test_readTimeStamp(self):
         with NamedTemporaryFile('wt') as f:
@@ -493,6 +360,95 @@ class General(generic.TestCase):
         self.assertEqual(
             ret[0],
             'echo start;echo foo;echo foo;echo foo;echo end')
+
+
+class CheckCronPattern(unittest.TestCase):
+    def test_valid(self):
+        to_test = (
+            '0',
+            '0,10,13,15,17,20,23',
+            '*/6'
+        )
+
+        self.assertTrue(tools.checkCronPattern(sut))
+
+    def test_not_valid(self):
+        to_test = (
+            'a',
+            ' 1',
+            '0,10,13,1a,17,20,23',
+            '0,10,13, 15,17,20,23',
+            '*/6,8',
+            '*/6 a'
+        )
+
+        self.assertFalse(tools.checkCronPattern(sut))
+
+
+
+class CheckCommand(unittest.TestCase):
+    def test_empty(self):
+        self.assertFalse(tools.checkCommand(''))
+
+    def test_not_existing(self):
+        self.assertFalse(tools.checkCommand('notExistedCommand'))
+
+    def test_existing(self):
+        for sut in ('ls', 'backintime'):
+            self.assertTrue(tools.checkCommand(sut))
+
+
+class MountArgs(unittest.TestCase):
+    def test_root_fs(self):
+        sut = tools.mountArgs('/')
+        self.assertIsInstance(sut, list)
+        self.assertGreaterEqual(len(sut), 3)
+        self.assertEqual(sut[1], '/')
+
+    def test_proc(self):
+        sut = tools.mountArgs('/proc')
+        self.assertGreaterEqual(len(sut), 3)
+        self.assertEqual(sut[0], 'proc')
+        self.assertEqual(sut[1], '/proc')
+        self.assertEqual(sut[2], 'proc')
+
+
+class EncryptableWildcards(unittest.TestCase):
+    def test_has(self):
+        to_test = (
+            'foo',
+            '/foo',
+            'foo/*/bar',
+            'foo/**/bar',
+            '*/foo',
+            '**/foo',
+            'foo/*',
+            'foo/**'
+        )
+
+        for sut in to_test:
+            self.assertFalse(tools.patternHasNotEncryptableWildcard(sut))
+
+    def test_has_not(self):
+        to_test = (
+            'foo?',
+            'foo[1-2]',
+            'foo*',
+            '*foo',
+            '**foo',
+            '*.foo',
+            'foo*bar',
+            'foo**bar',
+            'foo*/bar',
+            'foo**/bar',
+            'foo/*bar',
+            'foo/**bar',
+            'foo/*/bar*',
+            '*foo/*/bar'
+        )
+
+        for sut in to_test:
+            self.assertTrue(tools.patternHasNotEncryptableWildcard(sut))
 
 
 class EscapeIPv6(generic.TestCase):

--- a/common/tools.py
+++ b/common/tools.py
@@ -1974,21 +1974,6 @@ def isRoot():
     return os.geteuid() == 0
 
 
-def usingSudo() -> bool:
-    """
-    Check if 'sudo' was used to start this process.
-
-    Returns:
-        bool:   ``True`` if the process was started with sudo
-    """
-    if not isRoot():
-        return False
-
-    if not os.getenv('SUDO_USER'):
-        return False
-
-    return True
-
 re_wildcard = re.compile(r'(?:\[|\]|\?)')
 re_asterisk = re.compile(r'\*')
 re_separate_asterisk = re.compile(r'(?:^\*+[^/\*]|[^/\*]\*+[^/\*]|[^/\*]\*+|\*+[^/\*]|[^/\*]\*+$)')

--- a/common/tools.py
+++ b/common/tools.py
@@ -1960,20 +1960,6 @@ def uuidFromPath(path):
     return uuidFromDev(device(path))
 
 
-def isRoot():
-    """
-    Check if we are root.
-
-    Returns:
-        bool:   ``True`` if we are root
-    """
-
-    # The EUID (Effective UID) may be different from the UID (user ID)
-    # in case of SetUID or using "sudo" (where EUID is "root" and UID
-    # is the original user who executed "sudo").
-    return os.geteuid() == 0
-
-
 re_wildcard = re.compile(r'(?:\[|\]|\?)')
 re_asterisk = re.compile(r'\*')
 re_separate_asterisk = re.compile(r'(?:^\*+[^/\*]|[^/\*]\*+[^/\*]|[^/\*]\*+|\*+[^/\*]|[^/\*]\*+$)')

--- a/common/tools.py
+++ b/common/tools.py
@@ -20,7 +20,6 @@ import shlex
 import signal
 import re
 import errno
-import gzip
 import locale
 import gettext
 import hashlib
@@ -757,68 +756,6 @@ def get_git_repository_info(path=None, hash_length=None):
     return result
 
 
-def readFile(path, default=None):
-    """
-    Read the file in ``path`` or its '.gz' compressed variant and return its
-    content or ``default`` if ``path`` does not exist.
-
-    Args:
-        path (str):             full path to file that should be read.
-                                '.gz' will be added automatically if the file
-                                is compressed
-        default (str):          default if ``path`` does not exist
-
-    Returns:
-        str:                    content of file in ``path``
-    """
-    ret_val = default
-
-    try:
-        if os.path.exists(path):
-
-            with open(path) as f:
-                ret_val = f.read()
-
-        elif os.path.exists(path + '.gz'):
-
-            with gzip.open(path + '.gz', 'rt') as f:
-                ret_val = f.read()
-
-    except:
-        pass
-
-    return ret_val
-
-
-def readFileLines(path, default=None):
-    """
-    Read the file in ``path`` or its '.gz' compressed variant and return its
-    content as a list of lines or ``default`` if ``path`` does not exist.
-
-    Args:
-        path (str):             full path to file that should be read.
-                                '.gz' will be added automatically if the file
-                                is compressed
-        default (list):         default if ``path`` does not exist
-
-    Returns:
-        list:                   content of file in ``path`` split by lines.
-    """
-    ret_val = default
-
-    try:
-        if os.path.exists(path):
-            with open(path) as f:
-                ret_val = [x.rstrip('\n') for x in f.readlines()]
-        elif os.path.exists(path + '.gz'):
-            with gzip.open(path + '.gz', 'rt') as f:
-                ret_val = [x.rstrip('\n') for x in f.readlines()]
-    except:
-        pass
-
-    return ret_val
-
-
 def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
     """Return ``True`` if ``dt`` is older than ``value`` months, weeks, days or
     hours compared to the current time (`datetime.now()`).
@@ -985,16 +922,6 @@ def mkdir(path, mode=0o755, enforce_permissions=True):
     return os.path.isdir(path)
 
 
-def pids():
-    """
-    List all PIDs currently running on the system.
-
-    Returns:
-        list:   PIDs as int
-    """
-    return [int(x) for x in os.listdir('/proc') if x.isdigit()]
-
-
 def processStat(pid):
     """
     Get the stat's of the process with ``pid``.
@@ -1077,8 +1004,16 @@ def pidsWithName(name):
     Returns:
         list:       PIDs as int
     """
+    all_pids = [
+        int(fp.name)
+        for fp in pathlib.Path('/proc').iterdir()
+        if fp.name.isdigit()
+    ]
+
     # /proc/###/stat stores just the first 16 chars of the process name
-    return [x for x in pids() if processName(x) == name[:15]]
+    name_to_look_for = name[:15]
+
+    return [pid for pid in all_pids if processName(pid) == name_to_look_for]
 
 
 def processExists(name):
@@ -1179,12 +1114,12 @@ def is_Qt_working(systray_required=False):
     # Spawns a new process since it may crash with a SIGABRT and we
     # don't want to crash BiT if this happens...
 
-    try:
-        path = os.path.join(as_backintime_path("common"), "qt_probing.py")
-        cmd = [sys.executable, path]
-        if logger.DEBUG:
-            cmd.append('--debug')
+    path = os.path.join(as_backintime_path("common"), "qt_probing.py")
+    cmd = [sys.executable, path]
+    if logger.DEBUG:
+        cmd.append('--debug')
 
+    try:
         with subprocess.Popen(cmd,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE,
@@ -1198,26 +1133,28 @@ def is_Qt_working(systray_required=False):
 
             # if some Qt parts are missing: Show details
             if proc.returncode != 2 or logger.DEBUG:
-                logger.debug(f"Qt probing stdout:\n{std_output}")
-                logger.debug(f"Qt probing errout:\n{error_output}")
+                logger.debug(f'Qt probing stdout: "{std_output}"')
+                logger.debug(f'Qt probing errout: "{error_otuput}"')
 
-            return proc.returncode == 2 or (proc.returncode == 1 and systray_required is False)
+            rc = proc.returncode
+
+            return rc == 2 or (rc == 1 and systray_required is False)
 
     except FileNotFoundError:
-        logger.error(f"Qt probing script not found: {cmd[0]}")
+        logger.error(f'Qt probing script not found: {cmd[0]}')
         raise
 
     # Fix for #1592 (qt_probing.py may hang as root): Kill after timeout
     except subprocess.TimeoutExpired:
         proc.kill()
         outs, errs = proc.communicate()
-        logger.info("Qt probing sub process killed after timeout "
-                    "without response")
-        logger.debug(f"Qt probing stdout:\n{outs}")
-        logger.debug(f"Qt probing errout:\n{errs}")
+        logger.info('Qt probing sub process killed after timeout '
+                    'without response')
+        logger.debug(f'Qt probing stdout: "{outs}"')
+        logger.debug(f'Qt probing errout: "{errs}"')
 
-    except Exception as e:
-        logger.error(f"Error: {repr(e)}")
+    except Exception as exc:
+        logger.critical(f'Unknown Error: {exc}')
         raise
 
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -872,7 +872,7 @@ def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
                        'Please report it via a bug ticket.')
 
 
-def checkCommand(cmd):
+def checkCommand(cmd: str) -> bool:
     """Check if command ``cmd`` is a file in 'PATH' environment.
 
     Args:
@@ -1286,29 +1286,34 @@ def onBattery():
     return False
 
 
-def rsyncCaps(data=None):
+def rsyncCaps() -> list[str]:
     """
     Get capabilities of the installed rsync binary. This can be different from
     version to version and also on build arguments used when building rsync.
 
-    Args:
-        data (str): 'rsync --version' output. This is just for unittests.
+    Dev note (buhtz, 2025-07): BIT uses --xattrs and --acls only. Both are
+    introduced with rsync 3.0.0 in year 2008. Might be worth to keep this
+    check.
 
     Returns:
-        list:       List of str with rsyncs capabilities
+        List of str with rsyncs capabilities.
     """
-    if not data:
-        proc = subprocess.Popen(['rsync', '--version'],
-                                stdout=subprocess.PIPE,
-                                universal_newlines=True)
-        data = proc.communicate()[0]
+    proc = subprocess.Popen(['rsync', '--version'],
+                            stdout=subprocess.PIPE,
+                            universal_newlines=True)
+    data = proc.communicate()[0]
+
     caps = []
 
     # rsync >= 3.1 does provide --info=progress2
-    matchers = [r'rsync\s*version\s*(\d\.\d)', r'rsync\s*version\s*v(\d\.\d.\d)']
+    matchers = (
+        r'rsync\s*version\s*(\d\.\d)',
+        r'rsync\s*version\s*v(\d\.\d.\d)'
+    )
 
     for matcher in matchers:
         m = re.match(matcher, data)
+
         if m and Version(m.group(1)) >= Version('3.1'):
             caps.append('progress2')
             break
@@ -1322,6 +1327,7 @@ def rsyncCaps(data=None):
     for line in m.group(1).split('\n'):
         caps.extend(
             [i.strip(' \n') for i in line.split(',') if i.strip(' \n')])
+
     return caps
 
 
@@ -1397,6 +1403,7 @@ def rsyncPrefix(config,
 
     if no_perms:
         cmd.extend(('--no-perms', '--no-group', '--no-owner'))
+
     else:
         cmd.extend(('--perms',          # preserve permissions
                     '--executability',  # preserve executability
@@ -1531,18 +1538,22 @@ def checkCronPattern(s):
     """
     if s.find(' ') >= 0:
         return False
+
     try:
         if s.startswith('*/'):
             if s[2:].isdigit() and int(s[2:]) <= 24:
                 return True
             else:
                 return False
+
         for i in s.split(','):
             if i.isdigit() and int(i) <= 24:
                 continue
             else:
                 return False
+
         return True
+
     except ValueError:
         return False
 
@@ -1746,7 +1757,7 @@ def decodeOctalEscape(s):
     return re.sub(r'\\(\d{3})', repl, s)
 
 
-def mountArgs(path):
+def mountArgs(path: str) -> list | None:
     """
     Get all /etc/mtab args for the filesystem of ``path`` as a list.
     Example::
@@ -1759,7 +1770,7 @@ def mountArgs(path):
         path (str): full path
 
     Returns:
-        list:       mount args
+        The mount args.
     """
     mp = mountpoint(path)
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -29,7 +29,7 @@ from datetime import datetime, timedelta
 from collections.abc import MutableMapping
 from packaging.version import Version
 from typing import Union
-from bitbase import TimeUnit
+from bitbase import TimeUnit, BINARY_NAME_BASE
 from storagesize import StorageSize, SizeUnit
 import logger
 
@@ -135,34 +135,10 @@ def as_backintime_path(*path: str) -> str:
     return str(result)
 
 
-def docPath():
-    """Not sure what this path is about.
-    """
-    path = pathlib.Path(sharePath()) / 'doc' / 'backintime-common'
-
-    # Dev note (buhtz, aryoda, 2024-02):
-    # This piece of code originally resisted in Config.__init__() and was
-    # introduced by Dan in 2008. The reason for the existence of this "if"
-    # is unclear.
-
-    # Makefile (in common) does only install into share/doc/backintime-common
-    # but never into the the backintime "binary" path so I guess the if is
-    # a) either a distro-specific exception for a distro package that
-    # (manually?) installs the LICENSE into another path
-    # b) or a left-over from old code where the LICENSE was installed
-    # differently...
-
-    license_file = pathlib.Path(as_backintime_path()) / 'LICENSE'
-    if license_file.exists():
-        path = as_backintime_path()
-
-    return str(path)
-
-
 # |---------------------------------------------------|
 # | Internationalization (i18n) & localization (L10n) |
 # |---------------------------------------------------|
-_GETTEXT_DOMAIN = 'backintime'
+_GETTEXT_DOMAIN = BINARY_NAME_BASE
 _GETTEXT_LOCALE_DIR = pathlib.Path(sharePath()) / 'locale'
 
 

--- a/common/tools.py
+++ b/common/tools.py
@@ -1974,14 +1974,20 @@ def isRoot():
     return os.geteuid() == 0
 
 
-def usingSudo():
+def usingSudo() -> bool:
     """
     Check if 'sudo' was used to start this process.
 
     Returns:
         bool:   ``True`` if the process was started with sudo
     """
-    return isRoot() and os.getenv('HOME', '/root') != '/root'
+    if not isRoot():
+        return False
+
+    if not os.getenv('SUDO_USER'):
+        return False
+
+    return True
 
 re_wildcard = re.compile(r'(?:\[|\]|\?)')
 re_asterisk = re.compile(r'\*')
@@ -2115,7 +2121,6 @@ def escapeIPv6Address(address):
         return f'[{address}]'
 
     return address
-
 
 
 class Alarm:

--- a/common/tools.py
+++ b/common/tools.py
@@ -2117,18 +2117,6 @@ def escapeIPv6Address(address):
     return address
 
 
-def camelCase(s):
-    """
-    Remove underlines and make every first char uppercase.
-
-    Args:
-        s (str):    string separated by underlines (foo_bar)
-
-    Returns:
-        str:        string without underlines but uppercase chars (FooBar)
-    """
-    return ''.join([x.capitalize() for x in s.split('_')])
-
 
 class Alarm:
     """Establish a callback function that is called after a timeout using

--- a/common/tools.py
+++ b/common/tools.py
@@ -1134,7 +1134,7 @@ def is_Qt_working(systray_required=False):
             # if some Qt parts are missing: Show details
             if proc.returncode != 2 or logger.DEBUG:
                 logger.debug(f'Qt probing stdout: "{std_output}"')
-                logger.debug(f'Qt probing errout: "{error_otuput}"')
+                logger.debug(f'Qt probing errout: "{error_output}"')
 
             rc = proc.returncode
 

--- a/qt/aboutdlg.py
+++ b/qt/aboutdlg.py
@@ -25,6 +25,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPalette
 import logger
 import bitbase
+import bitlicense
 import tools
 import version
 import messagebox
@@ -85,7 +86,7 @@ class AboutDlg(QDialog):
             label.setLineWidth(1)
 
         label_copyright = QLabel('<strong>' + _('Copyright:') + '</strong>')
-        copyr = QLabel(bitbase.COPYRIGHT)
+        copyr = QLabel(bitlicense.COPYRIGHT)
         _set_label_props(copyr)
 
         label_authors = QLabel('<strong>' + _('Authors:') + '</strong>')
@@ -146,13 +147,8 @@ class AboutDlg(QDialog):
         # Dev note (buhtz, 2025-03): That string is untranslated on purpose.
         # It is legally relevant, and no one should be given the opportunity
         # to change the string—whether intentionally or accidentally.
-        text_gpl = (
-            f'The application is released under <a href="{_HREF_SPDX_GPL}">'
-            'GNU General Public License v2.0 or later (GPL-2.0-or-later)</a>.')
-        text_licenses = _(
-            'All licenses used in this project are located in the {dir_link} '
-            'directory. To extract per-file license and copyright information '
-            'using SPDX metadata, refer to {readme_link}.').format(
+        text_gpl = bitlicense.get_gpl_short_text(href=_HREF_SPDX_GPL)
+        text_licenses = bitlicense.TXT_LICENSES.format(
                 dir_link=f'<a href="{_HREF_LICENSES_DIR}">LICENSES</a>',
                 readme_link=f'<a href="{_HREF_LICENSES_MD}">LICENSES.md</a>')
 
@@ -169,7 +165,7 @@ class AboutDlg(QDialog):
 
     def _slot_license_link_acivated(self, link):
         if link in (_HREF_LICENSES_DIR, _HREF_LICENSES_MD):
-            fp = bitbase.DIR_LICENSES
+            fp = bitlicense.DIR_LICENSES
 
             if link == _HREF_LICENSES_MD:
                 fp = fp.parent / 'LICENSES.md'
@@ -189,7 +185,7 @@ class AboutDlg(QDialog):
             return
 
         if link == _HREF_SPDX_GPL:
-            qttools.open_url(bitbase.URL_GPL_TWO)
+            qttools.open_url(bitlicense.URL_GPL_TWO)
             return
 
         logger.critical(f'Unknown link "{link}". Please open a bug report.')

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -481,7 +481,7 @@ def createQApplication(app_name=bitbase.APP_NAME):
 
     try:
 
-        if tools.isRoot():
+        if bitbase.IS_IN_ROOT_MODE:
             qapp.setApplicationName(app_name + " (root)")
             qapp.setDesktopFileName("backintime-qt-root")
 
@@ -492,7 +492,7 @@ def createQApplication(app_name=bitbase.APP_NAME):
         logger.warning('Could not set App ID (required for Wayland App icon '
                        f'and more). Reason: {exc}')
 
-    if (os.geteuid() == 0
+    if (bitbase.IS_IN_ROOT_MODE
             and qapp.style().objectName().lower() == 'windows'
             and 'GTK+' in QStyleFactory.keys()):
 


### PR DESCRIPTION
Refactored and removed some code from tools.py.
Created `bitlicense.py` file. It need to be separated from `bitbase.py` because the later is not able to handle translatable strings at import time.
Improved `--license` output.