### PR TITLE
fix: Proper error message regarding pkexec problems

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file
 * Removed: SSH Cipher configuration in Manage profiles dialog (#2143)
+* Fixed: Show proper message to users when root mode fails due to inactive or missing polkit agent
 * Fixed: Enforce UTF-8 encoding in takesnapshot.log and some other files (#2298)
 * Fixed: Attribute error about missing 'cbCopyUnsafeLinks' (#2279)
 * Fixed: Use LC_ALL instead of LC_TIME to set the locale

--- a/CHANGES
+++ b/CHANGES
@@ -51,7 +51,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file
 * Removed: SSH Cipher configuration in Manage profiles dialog (#2143)
-* Fixed: Show proper message to users when root mode fails due to inactive or missing polkit agent
+* Fixed: Show proper message to users when root mode fails due to inactive or missing polkit agent (#2328, Derek Veit @DerekVeit)
 * Fixed: Enforce UTF-8 encoding in takesnapshot.log and some other files (#2298)
 * Fixed: Attribute error about missing 'cbCopyUnsafeLinks' (#2279)
 * Fixed: Use LC_ALL instead of LC_TIME to set the locale

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Changed: New dependency "bash" for root mode starter script "backintime-qt_polkit" (#2328)
 * Changed: New dependency (runtime GUI) to "python3-pyqt6.qtsvg" for loading SVG icons (#1961)
 * Changed: Disable scheduling widget in GUI if cron/crontab is missing (#2245, @m4rcu5 Marcus von Dam)
 * Changed: "Repeatedly (anacron)" scheduling behave consistent. Reversed minor bug introduced with 060324e (#1791) in 1.5.3 (#2250)

--- a/CHANGES
+++ b/CHANGES
@@ -55,7 +55,7 @@ Version 1.6.0-dev (development of upcoming release)
 * Fixed: Show proper message to users when root mode fails due to inactive or missing polkit agent (#2328, Derek Veit @DerekVeit)
 * Fixed: Crash in Compare snapshots dialog (aka Snapshots dialog) when comparing/diff two backups (#2327 Michael Neese @madic-creates)
 * Fixed: File view and Compare Backups dialog now open the clicked item correctly even with multiple selection or single-click-to-open enabled (#2330)
-* Fixed: Crash in Compare snapshots dialog (aka Snapshots dialog) whhen comparing/diff two backups (#2327 Michael Neese @madic-creates)
+* Fixed: Crash in Compare snapshots dialog (aka Snapshots dialog) when comparing/diff two backups (#2327 Michael Neese @madic-creates)
 * Fixed: Enforce UTF-8 encoding in takesnapshot.log and some other files (#2298)
 * Fixed: Attribute error about missing 'cbCopyUnsafeLinks' (#2279)
 * Fixed: Use LC_ALL instead of LC_TIME to set the locale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,10 +136,11 @@ distribution.
 * Runtime dependencies for the GUI
 
   - `x11-utils`
-  - `python3-pyqt6` (not from _PyPi_ via `pip`)
+  - `python3-pyqt6` (Do not use the version from _PyPi_ via `pip`)
   - `python3-dbus.mainloop.pyqt6` (not available from _PyPi_ via `pip`)
   - `python3-pyqt6.qtsvg`
   - `pkexec`
+  - `bash` (Used by root mode starter script `qt/backintime-qt_polkit`)
   - `polkitd`
   - `qttranslations6-l10n`
   - `qtwayland6` (if Wayland is used as display server instead of X11)

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -51,8 +51,7 @@ class General(unittest.TestCase):
             self.assertIn(key, result['backintime'], key)
 
         # 2nd level "host-setup"
-        minimal_keys = ['platform', 'system', 'display-system', 'locale',
-                        'PATH', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS']
+        minimal_keys = ['platform', 'system', 'locale', 'PATH']
         for key in minimal_keys:
             self.assertIn(key, result['host-setup'], key)
 
@@ -60,7 +59,8 @@ class General(unittest.TestCase):
         self.assertIn('python', result['python-setup'], 'python')
 
         # 2nd level "external-programs"
-        minimal_keys = ['rsync', 'shell']
+        minimal_keys = [
+            'rsync', 'shell', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS']
         for key in minimal_keys:
             self.assertIn(key, result['external-programs'], key)
 

--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -27,10 +27,10 @@ pkexec --disable-internal-agent "${PREFIX}/usr/bin/backintime-qt" "$@" 2> >(tee 
 
 STATUS=$?
 
-if [[ ${STATUS} -eq 127 ]]; then
+if [[ ${STATUS} -ne 0 ]]; then
     ERR=$(< /tmp/backintime-error)
 
-    xmessage -nearmouse "Back In Time: Can't start in root mode.
+    xmessage -nearmouse "Back In Time: Problems running in root mode
     Error: ${ERR}
     Return code: ${STATUS}"
 

--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # SPDX-FileCopyrightText: © 2009 Back In Time team
 #
 # SPDX-License-Identifier: CC0-1.0
@@ -10,7 +10,8 @@
 # and <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 if [ "x$XDG_SESSION_TYPE" = "xwayland" ]; then
     # PREFIX="env QT_QPA_PLATFORM=wayland-egl XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
-    # Empty prefix to use the default Qt platform plugin (normally xcb) to fix #836 and #1350
+    # Empty prefix to use the default Qt platform plugin (normally xcb)
+    # to fix #836 and #1350
     PREFIX=""
 else
     # X11
@@ -19,13 +20,19 @@ fi
 
 # Catch error message of pkexec if there is one. Might happen if no polkit
 # agent is active, e.g. when using IceWM.
-ERR=$(pkexec --disable-internal-agent $PREFIX "/usr/bin/backintime-qt" "$@" 2>&1)
+# Details:
+#    https://github.com/bit-team/backintime/pull/2328#issuecomment-3702705290
+# Error message (stderr) of pkexec is written to /tmp/backintime-error
+pkexec --disable-internal-agent "${PREFIX}/usr/bin/backintime-qt" "$@" 2> >(tee /tmp/backintime-error >&2)
 
 STATUS=$?
 
-if [ -n "$ERR" ]; then
+if [[ ${STATUS} -eq 127 ]]; then
+    ERR=$(< /tmp/backintime-error)
+
     xmessage -nearmouse "Back In Time: Can't start in root mode.
-    Error: $ERR
-    Return code: $STATUS"
-    exit $STATUS
+    Error: ${ERR}
+    Return code: ${STATUS}"
+
+    exit "${STATUS}"
 fi

--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -17,4 +17,15 @@ else
     PREFIX=""
 fi
 
-pkexec --disable-internal-agent $PREFIX "/usr/bin/backintime-qt" "$@"
+# Catch error message of pkexec if there is one. Might happen if no polkit
+# agent is active, e.g. when using IceWM.
+ERR=$(pkexec --disable-internal-agent $PREFIX "/usr/bin/backintime-qt" "$@" 2>&1)
+
+STATUS=$?
+
+if [ -n "$ERR" ]; then
+    xmessage -nearmouse "Back In Time: Can't start in root mode.
+    Error: $ERR
+    Return code: $STATUS"
+    exit $STATUS
+fi

--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -27,7 +27,7 @@ pkexec --disable-internal-agent "${PREFIX}/usr/bin/backintime-qt" "$@" 2> >(tee 
 
 STATUS=$?
 
-if [[ ${STATUS} -ne 0 ]]; then
+if (( STATUS )); then
     ERR=$(< /tmp/backintime-error)
 
     xmessage -nearmouse "Back In Time: Problems running in root mode


### PR DESCRIPTION
Using "Back In Time (root mode)" in desktop environments or window managers without an active polkit agent, now gives a proper message to the user via xmessage.

In the past this failed silently leaving the user without information.

Related #2262