### PR TITLE
chore(gui): Improve error message for missing icon theme

### DIFF
--- a/qt/icon.py
+++ b/qt/icon.py
@@ -50,8 +50,10 @@ for theme in themes_to_try:
 if QIcon.fromTheme(ICON_NAME_TO_CHECK).isNull():
     logger.error(
         f'Icon theme missing or not supported. Icon "{ICON_NAME_TO_CHECK}" '
-        'not found. An icon theme should be installed. '
-        'For example: tango-icon-theme, oxygen-icon-theme'
+        'not found. Please install a complete icon theme. '
+        'For Debian/Ubuntu with Gnome: "apt install adwaita-icon-theme-legacy". '
+        'For other systems: oxygen-icon-theme, breeze-icon-theme, or '
+        'tango-icon-theme.'
     )
 
 # Dev note: Please prefer choosing icons from the freedesktop.org spec


### PR DESCRIPTION
## Summary

Improves the error message shown when no icon theme is found, providing specific guidance for users affected by the Adwaita icon theme split in Debian 13/Ubuntu with Gnome.

## Problem

On Debian 13 (Trixie) with Gnome, the Adwaita icon theme package was split:
- `adwaita-icon-theme` now only contains symbolic icons
- Legacy icons (like `document-save`) are in `adwaita-icon-theme-legacy`

This causes BackInTime to show missing icons with a generic error message that doesn't help users fix the issue.

## Solution

Updated the error message to provide specific installation commands:

**Before:**
```
Icon theme missing or not supported. Icon "document-save" not found. 
An icon theme should be installed. For example: tango-icon-theme, oxygen-icon-theme
```

**After:**
```
Icon theme missing or not supported. Icon "document-save" not found. 
Please install a complete icon theme. 
For Debian/Ubuntu with Gnome: "apt install adwaita-icon-theme-legacy". 
For other systems: oxygen-icon-theme, breeze-icon-theme, or tango-icon-theme.
```

## Note

This is a documentation/UX improvement only. A more comprehensive fix would involve bundling fallback icons or detecting the specific environment, but that requires more significant changes.

Relates to #2289