### PR TITLE
fix: Restore config dialog crash

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,7 +52,8 @@ Version 1.6.0-dev (development of upcoming release)
 * Removed: UI translation in Bosnian, Thai, and Occidental/Interlingue (#1914)
 * Removed: LICENSE file in favor of LICENSES directory and LICENSES.md file
 * Removed: SSH Cipher configuration in Manage profiles dialog (#2143)
-# Fixed: Consider symbolic icons as fallbacks (#2345, #2289)
+* Fixed: Crash in config restore dialog
+* Fixed: Consider symbolic icons as fallbacks (#2345, #2289)
 * Fixed: Warn users and prevent backups to exFAT volumes due to lack of hardlink support (#2337)
 * Fixed: Show proper message to users when root mode fails due to inactive or missing polkit agent (#2328, Derek Veit @DerekVeit)
 * Fixed: Crash in Compare snapshots dialog (aka Snapshots dialog) when comparing/diff two backups (#2327 Michael Neese @madic-creates)

--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -18,21 +18,33 @@ else
     PREFIX=""
 fi
 
+ERR_FILE=$(mktemp)
+
 # Catch error message of pkexec if there is one. Might happen if no polkit
 # agent is active, e.g. when using IceWM.
 # Details:
 #    https://github.com/bit-team/backintime/pull/2328#issuecomment-3702705290
 # Error message (stderr) of pkexec is written to /tmp/backintime-error
-pkexec --disable-internal-agent $PREFIX "/usr/bin/backintime-qt" "$@" 2> >(tee /tmp/backintime-error >&2)
+pkexec --disable-internal-agent $PREFIX "/usr/bin/backintime-qt" "$@" 2> >(tee "$ERR_FILE" >&2)
 
 STATUS=$?
 
 if (( STATUS )); then
-    ERR=$(< /tmp/backintime-error)
+    ERR=$(< "$ERR_FILE")
+    rm -f "$ERR_FILE"
 
-    xmessage -nearmouse "Back In Time: Problems running in root mode
-    Error: ${ERR}
-    Return code: ${STATUS}"
+    # Use zentiy or xmessage
+    if command -v zenity >/dev/null 2>&1; then
+        zenity --error \
+            --title="Back In Time - Problems running in root mode" \
+            --text="Error: ${ERR}\nReturn code: ${STATUS}"
+    else
+        xmessage -nearmouse "Back In Time: Problems running in root mode
+        Error: ${ERR}
+        Return code: ${STATUS}"
+    fi
 
     exit "${STATUS}"
 fi
+
+

--- a/qt/restoreconfigdialog.py
+++ b/qt/restoreconfigdialog.py
@@ -66,6 +66,8 @@ class RestoreConfigDialog(QDialog):
     def __init__(self, config: Config):
         super().__init__()
 
+        self.config = config
+
         # pylint: disable-next=import-outside-toplevel
         import icon  # noqa: PLC0415
         self.setWindowIcon(icon.SETTINGS_DIALOG)


### PR DESCRIPTION
- Fix crash in restore config dialog. Introduced in version 1.5.4.
- Minor mods of root mode starter script. Follow-up of #2328