### PR TITLE
docs(manual): Add 'Every Year' schedule option documentation

### DIFF
--- a/doc/manual/src/manage-profiles.md
+++ b/doc/manual/src/manage-profiles.md
@@ -197,6 +197,7 @@ schedules. You can use `crontab -l` to view them or `crontab -e` to edit.
 - **Every Month**: start a new backup on a configurable day/time every
   month. If the computer is not running at the configured time there will be no
   new backup for the month.
+  - **Every Year**: start a new backup on a configurable day/month/time every year. If the computer is not running at the configured time there will be no new backup for the year.
 
 !!! note
     For hourly schedules (every hour, every x hours, and custom hours),


### PR DESCRIPTION
## Description

This PR addresses issue #2303 by adding the missing "Every Year" scheduling option to the user manual.

## Changes Made

- Added documentation for the "Every Year" schedule option in `doc/manual/src/manage-profiles.md`
- The new entry follows the same format as other schedule options (Every Week, Every Month)
- Describes the yearly backup scheduling behavior and notes that backups won't occur if the computer is off at the scheduled time

## Related Issue

Fixes #2303 - Schedule "Every year" missing in manual