### PR TITLE
fix: Temporarily disable status command due to unresolved problems

### DIFF
--- a/common/cliarguments.py
+++ b/common/cliarguments.py
@@ -724,8 +724,10 @@ class ParserAgent:
                 self._reusable_parsers['profile'],
                 self._reusable_parsers['common'],
             ],
-            help='summarize backup status for all profiles or a specific one',
-            description='Display last run and status of last backup')
+            help='[TEMPORARILY DISABLED] summarize backup status',
+            description='TEMPORARILY DISABLED due to unresolved problems '
+                        '(see issue #2321). Will be re-enabled in a future '
+                        'release.')
 
         parser.set_defaults(func=self._cmd_func_dict[name])
 

--- a/common/clicommands.py
+++ b/common/clicommands.py
@@ -32,7 +32,7 @@ import mount
 from exceptions import MountException
 from applicationinstance import ApplicationInstance
 from shutdownagent import ShutdownAgent
-from status import BackupStatus
+# BackupStatus import removed - status command temporarily disabled (see #2321)
 
 
 def _deprecation_msg(cmd_flag: str, replacement: str) -> str:
@@ -652,15 +652,15 @@ def status(args: argparse.Namespace):
         args (argparse.Namespace):
                         Parsed command-line arguments.
     """
-    cfg = _get_config(args)
-
-    status_object = BackupStatus(
-        cfg=cfg,
-        all_status=False if args.profile else True,
-        format_json=args.json
+    # Temporarily disabled due to unresolved problems with remote filesystem
+    # mounting/unmounting. See issue #2321 for details.
+    # The feature will be re-enabled once the underlying issues are resolved.
+    logger.error(
+        'The "status" command is temporarily disabled due to unresolved '
+        'problems (see https://github.com/bit-team/backintime/issues/2321). '
+        'It will be re-enabled in a future release once the issues are fixed.'
     )
-
-    print(status_object.get_status())
+    sys.exit(bitbase.RETURN_ERR)
 
 
 def unmount(args):


### PR DESCRIPTION
## Summary

- Temporarily disables the `--status` command due to unresolved problems with remote filesystem mounting/unmounting
- Command now displays an error message directing users to the tracking issue
- Help text updated to indicate the command is temporarily disabled

## Problem

The `--status` command (introduced in #2019) causes issues with remote filesystem handling that need to be resolved before the 1.6.0 release. Rather than risk instability, this PR disables the feature temporarily.

Related issues:
- #2296 - FileNotFoundError during unmount
- #2019 - Original status feature PR

## Changes

1. **`common/clicommands.py`**: 
   - `status()` function now shows an error message and exits
   - Removed unused `BackupStatus` import

2. **`common/cliarguments.py`**:
   - Updated help text to indicate `[TEMPORARILY DISABLED]`
   - Updated description to explain the situation

## User Experience

When users run `backintime status`, they will see:
```
ERROR: The "status" command is temporarily disabled due to unresolved 
problems (see https://github.com/bit-team/backintime/issues/2321). 
It will be re-enabled in a future release once the issues are fixed.
```

Fixes #2321