### PR TITLE
fix: Allow in BITs root-mode opening URLs in extern browser

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Fixed: Stop waking up monitor when inhibit suspend on backup starts (#714, #1090)
 * Fixed: Avoid shutdown confirmation dialog on Budgie and Cinnamon desktop environments (#788)
 * Fixed: Crash in "Manage profiles" dialog when using "qt6ct" (#2128)
+* Fixed: Allow in BITs root-mode opening URLs in extern browse
 
 Version 1.5.6 (2025-10-05)
 * Fixed: Always use 0 as window ID value when inhibiting suspend via D-Bus power manager (#2084, #2268, #2192)

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -19,6 +19,7 @@
 """
 import os
 import sys
+import pwd
 import re
 import json
 import textwrap
@@ -291,14 +292,59 @@ class MouseButtonEventFilter(QObject):
         return super().eventFilter(receiver, event)
 
 
-def open_url(url: str) -> None:
-    """Open an URL or URI"""
-    QDesktopServices.openUrl(QUrl(url))
+def _determine_root_mode_user() -> str:
+    """Determine the users name who started BIT in root mode
+
+    Usually pkexec is used but some users do use sudo themself.
+    """
+    # Try pkexec
+    uid = os.getenv('PKEXEC_UID', None)
+    if uid:
+        return pwd.getpwuid(uid).pw_name
+
+    # Try sudo
+    sudo_user = os.getenv('SUDO_USER', None)
+    if sudo_user:
+        return sudo_user
+
+    return None
+
+
+def open_url(self, url):
+    # regular user mode
+    if not bitbase.IS_IN_ROOT_MODE:  
+        return QDesktopServices.openUrl(QUrl(url))
+
+    # root mode
+    user_name = _determine_root_mode_user()
+
+    try:
+        subprocess.run(
+            [
+                'runuser',
+                '-u',
+                user_name,
+                '--',
+                'xdg-open',
+                url
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        logger.error(f'Problem while opening "{url}" in as user '
+                     f'"{user_name}" while in root-mode. '
+                     f'Error was: {exc}')
+    except Exception as exc:
+        logger.critical(f'Unknown problem while opening "{url}" in as user '
+                        f'"{user_name}" while in root-mode. '
+                        f'Error was: {exc}')
 
 
 def open_man_page(manpage: str) -> None:
     """Open the manpage in a terminal window."""
-    env=os.environ.copy()
+    env = os.environ.copy()
     env['MANWIDTH'] = '80'
 
     content = ''

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -310,7 +310,7 @@ def _determine_root_mode_user() -> str:
     return None
 
 
-def open_url(self, url):
+def open_url(url):
     # regular user mode
     if not bitbase.IS_IN_ROOT_MODE:  
         return QDesktopServices.openUrl(QUrl(url))

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -300,7 +300,7 @@ def _determine_root_mode_user() -> str:
     # Try pkexec
     uid = os.getenv('PKEXEC_UID', None)
     if uid:
-        return pwd.getpwuid(uid).pw_name
+        return pwd.getpwuid(int(uid)).pw_name
 
     # Try sudo
     sudo_user = os.getenv('SUDO_USER', None)


### PR DESCRIPTION
This fix allows BIT to open URLs (e.g. project website) in extern browser even if BIT itself runs in root-mode.