### PR TITLE
fix: escape curly braces in translation strings

### DIFF
--- a/qt/manageprofiles/tab_expert_options.py
+++ b/qt/manageprofiles/tab_expert_options.py
@@ -293,7 +293,7 @@ class ExpertOptionsTab(QDialog):
         tab_layout.addWidget(self._cb_one_filesystem)
 
         # additional rsync options
-        tooltip = _('Options must be quoted e.g. {example}.').format(
+        tooltip = _('Options must be quoted e.g. {{example}}.').format(
             example='--exclude-from="/path/to/my exclude file"')
 
         self._txt_rsync_options = QLineEdit(self)


### PR DESCRIPTION
**fix(qt): escape curly braces in translation strings to prevent KeyError**
Clicking "Manage profiles" → "Expert options" triggers a `KeyError` in `tab_expert_options.py` (line 296)
**Error:**
  File "./backintime/qt/manageprofiles/tab_expert_options.py", line 296, in __init__
    tooltip = _('Options must be quoted e.g. {example}.').format(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: '--exclude-from="/path/to/my exclude file"'"
Python 3.12.10
