### PR TITLE
chore: Identify subcomponents in syslog messages

### DIFF
--- a/common/backintime.py
+++ b/common/backintime.py
@@ -110,21 +110,29 @@ def encfs_deprecation_warning():
     fp.touch()
 
 
-def startApp(app_name='backintime'):
+def startApp(bin_name: str) -> config.Config | None:
     """
-    Start the requested command or return config if there was no command
-    in arguments.
+    Start the requested command or return config.
+
+    Command (e.g. 'backup') is specified via command line argument.
+    Without command the current config is returned instead.
 
     Args:
-        app_name (str): string representing the current application
+        bin_name: The binaries name of current application.
 
     Returns:
-        config.Config:  current config if no command was given in arguments
+        Current configuration instance if command is missing.
     """
     parser_agent = cliarguments.ParserAgent(
-        app_name=bitbase.APP_NAME, bin_name=app_name)
+        app_name=bitbase.APP_NAME, bin_name=bin_name)
 
-    logger.openlog()
+    syslog_id_suffix = {
+        bitbase.BINARY_NAME_CLI: 'CLI',
+        bitbase.BINARY_NAME_GUI: 'GUI'
+    }[bin_name]
+
+    print('X'*200)
+    logger.openlog(syslog_id_suffix)
 
     args = cliarguments.parse_arguments(args=None, agent=parser_agent)
 
@@ -170,4 +178,4 @@ def startApp(app_name='backintime'):
 
 
 if __name__ == '__main__':
-    startApp()
+    startApp(bin_name=bitbase.BINARY_NAME_CLI)

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -131,7 +131,6 @@ def startApp(bin_name: str) -> config.Config | None:
         bitbase.BINARY_NAME_GUI: 'GUI'
     }[bin_name]
 
-    print('X'*200)
     logger.openlog(syslog_id_suffix)
 
     args = cliarguments.parse_arguments(args=None, agent=parser_agent)
@@ -154,7 +153,7 @@ def startApp(bin_name: str) -> config.Config | None:
         logger.warning(
             "It looks like you're using 'sudo' to start "
             f"{config.Config.APP_NAME}. This will cause some trouble. "
-            f"Please use either 'sudo -i {app_name}' or 'pkexec {app_name}'.")
+            f"Please use either 'sudo -i {bin_name}' or 'pkexec {bin_name}'.")
 
     encfs_deprecation_warning()
 

--- a/common/logger.py
+++ b/common/logger.py
@@ -30,14 +30,15 @@ _level_names = {
     syslog.LOG_DEBUG: 'DEBUG',
 }
 
+syslog_id_suffix = '<unknown>'
 
-def openlog():
-    """Initialize the BIT logger system (which uses syslog)
-
-    Esp. sets the app name as identifier for the log entries in the syslog.
+def openlog(suffix: str):
+    """Initialize the BIT logger system using syslog.
 
     Attention: Call it in each sub process that uses logging.
     """
+    global syslog_id_suffix
+    syslog_id_suffix = suffix
     syslog.openlog(SYSLOG_IDENTIFIER)
     atexit.register(closelog)
 
@@ -52,10 +53,10 @@ def closelog():
 
 
 def _do_syslog(message: str, level: int) -> str:
-    syslog.syslog(level, '{}{}{}: {}'.format(
+    syslog.syslog(level, '{}: {}{}{}'.format(
+        _level_names[level],
         f'{USER} ' if DEBUG else '',
         SYSLOG_MESSAGE_PREFIX,
-        _level_names[level],
         message
     ))
 
@@ -117,4 +118,4 @@ def _debugHeader(parent, traceDepth):
 
     fclass = f'{parent.__class__.__name__}.' if parent else ''
 
-    return f'[{fmodule}/{fname}:{line} {fclass}{func}]'
+    return f'[{syslog_id_suffix}::{fmodule}/{fname}:{line} {fclass}{func}]'

--- a/common/plugins/usercallbackplugin.py
+++ b/common/plugins/usercallbackplugin.py
@@ -50,7 +50,12 @@ class UserCallbackPlugin(pluginmanager.Plugin):
         in the first line of the script file.
     """
     def __init__(self):
-        logger.openlog()
+        # Dev note (2025-11, buhtz): Aryoda wrote that line one year ago in
+        # commit 9618d03. Not sure if there really is a need for it.
+        # In context of my syslog sub-identfiers, I need to remove that.
+        # My assumption is that at this point the syslog.openlog() was called.
+        # All this problems will vanish if #2286 is completed.
+        # logger.openlog('USERCALLBACKUP')
         return
 
     def init(self, snapshots):

--- a/common/qt_probing.py
+++ b/common/qt_probing.py
@@ -10,7 +10,7 @@ import sys
 import resource
 import logger
 
-logger.openlog()
+logger.openlog('QT-PROBING')
 
 # from tools import isRoot
 

--- a/common/schedule.py
+++ b/common/schedule.py
@@ -46,7 +46,7 @@ def _determine_crontab_command() -> str | None:
             return cmd
 
     # syslog is not yet initialized
-    logger.openlog()
+    logger.openlog('pre-init.schedule')
     msg = 'Command ' + ' and '.join(to_check_commands) + ' not found.'
     logger.warning(msg)
 

--- a/common/test/generic.py
+++ b/common/test/generic.py
@@ -143,7 +143,7 @@ class TestCase(unittest.TestCase):
 
         # Initialize logging
         logger.APP_NAME = 'BIT_unittest'
-        logger.openlog()
+        logger.openlog('UNITTEST.generic')
 
         super(TestCase, self).__init__(methodName)
 

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -694,7 +694,7 @@ def _init_basic_config(data_dir_prefix='DATADIR', data_dir_suffix=''):
 
     # Initialize logging
     logger.APP_NAME = 'BIT_unittest'
-    logger.openlog()
+    logger.openlog('UNITTEST')
     logger.DEBUG = '-v' in sys.argv
 
     # Path to config file (in "common/test/config")

--- a/qt/app.py
+++ b/qt/app.py
@@ -2445,7 +2445,6 @@ if __name__ == '__main__':
     cfg.PLUGIN_MANAGER.load(cfg=cfg)
     cfg.PLUGIN_MANAGER.appStart()
 
-    # logger.openlog('QT-FOO')
     qapp = qttools.create_qapplication(bitbase.APP_NAME)
     translator = qttools.initiate_translator(cfg.language())
     qapp.installTranslator(translator)

--- a/qt/app.py
+++ b/qt/app.py
@@ -2445,7 +2445,7 @@ if __name__ == '__main__':
     cfg.PLUGIN_MANAGER.load(cfg=cfg)
     cfg.PLUGIN_MANAGER.appStart()
 
-    logger.openlog()
+    # logger.openlog('QT-FOO')
     qapp = qttools.create_qapplication(bitbase.APP_NAME)
     translator = qttools.initiate_translator(cfg.language())
     qapp.installTranslator(translator)

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -288,7 +288,7 @@ class QtSysTrayIcon:
 
 if __name__ == '__main__':
 
-    logger.openlog()
+    logger.openlog('SYSTRAY')
 
     # HACK: Minimal arg parsing to enable debug-level logging
     if '--debug' in sys.argv:


### PR DESCRIPTION
Syslog messages contain an additional identifier (e.g. GUI, CLI, SYSTRAY) to make it clear which BIT component send it.

A workaround before #2286 is completed.