### PR TITLE
chore: Add Flatpak runtime repo to exclude suggestions

### DIFF
--- a/common/snapshotlog.py
+++ b/common/snapshotlog.py
@@ -243,8 +243,8 @@ class SnapshotLog:
             date (datetime.datetime):   current date
         """
         if snapshots.NewSnapshot(self.config).saveToContinue:
-            msg = "Last snapshot didn't finish but can be continued.\n\n"
-            msg += "======== continue snapshot (profile %s): %s ========\n"
+            msg = "Last backup did not complete but can be resumed.\n\n"
+            msg += "======== Continue backup (profile %s): %s ========\n"
 
         else:
             if os.path.exists(self.logFileName):
@@ -252,7 +252,7 @@ class SnapshotLog:
                     self.logFile.close()
                     self.logFile = None
                 os.remove(self.logFileName)
-            msg = "========== Take snapshot (profile %s): %s ==========\n"
+            msg = "========== Create backup (profile %s): %s ==========\n"
 
         self.append(msg % (self.profile, date.strftime('%c')), 1)
 

--- a/common/test/test_snapshotlog.py
+++ b/common/test/test_snapshotlog.py
@@ -115,7 +115,7 @@ class Log(generic.SnapshotsTestCase):
             self.assertRegex(
                 f.read(),
                 re.compile(
-                    r'''========== Take snapshot \(profile .*\): .* ==========
+                    r'''========== Create backup \(profile .*\): .* ==========
 
 ''', re.MULTILINE))
 
@@ -134,9 +134,9 @@ class Log(generic.SnapshotsTestCase):
         with open(self.logFile, 'rt') as f:
             self.assertRegex(f.read(), re.compile(r'''foo
 bar
-Last snapshot didn't finish but can be continued.
+Last backup did not complete but can be resumed.
 
-======== continue snapshot \(profile .*\): .* ========
+======== Continue backup \(profile .*\): .* ========
 
 ''', re.MULTILINE))
 

--- a/qt/manageprofiles/excludesuggestions.py
+++ b/qt/manageprofiles/excludesuggestions.py
@@ -72,6 +72,11 @@ EXCLUDE_SUGGESTIONS = {
             _('Package cache for Debian(-based) GNU/Linux distributions'),
             bitbase.IS_IN_ROOT_MODE
         ],
+        [
+            '~/.local/share/flatpak',
+            _('Flatpak app and runtime repository'),
+            True
+        ],
     ),
     _('System runtime directories'): (
         [


### PR DESCRIPTION
- Add directory ~/.local/share/flatpak to exclude suggestions and enable it by default in new profiles.
- Slightly modifies some strings in the logs.

Related to #2332