### PR TITLE
chore(gui): No more use of "Gtk+" style in root mode

### DIFF
--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -548,11 +548,6 @@ def create_qapplication(app_name=bitbase.APP_NAME) -> QApplication:
     except NameError:
         pass
 
-    if (Version(QT_VERSION_STR) >= Version('5.6')
-            and hasattr(Qt, 'AA_EnableHighDpiScaling')):
-
-        QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
-
     qapp = QApplication(sys.argv)
 
     _show_qt_debug_info(qapp)
@@ -581,12 +576,6 @@ def create_qapplication(app_name=bitbase.APP_NAME) -> QApplication:
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.warning('Could not set App ID (required for Wayland App icon '
                        f'and more). Reason: {exc}')
-
-    if (bitbase.IS_IN_ROOT_MODE
-            and qapp.style().objectName().lower() == 'windows'
-            and 'GTK+' in QStyleFactory.keys()):
-
-        qapp.setStyle('GTK+')
 
     # With "--debug" arg show the QT QPA platform name in the main window's
     # title

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -38,7 +38,6 @@ from PyQt6.QtCore import (QEvent,
                           QLocale,
                           Qt,
                           QObject,
-                          QT_VERSION_STR,
                           QTranslator,
                           QUrl)
 from PyQt6.QtWidgets import (QApplication,
@@ -48,7 +47,6 @@ from PyQt6.QtWidgets import (QApplication,
                              QStyleFactory,
                              QSystemTrayIcon,
                              QWidget)
-from packaging.version import Version
 from qttools_path import register_backintime_path
 register_backintime_path('common')
 import tools  # noqa: E402


### PR DESCRIPTION
Rewind an 11-year old workaround commit using "Gtk+" style in root mode to prevent an "ugly GUI".

Original bug report: https://bugs.launchpad.net/backintime/+bug/1418447
Original commit: 831051c

I see no good or strong reason to keep it. Even the screenshot from the original bug report illustrating the "ugly GUI" is not really ugly.

This might influence the issue about missing toolbar icons in root mode. #1836