### PR TITLE
feat(gui): Systray icon can be forced to Dark or Light

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,8 +2,6 @@ Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
 * Changed: New dependency (runtime GUI) to "python3-pyqt6.qtsvg" for loading SVG icons (#1961)
-* Changed: New dependency (build) "librsvg2-bin" containing "rsvg-convert"
-* Changed: New dependency (build) "optipng"
 * Changed: Disable scheduling widget in GUI if cron/crontab is missing (#2245, @m4rcu5 Marcus von Dam)
 * Changed: "Repeatedly (anacron)" scheduling behave consistent. Reversed minor bug introduced with 060324e (#1791) in 1.5.3 (#2250)
 * Changed: Stricter permissions (600) for fileinfo.bz2 and takesnapshot.log.bz2 (#2235)
@@ -28,7 +26,8 @@ Version 1.6.0-dev (development of upcoming release)
 * Changed: Generating new SSH key will use default key type provided by ssh-keygen (#2194)
 * Changed: Open man page and changelog in a text dialog
 * Changed: Minimum PyLint version increased to 4.0.0
-* Added: Application logo (#1961, Gregory Deseck @gregorydk)
+* Added: Systray icon can be forced to Dark or Light
+* Added: Application logo and symbolic systray icon (#1961, Gregory Deseck @gregorydk)
 * Added: CLI command "status" summarize last run and backup status (#1018, Samuel Moore @s4moore)
 * Added: Root mode indicator in status bar (#1964)
 * Added: Option to not using an explicit SSH key file. In consequence this supports extern key agents and SSH clients own configuration (#1146)

--- a/common/config.py
+++ b/common/config.py
@@ -462,6 +462,13 @@ class Config(configfile.ConfigFileWithProfiles):
         value = self.hashCollision() + 1
         self.setIntValue('global.hash_collision', value)
 
+    def systray(self) -> str:
+        #?Color of systray icon.;auto,dark,light
+        return self.strValue('global.systray', 'auto')
+
+    def setSystray(self, value: str) -> None:
+        self.setStrValue('global.systray', value)
+
     def language(self) -> str:
         #?Language code (ISO 639) used to translate the user interface.
         #?If empty the operating systems current local is used. If 'en' the

--- a/common/config.py
+++ b/common/config.py
@@ -466,7 +466,7 @@ class Config(configfile.ConfigFileWithProfiles):
         #?Color of systray icon.;auto,dark,light
         return self.strValue('global.systray', 'auto')
 
-    def setSystray(self, value: str) -> None:
+    def set_systray(self, value: str) -> None:
         self.setStrValue('global.systray', value)
 
     def language(self) -> str:

--- a/qt/app.py
+++ b/qt/app.py
@@ -757,6 +757,7 @@ class MainWindow(QMainWindow):
         ]
         action_group = QActionGroup(self)
         action_group.setExclusive(True)
+        action_group.triggered.connect(self._slot_systray_icon)
 
         val = self.config.systray()
 
@@ -771,7 +772,6 @@ class MainWindow(QMainWindow):
             menu.addAction(act)
 
         return menu
-
 
     def _button_styles(self):
         return (
@@ -788,6 +788,10 @@ class MainWindow(QMainWindow):
                 _('Text beside icon'),
                 Qt.ToolButtonStyle.ToolButtonTextBesideIcon),
         )
+
+    def _slot_systray_icon(self, action: QAction):
+        print(f'{action.data()=}')
+        self.config.set_systray(action.data())
 
     def _set_toolbar_button_style(self, toolbar, style):
         """Set toolbar button style and store the selected index."""

--- a/qt/app.py
+++ b/qt/app.py
@@ -49,6 +49,7 @@ from PyQt6.QtGui import (QAction,
                          QActionGroup,
                          QDesktopServices,
                          QFileSystemModel,
+                         QIcon,
                          QShortcut)
 from PyQt6.QtWidgets import (QAbstractItemView,
                              QApplication,
@@ -735,11 +736,42 @@ class MainWindow(QMainWindow):
         restore.setToolTipsVisible(True)
 
         # Menu: "Back In Time" -> "Systray Icon"
-        ico_dark_light = QtSysTrayIcon.get_dark_light_split_icon()
-        systray_ico_menu = QMenu(_('Systray Icon'), self)
-        systray_ico_menu.setIcon(ico_dark_light)
+        submenu_systray = self._create_submenu_systray_icon()
+        self.act_group_systray = submenu_systray.actions()[0].actionGroup()
         self.menuBar().actions()[0].menu().insertMenu(
-            self.act_shutdown, systray_ico_menu)
+            self.act_shutdown, submenu_systray)
+
+    def _create_submenu_systray_icon(self) -> QMenu:
+        menu = QMenu(_('Systray Icon'), self)
+        import icon
+        menu.setIcon(icon.SETTINGS)
+
+        ico_group_data = [
+            # (_('Automatic'), QIcon.fromTheme('system-search'), 'auto'),
+            (_('Automatic'),
+             QIcon.fromTheme('system-run',
+                             QIcon.fromTheme('system-search')),
+             'auto'),
+            (_('Light icon'), QtSysTrayIcon.get_light_icon(), 'light'),
+            (_('Dark icon'), QtSysTrayIcon.get_dark_icon(), 'dark'),
+        ]
+        action_group = QActionGroup(self)
+        action_group.setExclusive(True)
+
+        val = self.config.systray()
+
+        for txt_label, ico, data in ico_group_data:
+            act = QAction(ico, txt_label, checkable=True)
+            act.setData(data)
+
+            if val == data:
+                act.setChecked(True)
+
+            action_group.addAction(act)
+            menu.addAction(act)
+
+        return menu
+
 
     def _button_styles(self):
         return (

--- a/qt/app.py
+++ b/qt/app.py
@@ -95,6 +95,7 @@ from bitwidgets import ProfileCombo
 from shutdowndlg import get_shutdown_confirmation
 from statusbar import StatusBar
 from placeswidget import PlacesWidget
+from qtsystrayicon import QtSysTrayIcon
 
 
 class MainWindow(QMainWindow):
@@ -732,6 +733,13 @@ class MainWindow(QMainWindow):
         restore = self.act_restore_menu.menu()
         restore.insertSeparator(self.act_restore_parent)
         restore.setToolTipsVisible(True)
+
+        # Menu: "Back In Time" -> "Systray Icon"
+        ico_dark_light = QtSysTrayIcon.get_dark_light_split_icon()
+        systray_ico_menu = QMenu(_('Systray Icon'), self)
+        systray_ico_menu.setIcon(ico_dark_light)
+        self.menuBar().actions()[0].menu().insertMenu(
+            self.act_shutdown, systray_ico_menu)
 
     def _button_styles(self):
         return (

--- a/qt/app.py
+++ b/qt/app.py
@@ -790,8 +790,8 @@ class MainWindow(QMainWindow):
         )
 
     def _slot_systray_icon(self, action: QAction):
-        print(f'{action.data()=}')
         self.config.set_systray(action.data())
+        self.config.save()
 
     def _set_toolbar_button_style(self, toolbar, style):
         """Set toolbar button style and store the selected index."""

--- a/qt/icon.py
+++ b/qt/icon.py
@@ -97,7 +97,8 @@ EXIT                = QIcon.fromTheme('gtk-close',
                       QIcon.fromTheme('application-exit'))
 
 # Help menu
-HELP                = QIcon.fromTheme('help-contents')
+HELP                = QIcon.fromTheme('help-browser',
+                                      QIcon.fromTheme('help-contents'))
 WEBSITE             = QIcon.fromTheme('go-home')
 CHANGELOG           = QIcon.fromTheme('format-justify-fill')
 FAQ                 = QIcon.fromTheme('help-faq',

--- a/qt/icons/scalable/apps/backintime-symbolic.svg
+++ b/qt/icons/scalable/apps/backintime-symbolic.svg
@@ -8,6 +8,7 @@ This file is part of the program "Back In Time" which is released under GNU
 General Public License v2 (GPLv2). See LICENSES directory or go to
 <https://spdx.org/licenses/GPL-2.0-or-later.html>
 -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
 <path d="M4.1 1a2.5 2.5 0 0 0-1.768.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 4.1 1m7.8 0a2.5 2.5 0 0 0-1.767.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 11.9 1M8 10a2.5 2.5 0 0 0-2.5 2.5A2.5 2.5 0 0 0 8 15c1.379 0 2.5-1.121 2.5-2.5S9.379 10 8 10" style="fill-opacity:.5"/>
 <path d="M4.102 1.998A1.504 1.504 0 0 0 3.04 4.562L6.5 8.024V12.5c0 .832.668 1.5 1.5 1.5s1.5-.668 1.5-1.5V8.023l3.46-3.46a1.504 1.504 0 0 0 0-2.125 1.5 1.5 0 0 0-2.12 0L8 5.28 5.16 2.438a1.5 1.5 0 0 0-1.058-.44"/>
 </svg>

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -37,10 +37,10 @@ import snapshots
 import progress
 import logviewdialog
 import encfstools
-from PyQt6.QtCore import QTimer
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import QSystemTrayIcon, QMenu, QProgressBar, QWidget
-from PyQt6.QtGui import QIcon, QRegion
-
+from PyQt6.QtGui import QColor, QIcon, QPainter, QPixmap, QRegion
+from PyQt6.QtSvg import QSvgRenderer
 
 class QtSysTrayIcon:
     """Application instance for the Back In Time systray icon"""
@@ -298,23 +298,6 @@ class QtSysTrayIcon:
             QIcon: A QIcon object.
         """
 
-        """
-pix = QPixmap(size, size)
-pix.fill(QColor(128, 128, 128))  # grauer Hintergrund
-
-p = QPainter(pix)
-renderer = QSvgRenderer(bytearray(svg_str, encoding='utf-8'))
-renderer.render(p)
-
-p.setCompositionMode(QPainter.CompositionMode_SourceIn)
-p.fillRect(0, 0, size//2, size, Qt.GlobalColor.black)
-p.fillRect(size//2, 0, size//2, size, Qt.GlobalColor.white)
-p.end()
-
-icon = QIcon(pix)
-
-        """
-
         svg_clipping = '''
           <svg xmlns="http://www.w3.org/2000/svg"
             width="16" height="16" viewBox="0 0 16 16">
@@ -336,7 +319,36 @@ icon = QIcon(pix)
           </svg>
         '''.format(ORIGINAL_PATH=QtSysTrayIcon.ICON_PATH_ONLY)
 
-        return qttools.create_qicon_from_svg_source(svg_clipping)
+        size = 16
+        pix = QPixmap(size, size)
+        pix.fill(QColor(128, 128, 128))  # grauer Hintergrund
+
+        p = QPainter(pix)
+        svg_str = QtSysTrayIcon.ICON_PART_A + QtSysTrayIcon.ICON_PART_B
+        renderer = QSvgRenderer(bytearray(svg_str, encoding='utf-8'))
+        renderer.render(p)
+        p.end()
+
+        # linke Hälfte schwarz, rechte Hälfte weiß als Alpha-Maske
+        mask = QPixmap(size, size)
+        mask.fill(Qt.GlobalColor.transparent)
+        p = QPainter(mask)
+        p.fillRect(0, 0, size//2, size, Qt.GlobalColor.black)
+        p.fillRect(size//2, 0, size//2, size, Qt.GlobalColor.white)
+        p.end()
+
+        # fertiges Icon
+        final_pix = QPixmap(size, size)
+        final_pix.fill(Qt.GlobalColor.transparent)
+        p = QPainter(final_pix)
+        p.drawPixmap(0, 0, pix)
+        p.setCompositionMode(QPainter.CompositionMode.CompositionMode_DestinationIn)
+        p.drawPixmap(0, 0, mask)
+        p.end()
+
+        return QIcon(pix)
+
+        # return qttools.create_qicon_from_svg_source(svg_clipping)
 
 
 if __name__ == '__main__':

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -46,9 +46,11 @@ class QtSysTrayIcon:
     """Application instance for the Back In Time systray icon"""
 
     # pylint: disable-next=line-too-long
+    ICON_PATH_ONLY = '<path d="M4.1 1a2.5 2.5 0 0 0-1.768.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 4.1 1m7.8 0a2.5 2.5 0 0 0-1.767.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 11.9 1M8 10a2.5 2.5 0 0 0-2.5 2.5A2.5 2.5 0 0 0 8 15c1.379 0 2.5-1.121 2.5-2.5S9.379 10 8 10" style="fill-opacity:.5"/>\n<path d="M4.102 1.998A1.504 1.504 0 0 0 3.04 4.562L6.5 8.024V12.5c0 .832.668 1.5 1.5 1.5s1.5-.668 1.5-1.5V8.023l3.46-3.46a1.504 1.504 0 0 0 0-2.125 1.5 1.5 0 0 0-2.12 0L8 5.28 5.16 2.438a1.5 1.5 0 0 0-1.058-.44"/>'
+    # pylint: disable-next=line-too-long
     ICON_PART_A = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"'
     # pylint: disable-next=line-too-long
-    ICON_PART_B = '>\n<path d="M4.1 1a2.5 2.5 0 0 0-1.768.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 4.1 1m7.8 0a2.5 2.5 0 0 0-1.767.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 11.9 1M8 10a2.5 2.5 0 0 0-2.5 2.5A2.5 2.5 0 0 0 8 15c1.379 0 2.5-1.121 2.5-2.5S9.379 10 8 10" style="fill-opacity:.5"/>\n<path d="M4.102 1.998A1.504 1.504 0 0 0 3.04 4.562L6.5 8.024V12.5c0 .832.668 1.5 1.5 1.5s1.5-.668 1.5-1.5V8.023l3.46-3.46a1.504 1.504 0 0 0 0-2.125 1.5 1.5 0 0 0-2.12 0L8 5.28 5.16 2.438a1.5 1.5 0 0 0-1.058-.44"/>\n</svg>'
+    ICON_PART_B = '>\n' + ICON_PATH_ONLY + '\n</svg>'
 
     def __init__(self):
 
@@ -128,21 +130,23 @@ class QtSysTrayIcon:
         # Logo color depending on dark/light mode
         color = 'white' if qttools.in_dark_mode(self.qapp) else 'black'
 
-        svg_fn = None
+        # svg_fn = None
 
-        # QIcon is not capable of reading from a byte stream.
-        # This workaround write the SVG/XML-string to a temporary in-RAM file
-        # before QIcon reads it back.
-        with tempfile.NamedTemporaryFile(suffix='.svg', mode='w', delete=False
-                                         ) as handle:
-            handle.write(
-                self.ICON_PART_A + f' fill="{color}"' + self.ICON_PART_B)
+        # # QIcon is not capable of reading from a byte stream.
+        # # This workaround write the SVG/XML-string to a temporary in-RAM file
+        # # before QIcon reads it back.
+        # with tempfile.NamedTemporaryFile(suffix='.svg', mode='w', delete=False
+        #                                  ) as handle:
+        #     handle.write(
+        #         self.ICON_PART_A + f' fill="{color}"' + self.ICON_PART_B)
 
-            svg_fn = handle.name
+        #     svg_fn = handle.name
 
-        atexit.register(Path(svg_fn).unlink)
+        # atexit.register(Path(svg_fn).unlink)
 
-        return QSystemTrayIcon(QIcon(svg_fn))
+        svg_content = self.ICON_PART_A + f' fill="{color}"' + self.ICON_PART_B
+        qicon = qttools.create_qicon_from_svg_source(svg_content)
+        return QSystemTrayIcon(qicon)
 
     def _create_progress_bar(self) -> QProgressBar:
         bar = QProgressBar()
@@ -281,6 +285,58 @@ class QtSysTrayIcon:
         self.btnPause.setEnabled(False)
         self.btnResume.setEnabled(False)
         self.snapshots.setTakeSnapshotMessage(0, 'Backup terminated')
+
+    @staticmethod
+    def get_dark_light_split_icon():
+        """Generate the symbolic icon by splitting it into dark and light halves.
+
+        The SVG is rendered twice, clipping each half separately. Left half is
+        filled black and right is white. A neutral background is applied to
+        ensure visibility across different UI themes.
+
+        Returns:
+            QIcon: A QIcon object.
+        """
+
+        """
+pix = QPixmap(size, size)
+pix.fill(QColor(128, 128, 128))  # grauer Hintergrund
+
+p = QPainter(pix)
+renderer = QSvgRenderer(bytearray(svg_str, encoding='utf-8'))
+renderer.render(p)
+
+p.setCompositionMode(QPainter.CompositionMode_SourceIn)
+p.fillRect(0, 0, size//2, size, Qt.GlobalColor.black)
+p.fillRect(size//2, 0, size//2, size, Qt.GlobalColor.white)
+p.end()
+
+icon = QIcon(pix)
+
+        """
+
+        svg_clipping = '''
+          <svg xmlns="http://www.w3.org/2000/svg"
+            width="16" height="16" viewBox="0 0 16 16">
+
+          <rect x="0" y="0" width="16" height="16" fill="#d0d0d0"/>
+
+          <defs>
+            <clipPath id="clip_dark">
+              [<polygon points="0,0 8,0 8,16 0,16"/>]</clipPath>
+            <clipPath id="clip_light">
+              [<polygon points="8,0 16,0 16,16 8,16"/>]</clipPath>
+
+            <g id="icon_shape">{ORIGINAL_PATH}</g>
+          </defs>
+
+          <use href="#icon_shape" clip-path="url(#clip_dark)" fill="black"/>
+          <use href="#icon_shape" clip-path="url(#clip_light)" fill="white"/>
+
+          </svg>
+        '''.format(ORIGINAL_PATH=QtSysTrayIcon.ICON_PATH_ONLY)
+
+        return qttools.create_qicon_from_svg_source(svg_clipping)
 
 
 if __name__ == '__main__':

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -123,6 +123,14 @@ class QtSysTrayIcon:
 
     def _create_status_icon(self) -> QSystemTrayIcon:
         # Logo color depending on dark/light mode
+        mode = self.config.systray()
+
+        if mode == 'light':
+            return QSystemTrayIcon(self.get_light_icon())
+
+        if mode == 'dark':
+            return QSystemTrayIcon(self.get_dark_icon())
+
         if qttools.in_dark_mode(self.qapp):
             return QSystemTrayIcon(self.get_light_icon())
 

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -12,13 +12,10 @@
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Separate application managing the systray icon"""
 import sys
-import atexit
 import os
-import tempfile
 import subprocess
 import signal
 import textwrap
-from pathlib import Path
 
 # TODO Is this really required? If the client is not configured for X11
 #      it may use Wayland or something else...
@@ -37,10 +34,9 @@ import snapshots
 import progress
 import logviewdialog
 import encfstools
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import QTimer
 from PyQt6.QtWidgets import QSystemTrayIcon, QMenu, QProgressBar, QWidget
-from PyQt6.QtGui import QColor, QIcon, QPainter, QPixmap, QRegion
-from PyQt6.QtSvg import QSvgRenderer
+from PyQt6.QtGui import QIcon, QRegion
 
 class QtSysTrayIcon:
     """Application instance for the Back In Time systray icon"""
@@ -49,7 +45,6 @@ class QtSysTrayIcon:
     ICON_PATH_ONLY = '<path d="M4.1 1a2.5 2.5 0 0 0-1.768.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 4.1 1m7.8 0a2.5 2.5 0 0 0-1.767.73 2.504 2.504 0 0 0 0 3.54 2.506 2.506 0 0 0 3.535 0 2.504 2.504 0 0 0 0-3.54A2.5 2.5 0 0 0 11.9 1M8 10a2.5 2.5 0 0 0-2.5 2.5A2.5 2.5 0 0 0 8 15c1.379 0 2.5-1.121 2.5-2.5S9.379 10 8 10" style="fill-opacity:.5"/>\n<path d="M4.102 1.998A1.504 1.504 0 0 0 3.04 4.562L6.5 8.024V12.5c0 .832.668 1.5 1.5 1.5s1.5-.668 1.5-1.5V8.023l3.46-3.46a1.504 1.504 0 0 0 0-2.125 1.5 1.5 0 0 0-2.12 0L8 5.28 5.16 2.438a1.5 1.5 0 0 0-1.058-.44"/>'
     # pylint: disable-next=line-too-long
     ICON_PART_A = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"'
-    # pylint: disable-next=line-too-long
     ICON_PART_B = '>\n' + ICON_PATH_ONLY + '\n</svg>'
 
     def __init__(self):
@@ -128,25 +123,11 @@ class QtSysTrayIcon:
 
     def _create_status_icon(self) -> QSystemTrayIcon:
         # Logo color depending on dark/light mode
-        color = 'white' if qttools.in_dark_mode(self.qapp) else 'black'
+        if qttools.in_dark_mode(self.qapp):
+            return QSystemTrayIcon(self.get_light_icon())
 
-        # svg_fn = None
+        return QSystemTrayIcon(self.get_dark_icon())
 
-        # # QIcon is not capable of reading from a byte stream.
-        # # This workaround write the SVG/XML-string to a temporary in-RAM file
-        # # before QIcon reads it back.
-        # with tempfile.NamedTemporaryFile(suffix='.svg', mode='w', delete=False
-        #                                  ) as handle:
-        #     handle.write(
-        #         self.ICON_PART_A + f' fill="{color}"' + self.ICON_PART_B)
-
-        #     svg_fn = handle.name
-
-        # atexit.register(Path(svg_fn).unlink)
-
-        svg_content = self.ICON_PART_A + f' fill="{color}"' + self.ICON_PART_B
-        qicon = qttools.create_qicon_from_svg_source(svg_content)
-        return QSystemTrayIcon(qicon)
 
     def _create_progress_bar(self) -> QProgressBar:
         bar = QProgressBar()
@@ -286,69 +267,20 @@ class QtSysTrayIcon:
         self.btnResume.setEnabled(False)
         self.snapshots.setTakeSnapshotMessage(0, 'Backup terminated')
 
+    @classmethod
+    def _get_icon_filled(cls, color: str) -> QIcon:
+        """Generate the dark symbolic icon"""
+        svg_content = cls.ICON_PART_A + f' fill="{color}"' + cls.ICON_PART_B
+        qicon = qttools.create_qicon_from_svg_source(svg_content)
+        return qicon
+
     @staticmethod
-    def get_dark_light_split_icon():
-        """Generate the symbolic icon by splitting it into dark and light halves.
+    def get_dark_icon() -> QIcon:
+        return QtSysTrayIcon._get_icon_filled('black')
 
-        The SVG is rendered twice, clipping each half separately. Left half is
-        filled black and right is white. A neutral background is applied to
-        ensure visibility across different UI themes.
-
-        Returns:
-            QIcon: A QIcon object.
-        """
-
-        svg_clipping = '''
-          <svg xmlns="http://www.w3.org/2000/svg"
-            width="16" height="16" viewBox="0 0 16 16">
-
-          <rect x="0" y="0" width="16" height="16" fill="#d0d0d0"/>
-
-          <defs>
-            <clipPath id="clip_dark">
-              [<polygon points="0,0 8,0 8,16 0,16"/>]</clipPath>
-            <clipPath id="clip_light">
-              [<polygon points="8,0 16,0 16,16 8,16"/>]</clipPath>
-
-            <g id="icon_shape">{ORIGINAL_PATH}</g>
-          </defs>
-
-          <use href="#icon_shape" clip-path="url(#clip_dark)" fill="black"/>
-          <use href="#icon_shape" clip-path="url(#clip_light)" fill="white"/>
-
-          </svg>
-        '''.format(ORIGINAL_PATH=QtSysTrayIcon.ICON_PATH_ONLY)
-
-        size = 16
-        pix = QPixmap(size, size)
-        pix.fill(QColor(128, 128, 128))  # grauer Hintergrund
-
-        p = QPainter(pix)
-        svg_str = QtSysTrayIcon.ICON_PART_A + QtSysTrayIcon.ICON_PART_B
-        renderer = QSvgRenderer(bytearray(svg_str, encoding='utf-8'))
-        renderer.render(p)
-        p.end()
-
-        # linke Hälfte schwarz, rechte Hälfte weiß als Alpha-Maske
-        mask = QPixmap(size, size)
-        mask.fill(Qt.GlobalColor.transparent)
-        p = QPainter(mask)
-        p.fillRect(0, 0, size//2, size, Qt.GlobalColor.black)
-        p.fillRect(size//2, 0, size//2, size, Qt.GlobalColor.white)
-        p.end()
-
-        # fertiges Icon
-        final_pix = QPixmap(size, size)
-        final_pix.fill(Qt.GlobalColor.transparent)
-        p = QPainter(final_pix)
-        p.drawPixmap(0, 0, pix)
-        p.setCompositionMode(QPainter.CompositionMode.CompositionMode_DestinationIn)
-        p.drawPixmap(0, 0, mask)
-        p.end()
-
-        return QIcon(pix)
-
-        # return qttools.create_qicon_from_svg_source(svg_clipping)
+    @staticmethod
+    def get_light_icon() -> QIcon:
+        return QtSysTrayIcon._get_icon_filled('white')
 
 
 if __name__ == '__main__':

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -20,12 +20,15 @@
 # pylint: disable=wrong-import-position,wrong-import-order
 import os
 import sys
+import atexit
 import pwd
 import re
 import json
 import textwrap
 import subprocess
+import tempfile
 from typing import Union, Iterable, Callable
+from pathlib import Path
 from contextlib import contextmanager
 from textdlg import TextDialog
 from PyQt6.QtGui import (QDesktopServices,
@@ -276,6 +279,26 @@ def create_info_label(
     label.setLayout(layout)
 
     return label
+
+
+def create_qicon_from_svg_source(svg_source: str) -> QIcon:
+    """Create a QIcon instance based on SVG/XML source.
+
+    QIcon is not capable of reading from a byte stream.
+    This workaround write the SVG/XML-string to a temporary in-RAM file
+    before QIcon reads it back.
+    """
+
+    svg_fn = None
+
+    with tempfile.NamedTemporaryFile(suffix='.svg', mode='w', delete=False
+                                        ) as handle:
+        handle.write(svg_source)
+        svg_fn = handle.name
+
+    atexit.register(Path(svg_fn).unlink)
+
+    return QIcon(svg_fn)
 
 
 def custom_sort_order(header, loop, new_column, new_order):

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -292,7 +292,7 @@ def create_qicon_from_svg_source(svg_source: str) -> QIcon:
     svg_fn = None
 
     with tempfile.NamedTemporaryFile(suffix='.svg', mode='w', delete=False
-                                        ) as handle:
+                                     ) as handle:
         handle.write(svg_source)
         svg_fn = handle.name
 


### PR DESCRIPTION
Usually the fill color of the symbolic systray icon is determined based on the theme used by the desktop environment. Because this can lead to false combination of colors under several circumstances, the user now is able, to force a dark or white fill color.

The setting is located in the main menu bar as submenu "Systray icon" in the "Back In Time" menu.

![x](https://github.com/user-attachments/assets/02ffc156-4f68-4439-b16d-7baddf065f6f)

The plan is to move the setting into the application settings dialog until we create that dialog.

This PR is a follow up of PR #2293 (899db58) and PR #2278 (31970ae).