### PR TITLE
Fix crash when comparing two backups using the diff feature

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,7 +51,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file
 * Removed: SSH Cipher configuration in Manage profiles dialog (#2143)
-* Fixed: Crash in Compare snapshots dialog (aka Snapshots dialog) (#2327 Michael Neese @madic-creates)
+* Fixed: Crash in Compare snapshots dialog (aka Snapshots dialog) whhen comparing/diff two backups (#2327 Michael Neese @madic-creates)
 * Fixed: Enforce UTF-8 encoding in takesnapshot.log and some other files (#2298)
 * Fixed: Attribute error about missing 'cbCopyUnsafeLinks' (#2279)
 * Fixed: Use LC_ALL instead of LC_TIME to set the locale

--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file
 * Removed: SSH Cipher configuration in Manage profiles dialog (#2143)
+* Fixed: Crash in Compare snapshots dialog (aka Snapshots dialog) (#2327 Michael Neese @madic-creates)
 * Fixed: Enforce UTF-8 encoding in takesnapshot.log and some other files (#2298)
 * Fixed: Attribute error about missing 'cbCopyUnsafeLinks' (#2279)
 * Fixed: Use LC_ALL instead of LC_TIME to set the locale

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -373,7 +373,7 @@ class SnapshotsDialog(QDialog):
         # prevent backup data from being accidentally overwritten
         # by create a temporary local copy and only open that one
         if not isinstance(self.sid, snapshots.RootSnapshot):
-            full_path = self.parent.tmpCopy(full_path, sid)
+            full_path = self.parent._create_temporary_copy(full_path, sid)
 
         QDesktopServices.openUrl(QUrl(full_path))
 

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -400,9 +400,9 @@ class SnapshotsDialog(QDialog):
         # prevent backup data from being accidentally overwritten
         # by create a temporary local copy and only open that one
         if not isinstance(sid1, snapshots.RootSnapshot):
-            path1 = self.parent.tmpCopy(path1, sid1)
+            path1 = self.parent._create_temporary_copy(path1, sid1)
         if not isinstance(sid2, snapshots.RootSnapshot):
-            path2 = self.parent.tmpCopy(path2, sid2)
+            path2 = self.parent._create_temporary_copy(path2, sid2)
 
         params = diffParams
         params = params.replace('%1', '"%s"' % path1)


### PR DESCRIPTION
Issue seems to be caused by calls to the renamed method `tmpCopy`, which was changed to `_create_temporary_copy` but not updated in `snapshotsdialog.py`

---

Bug introduced with 5506854 and released in 1.5.5 and 1.5.6.