### PR TITLE
fix: Prevent duplicate udev triggers for LUKS-encrypted drives

### DIFF
--- a/qt/serviceHelper.py
+++ b/qt/serviceHelper.py
@@ -241,12 +241,18 @@ class UdevRules(dbus.service.Object):
         # create su command
         sucmd = f"{self.su} - '{user}' -c '{cmd}'"
 
-        # create Udev rule
-        rule = 'ACTION=="add|change", ENV{ID_FS_UUID}=="' \
-            + uuid \
-            + '", RUN+="' \
-            + sucmd \
-            + '"\n'
+        # create Udev rules
+        # Two separate rules to handle both regular drives and LUKS-encrypted
+        # volumes properly (see issue #2340):
+        # 1. "add" event: For regular (non-encrypted) drives when connected
+        # 2. "change" event with DM_ACTIVATION=1: For LUKS-encrypted volumes
+        #    when the encrypted filesystem is unlocked. This prevents multiple
+        #    triggers during the LUKS unlock process.
+        rule = (
+            f'ACTION=="add", ENV{{ID_FS_UUID}}=="{uuid}", RUN+="{sucmd}"\n'
+            f'ACTION=="change", ENV{{ID_FS_UUID}}=="{uuid}", '
+            f'ENV{{DM_ACTIVATION}}=="1", RUN+="{sucmd}"\n'
+        )
 
         print(f'{sucmd=} {rule=}')
 


### PR DESCRIPTION
## Summary

- Fixes duplicate BackInTime launches when connecting LUKS-encrypted USB drives
- Splits the single udev rule into two separate rules:
  - `ACTION=="add"` for regular drives
  - `ACTION=="change"` with `ENV{DM_ACTIVATION}=="1"` for LUKS volumes

## Problem

When connecting a LUKS-encrypted USB backup drive, BackInTime was being triggered multiple times:

1. First trigger on device detection
2. Second trigger on LUKS unlock (this is the correct one)
3. Sometimes a third trigger on disconnection

This caused error messages about BiT already running, confusing users.

## Solution

By checking for `DM_ACTIVATION=1` on change events, we ensure BackInTime only triggers when the encrypted filesystem is actually unlocked and available, not during intermediate device mapper events.

## Test plan

- [ ] Connect a regular (non-encrypted) USB drive configured for udev triggering - should trigger once on connection
- [ ] Connect a LUKS-encrypted USB drive configured for udev triggering - should trigger once after entering passphrase
- [ ] Disconnect the drive - should not trigger a backup

Fixes #2340