### PR TITLE
fix!: Make scheduling with "Repeatedly (anacron)" consistent

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Changed: "Repeatedly (anacron)" scheduling behave consistent. Reversed minor bug introduced with 060324e (#1791) in 1.5.3 (#2250)
 * Changed: Stricter permissions (600) for fileinfo.bz2 and takesnapshot.log.bz2 (#2235)
 * Changed: **Breaking** A "snapshot" now is a "backup" (#1929)
 * Changed: **Breaking** Deprecated and removed make targets: "test", "test-v", "unittest", "unittest-v"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,10 +168,6 @@ distribution.
         packages
         - `kompare`
         - or `meld`
-      - Optional: Default icons
-        - The `oxygen` icons should be offered as optional dependency
-          since they are used as fallback in case of missing icons
-          (mainly app and system-tray icons)
 
 * Build and testing dependencies
   - All CLI runtime dependencies including the recommended

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -652,6 +652,18 @@ class OlderThan(unittest.TestCase):
 
         self.assertTrue(tools.older_than(birth, 2, TimeUnit.DAY))
 
+    def test_days_boundary(self, mock_dt):
+        """The boundary of days not their duration."""
+
+        # 18:23 compared to ...
+        last_job_run = datetime(1982, 8, 6, 18, 23, 0, 0)
+
+        # 2:13 the next day (only 8 hours later)
+        mock_dt.now.return_value = datetime(1982, 8, 7, 2, 23, 0, 0)
+
+        # compare by one day
+        self.assertTrue(tools.older_than(last_job_run, 1, TimeUnit.DAY))
+
     def test_week_not_older(self, mock_dt):
         """Two weeks"""
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -652,7 +652,7 @@ class OlderThan(unittest.TestCase):
 
         self.assertTrue(tools.older_than(birth, 2, TimeUnit.DAY))
 
-    def test_days_boundary(self, mock_dt):
+    def test_days_boundary_one_day(self, mock_dt):
         """The boundary of days not their duration."""
 
         # 18:23 compared to ...
@@ -663,6 +663,21 @@ class OlderThan(unittest.TestCase):
 
         # compare by one day
         self.assertTrue(tools.older_than(last_job_run, 1, TimeUnit.DAY))
+
+    def test_days_boundary_four_days(self, mock_dt):
+        """The boundary of days not their duration."""
+
+        # 6th August, 18:23
+        last_job_run = datetime(1982, 8, 6, 18, 23, 0, 0)
+
+        # 9th August (the 4th day), at 2:13
+        mock_dt.now.return_value = datetime(1982, 8, 9, 2, 23, 0, 0)
+        # ...four days not finished yet
+        self.assertFalse(tools.older_than(last_job_run, 4, TimeUnit.DAY))
+
+        # 10th August (the 5th day), at 2:13
+        mock_dt.now.return_value = datetime(1982, 8, 10, 2, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 4, TimeUnit.DAY))
 
     def test_week_not_older(self, mock_dt):
         """Two weeks"""

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -616,32 +616,39 @@ class ValidateSnapshotsPath(generic.TestCaseCfg):
 class OlderThan(unittest.TestCase):
 
     def test_hours_not_older(self, mock_dt):
-        """Exact two hours
-
-        Keep in mind: 20:23:00 is NOT two hours older than 18:23:00. But
-        20:23:01 IS OLDER than two hours.
-        """
-        # year, month, day, hour=0, minute=0, second=0, microsecond=0
+        # 6th August, 18:23
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
 
-        # exact two hours
-        mock_dt.now.return_value = datetime(1982, 8, 6, 20, 23, 0, 0)
+        # 6th August, 19:23
+        mock_dt.now.return_value = datetime(1982, 8, 6, 19, 23, 0, 0)
 
         self.assertFalse(tools.older_than(birth, 2, TimeUnit.HOUR))
 
     def test_hours_older(self, mock_dt):
-        """Two hours plus one ms"""
+        # 6th August, 18:23
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
 
-        # two hours + 1 ms
-        mock_dt.now.return_value = datetime(1982, 8, 6, 20, 23, 0, 1)
+        # 6h August, 20:04 (not 2x 60 minutes but the 3rd hour)
+        mock_dt.now.return_value = datetime(1982, 8, 6, 20, 4, 0, 0)
 
         self.assertTrue(tools.older_than(birth, 2, TimeUnit.HOUR))
 
+    def test_hours_boundary(self, mock_dt):
+        # 18:23
+        last_job_run = datetime(1982, 8, 6, 18, 23, 0, 0)
+
+        # 19:01 (only 36 minutes later, but the next hour)
+        mock_dt.now.return_value = datetime(1982, 8, 6, 19, 1, 0, 0)
+
+        self.assertTrue(tools.older_than(last_job_run, 1, TimeUnit.HOUR))
+
     def test_days_not_older(self, mock_dt):
         """Two days"""
+        # 6th August, 18:23
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1982, 8, 8, 18, 23, 0, 0)
+
+        # 7th August, 18:23
+        mock_dt.now.return_value = datetime(1982, 8, 7, 18, 23, 0, 0)
 
         self.assertFalse(tools.older_than(birth, 2, TimeUnit.DAY))
 
@@ -679,17 +686,24 @@ class OlderThan(unittest.TestCase):
         mock_dt.now.return_value = datetime(1982, 8, 10, 2, 23, 0, 0)
         self.assertTrue(tools.older_than(last_job_run, 4, TimeUnit.DAY))
 
-    def test_week_not_older(self, mock_dt):
-        """Two weeks"""
+    def test_week_boundary(self, mock_dt):
+        # 6th August (Friday)
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1982, 8, 20, 18, 23, 0, 0)
 
+        # 13th August (Friday next week)
+        mock_dt.now.return_value = datetime(1982, 8, 13, 18, 23, 0, 0)
         self.assertFalse(tools.older_than(birth, 2, TimeUnit.WEEK))
 
+        # 14th August (Saturday next week)
+        mock_dt.now.return_value = datetime(1982, 8, 14, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 2, TimeUnit.WEEK))
+
     def test_week_older(self, mock_dt):
-        """Two weeks plus one ms"""
+        # 6th August (Friday)
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1982, 8, 20, 18, 23, 0, 1)
+
+        # 17th August (Tuesday)
+        mock_dt.now.return_value = datetime(1982, 8, 17, 18, 23, 0, 1)
 
         self.assertTrue(tools.older_than(birth, 2, TimeUnit.WEEK))
 

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -614,33 +614,18 @@ class ValidateSnapshotsPath(generic.TestCaseCfg):
 
 @patch(f'{tools.__name__}.datetime', wraps=datetime)
 class OlderThan(unittest.TestCase):
-
-    def test_hours_not_older(self, mock_dt):
-        # 6th August, 18:23
-        birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-
-        # 6th August, 19:23
-        mock_dt.now.return_value = datetime(1982, 8, 6, 19, 23, 0, 0)
-
-        self.assertFalse(tools.older_than(birth, 2, TimeUnit.HOUR))
-
-    def test_hours_older(self, mock_dt):
-        # 6th August, 18:23
-        birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-
-        # 6h August, 20:04 (not 2x 60 minutes but the 3rd hour)
-        mock_dt.now.return_value = datetime(1982, 8, 6, 20, 4, 0, 0)
-
-        self.assertTrue(tools.older_than(birth, 2, TimeUnit.HOUR))
-
     def test_hours_boundary(self, mock_dt):
         # 18:23
         last_job_run = datetime(1982, 8, 6, 18, 23, 0, 0)
 
         # 19:01 (only 36 minutes later, but the next hour)
         mock_dt.now.return_value = datetime(1982, 8, 6, 19, 1, 0, 0)
-
         self.assertTrue(tools.older_than(last_job_run, 1, TimeUnit.HOUR))
+        self.assertFalse(tools.older_than(last_job_run, 2, TimeUnit.HOUR))
+
+        # 20:01 (only 36 minutes later, but the next hour)
+        mock_dt.now.return_value = datetime(1982, 8, 6, 20, 1, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 2, TimeUnit.HOUR))
 
     def test_days_not_older(self, mock_dt):
         """Two days"""
@@ -665,11 +650,10 @@ class OlderThan(unittest.TestCase):
         # 18:23 compared to ...
         last_job_run = datetime(1982, 8, 6, 18, 23, 0, 0)
 
-        # 2:13 the next day (only 8 hours later)
+        # next day 2:13 (only 8 hours later)
         mock_dt.now.return_value = datetime(1982, 8, 7, 2, 23, 0, 0)
-
-        # compare by one day
         self.assertTrue(tools.older_than(last_job_run, 1, TimeUnit.DAY))
+        self.assertFalse(tools.older_than(last_job_run, 2, TimeUnit.DAY))
 
     def test_days_boundary_four_days(self, mock_dt):
         """The boundary of days not their duration."""
@@ -686,69 +670,145 @@ class OlderThan(unittest.TestCase):
         mock_dt.now.return_value = datetime(1982, 8, 10, 2, 23, 0, 0)
         self.assertTrue(tools.older_than(last_job_run, 4, TimeUnit.DAY))
 
-    def test_week_boundary(self, mock_dt):
+    def test_weeks_boundary(self, mock_dt):
+        """
+            August 1982
+        Mo Tu We Th Fr Sa Su
+                           1
+         2  3  4  5  6  7  8
+         9 10 11 12 13 14 15
+        16 17 18 19 20 21 22
+        23 24 25 26 27 28 29
+        30 31
+        """
         # 6th August (Friday)
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
 
-        # 13th August (Friday next week)
-        mock_dt.now.return_value = datetime(1982, 8, 13, 18, 23, 0, 0)
+        # 9th August (Monday next week)
+        mock_dt.now.return_value = datetime(1982, 8, 9, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 1, TimeUnit.WEEK))
+
+        # 15th August (Saturday next week)
+        mock_dt.now.return_value = datetime(1982, 8, 15, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 1, TimeUnit.WEEK))
         self.assertFalse(tools.older_than(birth, 2, TimeUnit.WEEK))
 
-        # 14th August (Saturday next week)
-        mock_dt.now.return_value = datetime(1982, 8, 14, 18, 23, 0, 0)
+        # 16th August
+        mock_dt.now.return_value = datetime(1982, 8, 16, 18, 23, 0, 0)
         self.assertTrue(tools.older_than(birth, 2, TimeUnit.WEEK))
 
-    def test_week_older(self, mock_dt):
-        # 6th August (Friday)
+    def test_months_boundary(self, mock_dt):
+        # 6th August
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
 
-        # 17th August (Tuesday)
-        mock_dt.now.return_value = datetime(1982, 8, 17, 18, 23, 0, 1)
+        # 1st Sept
+        mock_dt.now.return_value = datetime(1982, 9, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 1, TimeUnit.MONTH))
 
-        self.assertTrue(tools.older_than(birth, 2, TimeUnit.WEEK))
-
-    def test_month_not_older(self, mock_dt):
-        """Two months."""
-        birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1982, 10, 6, 18, 23, 0, 0)
-
+        # 30 Sept
+        mock_dt.now.return_value = datetime(1982, 9, 30, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 1, TimeUnit.MONTH))
         self.assertFalse(tools.older_than(birth, 2, TimeUnit.MONTH))
 
-    def test_month_older(self, mock_dt):
-        """Two months plus one ms."""
-        birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1982, 10, 6, 18, 23, 0, 1)
-
+        # 1st Oct
+        mock_dt.now.return_value = datetime(1982, 10, 1, 18, 23, 0, 0)
         self.assertTrue(tools.older_than(birth, 2, TimeUnit.MONTH))
 
-    def test_month_31th(self, mock_dt):
-        """From May with 31th as last day to September with 30th as last day.
-        """
+        # 31 October
+        mock_dt.now.return_value = datetime(1982, 10, 31, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 2, TimeUnit.MONTH))
+        self.assertFalse(tools.older_than(birth, 3, TimeUnit.MONTH))
+
+        # 1st November
+        mock_dt.now.return_value = datetime(1982, 11, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 3, TimeUnit.MONTH))
+
+    def test_months_steps(self, mock_dt):
+        # 14th January
+        last_job_run = datetime(1982, 1, 14, 18, 23, 0, 0)
+
+        # 31th January
+        mock_dt.now.return_value = datetime(1982, 1, 31, 18, 23, 0, 0)
+        self.assertFalse(tools.older_than(last_job_run, 1, TimeUnit.MONTH))
+        # 1st Feb
+        mock_dt.now.return_value = datetime(1982, 2, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 1, TimeUnit.MONTH))
+
+        # 28th Feb
+        mock_dt.now.return_value = datetime(1982, 2, 28, 18, 23, 0, 0)
+        self.assertFalse(tools.older_than(last_job_run, 2, TimeUnit.MONTH))
+        # 1st March
+        mock_dt.now.return_value = datetime(1982, 3, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 2, TimeUnit.MONTH))
+
+        # 31th March
+        mock_dt.now.return_value = datetime(1982, 3, 31, 18, 23, 0, 0)
+        self.assertFalse(tools.older_than(last_job_run, 3, TimeUnit.MONTH))
+        # 1st April
+        mock_dt.now.return_value = datetime(1982, 4, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 3, TimeUnit.MONTH))
+
+        # 1st May
+        mock_dt.now.return_value = datetime(1982, 5, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 4, TimeUnit.MONTH))
+
+        # 1st June
+        mock_dt.now.return_value = datetime(1982, 6, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 5, TimeUnit.MONTH))
+
+        # 1st July
+        mock_dt.now.return_value = datetime(1982, 7, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 6, TimeUnit.MONTH))
+
+        # 1st Aug
+        mock_dt.now.return_value = datetime(1982, 8, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 7, TimeUnit.MONTH))
+
+        # 1st Sept
+        mock_dt.now.return_value = datetime(1982, 9, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 8, TimeUnit.MONTH))
+
+        # 1st Oct
+        mock_dt.now.return_value = datetime(1982, 10, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 9, TimeUnit.MONTH))
+
+        # 1st Nov
+        mock_dt.now.return_value = datetime(1982, 11, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 10, TimeUnit.MONTH))
+
+        # 1st Dec
+        mock_dt.now.return_value = datetime(1982, 12, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 11, TimeUnit.MONTH))
+
+        # 1st Jan (next year)
+        mock_dt.now.return_value = datetime(1983, 1, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(last_job_run, 12, TimeUnit.MONTH))
+
+    def test_months_31th(self, mock_dt):
+        # 31th May
         birth = datetime(1982, 5, 31, 18, 23, 0, 0)
+
+        # 1st June
+        mock_dt.now.return_value = datetime(1982, 6, 1, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 1, TimeUnit.MONTH))
+
+        # 30th September
         mock_dt.now.return_value = datetime(1982, 9, 30, 18, 23, 0, 0)
-
-        self.assertFalse(tools.older_than(birth, 4, TimeUnit.MONTH))
-
-    def test_month_31th_plus_ms(self, mock_dt):
-        """Plus one ms"""
-        birth = datetime(1982, 5, 31, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1982, 9, 30, 18, 23, 0, 1)
-
         self.assertTrue(tools.older_than(birth, 4, TimeUnit.MONTH))
+        self.assertFalse(tools.older_than(birth, 5, TimeUnit.MONTH))
 
-    def test_month_next_year(self, mock_dt):
-        """Into next year with 7 months."""
+    def test_months_next_year(self, mock_dt):
+        # 6th August, 1982
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1983, 3, 6, 18, 23, 0, 0)
 
-        self.assertFalse(tools.older_than(birth, 7, TimeUnit.MONTH))
-
-    def test_month_next_year_plus_ms(self, mock_dt):
-        """Into next year with 7 months plus 1 ms."""
-        birth = datetime(1982, 8, 6, 18, 23, 0, 0)
-        mock_dt.now.return_value = datetime(1983, 3, 6, 18, 23, 0, 1)
-
+        # 1st March, 1983
+        mock_dt.now.return_value = datetime(1983, 3, 1, 18, 23, 0, 0)
         self.assertTrue(tools.older_than(birth, 7, TimeUnit.MONTH))
+
+        # 6th March, 1983
+        mock_dt.now.return_value = datetime(1983, 3, 6, 18, 23, 0, 0)
+        self.assertTrue(tools.older_than(birth, 7, TimeUnit.MONTH))
+        self.assertFalse(tools.older_than(birth, 8, TimeUnit.MONTH))
 
 
 class NestedDictUpdate(unittest.TestCase):

--- a/common/tools.py
+++ b/common/tools.py
@@ -19,6 +19,7 @@ import subprocess
 import shlex
 import signal
 import re
+import math
 import errno
 import locale
 import gettext
@@ -765,13 +766,17 @@ def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
     now = datetime.now()
 
     if unit is TimeUnit.HOUR:
-        return dt < now - timedelta(hours=value)
+        # Calculate difference in hours, counting partial hours
+        delta_hours = math.ceil((now - dt).total_seconds() / 3600)
+        return delta_hours >= value
 
     if unit is TimeUnit.DAY:
         return dt.date() <= (now.date() - timedelta(days=value))
 
     if unit is TimeUnit.WEEK:
-        return dt < now - timedelta(weeks=value)
+        # Difference in weeks, counting partial weeks
+        delta_days = (now.date() - dt.date()).days
+        return math.ceil(delta_days / 7) >= value
 
     if unit is TimeUnit.MONTH:
         # Calculate months based on calendar because timedelta do not support

--- a/common/tools.py
+++ b/common/tools.py
@@ -774,25 +774,34 @@ def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
         return dt.date() <= (now.date() - timedelta(days=value))
 
     if unit is TimeUnit.WEEK:
-        # Difference in weeks, counting partial weeks
-        delta_days = (now.date() - dt.date()).days
+        # Difference in calendar weeks (starting monday), counting partial
+        # weeks
+        dt_week = dt.date() - timedelta(days=dt.weekday())
+        now_week = now.date() - timedelta(days=now.weekday())
+        delta_days = (now_week - dt_week).days
         return math.ceil(delta_days / 7) >= value
 
     if unit is TimeUnit.MONTH:
-        # Calculate months based on calendar because timedelta do not support
-        # months.
-        compare_month = (dt.month + value - 1) % 12 + 1
-        compare_year = dt.year + (dt.month + value - 1) // 12
-        # make sure that day exist in the month
-        last_day_dt \
-            = datetime(compare_year, compare_month + 1, 1) - timedelta(days=1)
-        compare_day = min(dt.day, last_day_dt.day)
+        # Difference in calendar month, counting partial months
+        year_diff = now.year - dt.year
+        month_diff = now.month - dt.month
+        delta_months = year_diff * 12 + month_diff
+        # count partial month
+        # delta_months += 1
+        return delta_months >= value
 
-        compare_dt = datetime(
-            compare_year, compare_month, compare_day,
-            now.hour, now.minute, now.microsecond)
+        # compare_month = (dt.month + value - 1) % 12 + 1
+        # compare_year = dt.year + (dt.month + value - 1) // 12
+        # # make sure that day exist in the month
+        # last_day_dt \
+        #     = datetime(compare_year, compare_month + 1, 1) - timedelta(days=1)
+        # compare_day = min(dt.day, last_day_dt.day)
 
-        return now < compare_dt
+        # compare_dt = datetime(
+        #     compare_year, compare_month, compare_day,
+        #     now.hour, now.minute, now.microsecond)
+
+        # return now < compare_dt
 
     # Dev note (buhtz, 2024-09): This code branch already existed in the
     # original code (but silent, without throwing an exception). Even if it may

--- a/common/tools.py
+++ b/common/tools.py
@@ -747,16 +747,17 @@ def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
     """Return ``True`` if ``dt`` is older than ``value`` months, weeks, days or
     hours compared to the current time (`datetime.now()`).
 
-    The resolution used is on microseconds level. Months are calculated based
-    on calendar.
+    The resolution used depends on `unit`. Months are calculated based on
+    calendar.
 
     Args:
-        dt: Timestamp to be compared with on microsecond level.
+        dt: Timestamp to be compared with.
         value: Number of units.
         unit: Specify to treat ``value`` as hours, days, weeks or months.
 
     Return:
         ``True`` if older, otherwise ``False``.
+
     """
     if not isinstance(unit, TimeUnit):
         unit = TimeUnit(unit)
@@ -767,7 +768,7 @@ def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
         return dt < now - timedelta(hours=value)
 
     if unit is TimeUnit.DAY:
-        return dt < now - timedelta(days=value)
+        return dt.date() <= (now.date() - timedelta(days=value))
 
     if unit is TimeUnit.WEEK:
         return dt < now - timedelta(weeks=value)

--- a/common/tools.py
+++ b/common/tools.py
@@ -786,22 +786,7 @@ def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
         year_diff = now.year - dt.year
         month_diff = now.month - dt.month
         delta_months = year_diff * 12 + month_diff
-        # count partial month
-        # delta_months += 1
         return delta_months >= value
-
-        # compare_month = (dt.month + value - 1) % 12 + 1
-        # compare_year = dt.year + (dt.month + value - 1) // 12
-        # # make sure that day exist in the month
-        # last_day_dt \
-        #     = datetime(compare_year, compare_month + 1, 1) - timedelta(days=1)
-        # compare_day = min(dt.day, last_day_dt.day)
-
-        # compare_dt = datetime(
-        #     compare_year, compare_month, compare_day,
-        #     now.hour, now.minute, now.microsecond)
-
-        # return now < compare_dt
 
     # Dev note (buhtz, 2024-09): This code branch already existed in the
     # original code (but silent, without throwing an exception). Even if it may

--- a/common/tools.py
+++ b/common/tools.py
@@ -748,8 +748,7 @@ def older_than(dt: datetime, value: int, unit: TimeUnit) -> bool:
     """Return ``True`` if ``dt`` is older than ``value`` months, weeks, days or
     hours compared to the current time (`datetime.now()`).
 
-    The resolution used depends on `unit`. Months are calculated based on
-    calendar.
+    The resolution used depends on `unit`. Partial units also counted.
 
     Args:
         dt: Timestamp to be compared with.


### PR DESCRIPTION
Behavior when scheduling with 'Repeatedly (anacron)' is now consistent.

This fixes bug #2250 introduced in 1.5.3 (060324e8, #1791) and restores
behavior present in BIT before 1.5.3. Minor bug, no data loss.

Fix #2250
Related #1791
Related 060324e8