### PR TITLE
fix!: Disable EncFS for new profiles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,9 @@
 Back In Time
 
 Version 1.6.0-dev (development of upcoming release)
+* Changed: **Breaking** Disable EncFS for creation of new backup profiles (#2315, #1734)
+* Changed: **Breaking** A "snapshot" now is a "backup" (#1929)
+* Changed: **Breaking** Deprecated and removed make targets: "test", "test-v", "unittest", "unittest-v"
 * Changed: Manpage backintime-config moved from section 1 to 5 (#1773)
 * Changed: New dependency "bash" for root mode starter script "backintime-qt_polkit" (#2328)
 * Changed: New dependency (runtime GUI) to "python3-pyqt6.qtsvg" for loading SVG icons (#1961)
@@ -8,8 +11,6 @@ Version 1.6.0-dev (development of upcoming release)
 * Changed: Expert Options replaced two checkboxes with single widget to configure symlink copying behavior (#1652)
 * Changed: "Repeatedly (anacron)" scheduling behave consistent. Reversed minor bug introduced with 060324e (#1791) in 1.5.3 (#2250)
 * Changed: Stricter permissions (600) for fileinfo.bz2 and takesnapshot.log.bz2 (#2235)
-* Changed: **Breaking** A "snapshot" now is a "backup" (#1929)
-* Changed: **Breaking** Deprecated and removed make targets: "test", "test-v", "unittest", "unittest-v"
 * Changed: Unlocking ssh-agent use "force" instead of "prefer" for SSH_ASKPASS_REQUIRE (#2170) (@daviewales)
 * Changed: Stop passing window ID when inhibiting suspend via D-Bus power manager (#2084)
 * Changed: Reorder DBUS service provider list for suspend mode inhibition (#2084)

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -89,23 +89,23 @@ def encfs_deprecation_warning():
         xdg_state = pathlib.Path.home() / '.local' / 'state'
     fp = xdg_state / 'backintime.encfs-warning.timestamp'
 
-    # ensure existence
-    if not fp.exists():
+    if fp.exists():
+        # Calculate age of that file
+        delta = datetime.now() - datetime.fromtimestamp(fp.stat().st_mtime)
+
+        # Don't warn if to young
+        if delta.days < 30:
+            return
+
+    else:
+        # ensure existence
         fp.parent.mkdir(parents=True, exist_ok=True)
-        fp.touch()
-
-    # Calculate age of that file
-    delta = datetime.now() - datetime.fromtimestamp(fp.stat().st_mtime)
-
-    # Don't warn if to young
-    if delta.days < 30:
-        return
 
     logger.error(
         'EncFS encrypted profiles are no longer supported in Back In Time. '
         'Existing profiles can be used. New ones can not be created. EncFS '
         'support will be completely removed in a future release (expected '
-        'around 2027). For details read: {bitbase.URL_ENCRYPT_TRANSITION}'
+        f'around 2027). For details read: {bitbase.URL_ENCRYPT_TRANSITION}'
     )
 
     # refresh timestamp

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -101,10 +101,12 @@ def encfs_deprecation_warning():
     if delta.days < 30:
         return
 
-    logger.warning('EncFS encrypted profiles are deprecated in Back In Time. '
-                   'Removal is schedule for minor release 1.7 in year 2026. '
-                   'For details and alternatives '
-                   f'read: {bitbase.URL_ENCRYPT_TRANSITION}')
+    logger.error(
+        'EncFS encrypted profiles are no longer supported in Back In Time. '
+        'Existing profiles can be used. New ones can not be created. EncFS '
+        'support will be completely removed in a future release (expected '
+        'around 2027). For details read: {bitbase.URL_ENCRYPT_TRANSITION}'
+    )
 
     # refresh timestamp
     fp.touch()

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -166,4 +166,4 @@ IS_IN_ROOT_MODE = os.geteuid() == 0
 # and clarity. This constant is the currently desired stage of intensity. The
 # last shown intensity is stored in the state data file. If they don't fit, the
 # message is displayed.
-ENCFS_MSG_STAGE = 2
+ENCFS_MSG_STAGE = 3

--- a/common/bitlicense.py
+++ b/common/bitlicense.py
@@ -57,6 +57,11 @@ def _determine_licenses_dir() -> str | None:
             if fp.is_dir():
                 return fp
 
+    # it might be a source repo
+    fp = Path.cwd().parent / 'LICENSES'
+    if fp.is_dir():
+        return fp
+
     return None
 
 

--- a/common/config.py
+++ b/common/config.py
@@ -235,25 +235,25 @@ class Config(configfile.ConfigFileWithProfiles):
                     # ),
                     'local': (
                         None, _('Local'), False, False),
+                    'local_gocryptfs': (
+                        gocryptfstools.GocryptfsMount,
+                        _('Local encrypted') + ' (via gocryptfs)',
+                        _('Encryption'),
+                        False
+                    ),
                     'ssh': (
                         sshtools.SSH, _('SSH'), _('SSH private key'), False),
                     'local_encfs': (
                         encfstools.EncFS_mount,
-                        _('Local encrypted') + ' (EncFS)',
+                        'DEPRECATED - Local encrypted (via EncFS)',
                         _('Encryption'),
                         False
                     ),
                     'ssh_encfs': (
                         encfstools.EncFS_SSH,
-                        _('SSH encrypted'),
+                        'DEPRECATED - SSH encrypted (via EncFS)',
                         _('SSH private key'),
                         _('Encryption')
-                    ),
-                    'local_gocryptfs':(
-                        gocryptfstools.GocryptfsMount,
-                        _('Local encrypted') + ' (gocryptfs)',
-                        _('Encryption'),
-                        False
                     ),
         }
 
@@ -426,9 +426,9 @@ class Config(configfile.ConfigFileWithProfiles):
 
         self.setProfileStrValue('snapshots.path', value, profile_id)
 
-    def is_mode_encrypted(self, profile_id=None):
-        mode = self.snapshotsMode(profile_id)
-        return mode in ('local_encfs', 'ssh_encfs')
+    # def is_mode_encrypted(self, profile_id=None):
+    #     mode = self.snapshotsMode(profile_id)
+    #     return mode in ('local_encfs', 'ssh_encfs')
 
     def snapshotsMode(self, profile_id=None):
         #? Use mode (or backend) for this snapshot. Look at 'man backintime'

--- a/qt/app.py
+++ b/qt/app.py
@@ -1085,16 +1085,16 @@ class MainWindow(QMainWindow):
         else:
             self.places.set_sorting(sorting)
 
-        # EncFS deprecation warning (see #1734)
-        current_mode = self.config.snapshotsMode(profile_id)
-        if current_mode in ('local_encfs', 'ssh_encfs'):
-            # Show the profile specific warning dialog only once per profile
-            # and only if the global warning was shown before.
-            if (state_data.msg_encfs_global == bitbase.ENCFS_MSG_STAGE
-                    and profile_state.msg_encfs < bitbase.ENCFS_MSG_STAGE):
-                profile_state.msg_encfs = bitbase.ENCFS_MSG_STAGE
-                dlg = encfsmsgbox.EncfsCreateWarning(self)
-                dlg.exec()
+        # # EncFS deprecation warning (see #1734)
+        # current_mode = self.config.snapshotsMode(profile_id)
+        # if current_mode in ('local_encfs', 'ssh_encfs'):
+        #     # Show the profile specific warning dialog only once per profile
+        #     # and only if the global warning was shown before.
+        #     if (state_data.msg_encfs_global == bitbase.ENCFS_MSG_STAGE
+        #             and profile_state.msg_encfs < bitbase.ENCFS_MSG_STAGE):
+        #         profile_state.msg_encfs = bitbase.ENCFS_MSG_STAGE
+        #         dlg = encfsmsgbox.EncfsCreateWarning(self)
+        #         dlg.exec()
 
     def comboProfileChanged(self, _index):
         if self.disableProfileChanged:

--- a/qt/encfsmsgbox.py
+++ b/qt/encfsmsgbox.py
@@ -19,7 +19,7 @@ class _EncfsWarningBase(QMessageBox):
     """
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, parent, text, informative_text, button_label = None):
+    def __init__(self, parent, text, informative_text, button_label=None):
         super().__init__(parent)
 
         self.setWindowTitle(_('Warning'))
@@ -56,8 +56,8 @@ class _EncfsWarningBase(QMessageBox):
 #         informative_text = _('Support for EncFS is being discontinued due '
 #                              'to security vulnerabilities.')
 #         informative_text = informative_text + ' ' + _(
-#             'For more details, including potential alternatives, please refer '
-#             'to this {whitepaper}.').format(
+#             'For more details, including potential alternatives, please '
+#             'refer to this {whitepaper}.').format(
 #                 whitepaper=whitepaper)
 
 #         super().__init__(parent, text, informative_text)

--- a/qt/encfsmsgbox.py
+++ b/qt/encfsmsgbox.py
@@ -19,7 +19,7 @@ class _EncfsWarningBase(QMessageBox):
     """
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, parent, text, informative_text):
+    def __init__(self, parent, text, informative_text, button_label = None):
         super().__init__(parent)
 
         self.setWindowTitle(_('Warning'))
@@ -33,29 +33,34 @@ class _EncfsWarningBase(QMessageBox):
                 lambda url: QToolTip.showText(
                     QCursor.pos(), url.replace('https://', '')))
 
+        if button_label:
+            self.setStandardButtons(QMessageBox.StandardButton.Ok)
+            ok_button = self.button(QMessageBox.StandardButton.Ok)
+            ok_button.setText(button_label)
 
-class EncfsCreateWarning(_EncfsWarningBase):
-    """Warning box when using EncFS encrypting while creating a new profile
-    or modify an existing one.
-    """
-    # pylint: disable=too-few-public-methods
 
-    def __init__(self, parent):
-        text = _('EncFS profile creation will be removed in the next minor '
-                 'release (1.7), scheduled for 2026.')
-        text = text + ' ' + _('It is not recommended to use that '
-                              'mode for a profile furthermore.')
-        whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
-            + _('whitepaper') + '</a>'
+# class EncfsCreateWarning(_EncfsWarningBase):
+#     """Warning box when using EncFS encrypting while creating a new profile
+#     or modify an existing one.
+#     """
+#     # pylint: disable=too-few-public-methods
 
-        informative_text = _('Support for EncFS is being discontinued due '
-                             'to security vulnerabilities.')
-        informative_text = informative_text + ' ' + _(
-            'For more details, including potential alternatives, please refer '
-            'to this {whitepaper}.').format(
-                whitepaper=whitepaper)
+#     def __init__(self, parent):
+#         text = _('EncFS profile creation will be removed in the next minor '
+#                  'release (1.7), scheduled for 2026.')
+#         text = text + ' ' + _('It is not recommended to use that '
+#                               'mode for a profile furthermore.')
+#         whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
+#             + _('whitepaper') + '</a>'
 
-        super().__init__(parent, text, informative_text)
+#         informative_text = _('Support for EncFS is being discontinued due '
+#                              'to security vulnerabilities.')
+#         informative_text = informative_text + ' ' + _(
+#             'For more details, including potential alternatives, please refer '
+#             'to this {whitepaper}.').format(
+#                 whitepaper=whitepaper)
+
+#         super().__init__(parent, text, informative_text)
 
 
 class EncfsExistsWarning(_EncfsWarningBase):
@@ -64,40 +69,33 @@ class EncfsExistsWarning(_EncfsWarningBase):
     # pylint: disable=too-few-public-methods
 
     def __init__(self, parent, profiles):
-        # DevNote: Code looks ugly because we need to take the needs of
-        # translators into account. Also the limitations of Qt's RichText
-        # feature need to be considered.
-        text = ' '.join([
-            _('EncFS profile creation will be removed in the next minor '
-              'release (1.7), scheduled for 2026.'),
-            _('It is not recommended to use that mode for a '
-              'profile furthermore.')
-        ])
+
+        whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
+            + 'whitepaper' + '</a>'
+
+        text = (
+            '<p><span style="color: red;"><strong>Encrypted profiles using '
+            'EncFS are no longer supported.</strong></span></p>'
+            '<p>EncFS is considered insecure and receives no further '
+            'updates.</p>'
+            '<p>Creation of new EncFS backup profiles is not possible. '
+            'Existing EncFS profiles are still displayed and supported for '
+            'now, but EncFS support will be <strong>completely removed'
+            '</strong> in a future release (expected around 2027).</p>'
+            f'For more information, see the {whitepaper}. This dialog is '
+            'available at any time via the help menu.'
+        )
 
         profiles = '<ul>' \
             + ''.join(f'<li>{profile}</li>' for profile in profiles) \
             + '</ul>'
 
-        whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
-            + _('whitepaper') + '</a>'
-
         info_paragraphs = (
-            _('The following profile(s) use encryption with EncFS:'),
+            'The following profile(s) use encryption with EncFS:',
             profiles,
-            ' '.join([
-                _('Support for EncFS is being discontinued due '
-                  'to security vulnerabilities.'),
-                _('A replacement is planned, but it cannot be guaranteed that '
-                  'it will arrive on time.')]),
-            _('Users are invited to join this discussion. Updated details '
-              'on the next steps are available in this {whitepaper}.').format(
-                  whitepaper=whitepaper),
-            _('This message will not be shown again. This dialog is '
-              'available at any time via the help menu.'),
-            _('Your Back In Time Team')
         )
 
         informative_text = ''.join(
             [f'<p>{par}</p>' for par in info_paragraphs])
 
-        super().__init__(parent, text, informative_text)
+        super().__init__(parent, text, informative_text, 'Got it')

--- a/qt/manageprofiles/__init__.py
+++ b/qt/manageprofiles/__init__.py
@@ -353,9 +353,9 @@ class SettingsDialog(QDialog):
 
         That slot is connected to a signal in the `GeneralTab`.
         """
-        self._tab_general.handle_combo_modes_changed()
-
         active_mode = self._tab_general.get_active_snapshots_mode()
+
+        self._tab_general.handle_combo_modes_changed()
 
         self._tab_exclude.mode = active_mode
         self._tab_exclude.update_exclude_items()

--- a/qt/manageprofiles/combobox.py
+++ b/qt/manageprofiles/combobox.py
@@ -84,10 +84,24 @@ class BitComboBox(QComboBox):
         idx = self._idx_by_data(data)
         self.model().item(idx).setEnabled(enable)
 
+    def disable_by_data(self, data: Any):
+        """Disable an entry based on its underlying data."""
+        self.enable_by_data(data, False)
+
+    def hide_by_data(self, data: Any, hide: bool = True):
+        """Hide an entry."""
+        idx = self._idx_by_data(data)
+        self.view().setRowHidden(idx, hide)
+
+    def unhide_by_data(self, data: Any):
+        """Hide an entry."""
+        self.hide_by_data(data, False)
+
     def select_by_data(self, data: Any):
         """Select an entry in the combo box by its underlying data.
 
-        Raise: ???
+        Args:
+            data: The data to select.
         """
         self.setCurrentIndex(self._idx_by_data(data))
 

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -628,7 +628,7 @@ class GeneralTab(QDialog):
         # encfs deprecation warning (see #1734, #1735)
 
         whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">'
-        whitepaper = whitepaper + _('whitepaper') + '</a>'
+        whitepaper = whitepaper + 'whitepaper' + '</a>'
 
         txt = [
             '<strong>Encrypted profiles using EncFS are no longer '

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -629,7 +629,7 @@ class GeneralTab(QDialog):
         txt = [
             '<strong>Encrypted profiles using EncFS are no longer '
             'supported.</strong>',
-            'New EncFS backup profiles can no longer be created. '
+            'New EncFS backup profiles can not be created anymore. '
             'Existing EncFS profiles are still displayed and '
             'supported for now, but EncFS support will be <strong>'
             'completely removed</strong> in a future release '

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -15,7 +15,6 @@ import os
 from pathlib import Path
 from typing import Any
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QCursor, QColor
 from PyQt6.QtWidgets import (QCheckBox,
                              QDialog,
                              QGridLayout,
@@ -24,21 +23,18 @@ from PyQt6.QtWidgets import (QCheckBox,
                              QLabel,
                              QLineEdit,
                              QToolButton,
-                             QToolTip,
-                             QVBoxLayout,
-                             QWidget)
+                             QVBoxLayout)
 import config
 import tools
 import logger
 import sshtools
 from exceptions import MountException, NoPubKeyLogin, KnownHost
 import mount
-from bitbase import URL_ENCRYPT_TRANSITION, ENCFS_MSG_STAGE, DIR_SSH_KEYS
+from bitbase import URL_ENCRYPT_TRANSITION, DIR_SSH_KEYS
 import schedule
 import qttools
 import messagebox
-import encfsmsgbox
-from statedata import StateData
+# from statedata import StateData
 from manageprofiles import combobox
 from manageprofiles import schedulewidget
 from manageprofiles.sshproxywidget import SshProxyWidget
@@ -764,8 +760,8 @@ class GeneralTab(QDialog):
         # Mode selected in the combo box
         active_mode = self.get_active_snapshots_mode()
 
-        state_data = StateData()
-        profile_state = state_data.profile(self.config.currentProfile())
+        # state_data = StateData()
+        # profile_state = state_data.profile(self.config.currentProfile())
 
         # New selected mode different from previous one?
         if active_mode != self.mode:

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -813,15 +813,15 @@ class GeneralTab(QDialog):
         if active_mode in ('local_encfs', 'ssh_encfs'):
             self._lbl_encfs_warning.show()
 
-            # Workaround to avoid showing the warning messagebox just when
-            # opening the manage profiles dialog.
-            if self._parent_dialog.isVisible():
-                # Show the profile specific warning dialog only once per
-                # profile.
-                if profile_state.msg_encfs < ENCFS_MSG_STAGE:
-                    profile_state.msg_encfs = ENCFS_MSG_STAGE
-                    dlg = encfsmsgbox.EncfsCreateWarning(self)
-                    dlg.exec()
+            # # Workaround to avoid showing the warning messagebox just when
+            # # opening the manage profiles dialog.
+            # if self._parent_dialog.isVisible():
+            #     # Show the profile specific warning dialog only once per
+            #     # profile.
+            #     if profile_state.msg_encfs < ENCFS_MSG_STAGE:
+            #         profile_state.msg_encfs = ENCFS_MSG_STAGE
+            #         dlg = encfsmsgbox.EncfsCreateWarning(self)
+            #         dlg.exec()
 
         else:
             self._lbl_encfs_warning.hide()

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -625,35 +625,26 @@ class GeneralTab(QDialog):
         return combobox.BitComboBox(self, snapshot_modes)
 
     def _create_label_encfs_deprecation(self):
-        icon_label = qttools.create_icon_label_warning()
-
         # encfs deprecation warning (see #1734, #1735)
-        txt = _('EncFS profile creation will be removed in the next minor '
-                'release (1.7), scheduled for 2026.')
-        txt = txt + ' ' + _('Support for EncFS is being discontinued due '
-                            'to security vulnerabilities.')
+
         whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">'
         whitepaper = whitepaper + _('whitepaper') + '</a>'
-        txt = txt + ' ' + _(
-            'For more details, including potential alternatives, please '
-            'refer to this {whitepaper}.'
-        ).format(whitepaper=whitepaper)
-        txt_label = QLabel(txt)
-        txt_label.setWordWrap(True)
-        txt_label.setOpenExternalLinks(True)
 
-        # Show URL in tooltip without anoing http-protocol prefix.
-        txt_label.linkHovered.connect(
-            lambda url: QToolTip.showText(
-                QCursor.pos(), url.replace('https://', ''))
-        )
+        txt = [
+            '<strong>Encrypted profiles using EncFS are no longer '
+            'supported.</strong>',
+            'New EncFS backup profiles can no longer be created. '
+            'Existing EncFS profiles are still displayed and '
+            'supported for now, but EncFS support will be <strong>'
+            'completely removed</strong> in a future release '
+            '(expected around 2027).',
+            'EncFS is considered insecure and is no longer actively '
+            'maintained. For more information, see this '
+            f'{whitepaper}.'
+        ]
+        txt = '<p>' + '</p><p>'.join(txt) + '</p>'
 
-        wdg = QWidget()
-        layout = QHBoxLayout(wdg)
-        layout.addWidget(icon_label, stretch=0)
-        layout.addWidget(txt_label, stretch=1)
-
-        return wdg
+        return qttools.create_warning_label(txt, icon_scale_factor=3)
 
     def _slot_snapshots_path_clicked(self):
         old_path = Path(self._edit_backup_path.text())
@@ -790,7 +781,7 @@ class GeneralTab(QDialog):
             self._wdg_schedule.allow_udev(
                 active_mode in ('local', 'local_encfs', 'local_gocryptfs'))
 
-            # Don't offer depreacted modes (#1734)
+            # Don't offer deprecated modes (#1734)
             modes_to_hide = {'local_encfs', 'ssh_encfs'} - {active_mode}
             for hide in modes_to_hide:
                 self._combo_modes.hide_by_data(hide)

--- a/qt/manageprofiles/tab_general.py
+++ b/qt/manageprofiles/tab_general.py
@@ -15,7 +15,7 @@ import os
 from pathlib import Path
 from typing import Any
 from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QCursor
+from PyQt6.QtGui import QCursor, QColor
 from PyQt6.QtWidgets import (QCheckBox,
                              QDialog,
                              QGridLayout,
@@ -324,8 +324,12 @@ class GeneralTab(QDialog):
 
     def load_values(self) -> Any:
         """Set the values of the widgets regarding the current config."""
+        backup_mode = self.config.snapshotsMode()
+        self._combo_modes.select_by_data(backup_mode)
 
-        self._combo_modes.select_by_data(self.config.snapshotsMode())
+        # If the profile us an deprecated backup mode (#1734)
+        if 'encfs' in backup_mode:
+            self._combo_modes.unhide_by_data(backup_mode)
 
         # local
         self._edit_backup_path.setText(
@@ -606,10 +610,17 @@ class GeneralTab(QDialog):
         return hash_id
 
     def _snapshot_mode_combobox(self) -> combobox.BitComboBox:
+        # Workaround until encryption transition (#1734) is finished.
+
+        # # Find out if profiles using EncFS
+        # all_used_modes = {
+        #     self.config.snapshotsMode(pid) for pid in self.config.profiles()
+        # }
+        # print(f'{all_used_modes=}')  # DEBUG
+
         snapshot_modes = {}
         for key in self.config.SNAPSHOT_MODES:
             snapshot_modes[key] = self.config.SNAPSHOT_MODES[key][1]
-        logger.debug(f'{snapshot_modes=}')
 
         return combobox.BitComboBox(self, snapshot_modes)
 
@@ -759,41 +770,32 @@ class GeneralTab(QDialog):
         This is not a slot connected to a signal. But it is called by the
         parent dialog.
         """
+        # Mode selected in the combo box
         active_mode = self.get_active_snapshots_mode()
 
         state_data = StateData()
         profile_state = state_data.profile(self.config.currentProfile())
 
-        # hide/show group boxes related to current mode
-        # note: self._group_mode_local_encfs = self._group_mode_local
-        # note: self._group_mode_sshEncfs = self._group_mode_ssh
+        # New selected mode different from previous one?
         if active_mode != self.mode:
-            # # DevNote (buhtz): Widgets of the GUI related to the four
-            # # snapshot modes are acccesed via "getattr(self, ...)".
-            # # These are 'Local', 'Ssh', 'LocalEncfs', 'SshEncfs'
-            # for mode in list(self.config.SNAPSHOT_MODES.keys()):
-            #     logger.debug(f'HIDE() :: mode%s' % tools.camelCase(mode))
-            #     # Hide all widgets
-            #     getattr(self, 'mode%s' % tools.camelCase(mode)).hide()
-
-            # for mode in list(self.config.SNAPSHOT_MODES.keys()):
-            #     # Show up the widget related to the selected mode.
-            #     if active_mode == mode:
-            #         logger.debug(f'SHOW() :: mode%s' % tools.camelCase(mode))
-            #         getattr(self, 'mode%s' % tools.camelCase(mode)).show()
 
             self.mode = active_mode
 
             self._group_mode_local.setVisible(
                 active_mode in ('local', 'local_encfs', 'local_gocryptfs'))
+
             self._group_mode_ssh.setVisible(
                 active_mode in ('ssh', 'ssh_encfs'))
-            # self._group_mode_local_encfs = self._group_mode_local
-            # self._group_mode_sshEncfs = self._group_mode_ssh
 
             self._wdg_schedule.allow_udev(
                 active_mode in ('local', 'local_encfs', 'local_gocryptfs'))
 
+            # Don't offer depreacted modes (#1734)
+            modes_to_hide = {'local_encfs', 'ssh_encfs'} - {active_mode}
+            for hide in modes_to_hide:
+                self._combo_modes.hide_by_data(hide)
+
+        # A mode using password fields?
         if self.config.modeNeedPassword(active_mode):
 
             self._lbl_password1.setText(
@@ -812,6 +814,7 @@ class GeneralTab(QDialog):
                 self._txt_password2.hide()
 
             self._load_passwords()
+
         else:
             self._group_password1.hide()
 
@@ -828,5 +831,6 @@ class GeneralTab(QDialog):
                     profile_state.msg_encfs = ENCFS_MSG_STAGE
                     dlg = encfsmsgbox.EncfsCreateWarning(self)
                     dlg.exec()
+
         else:
             self._lbl_encfs_warning.hide()

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -31,7 +31,8 @@ from typing import Union, Iterable, Callable
 from pathlib import Path
 from contextlib import contextmanager
 from textdlg import TextDialog
-from PyQt6.QtGui import (QDesktopServices,
+from PyQt6.QtGui import (QCursor,
+                         QDesktopServices,
                          QGuiApplication,
                          QFontMetricsF,
                          QIcon,
@@ -49,6 +50,7 @@ from PyQt6.QtWidgets import (QApplication,
                              QStyle,
                              QStyleFactory,
                              QSystemTrayIcon,
+                             QToolTip,
                              QWidget)
 from qttools_path import register_backintime_path
 register_backintime_path('common')
@@ -300,6 +302,14 @@ def _combine_icon_with_label(icon: QLabel, text: str) -> QWidget:
     """
     txt = QLabel(text)
     txt.setWordWrap(True)
+
+    # Show URL in tooltip without anoing http-protocol prefix.
+    if '<a href' in text:
+        txt.setOpenExternalLinks(True)
+        txt.linkHovered.connect(
+            lambda url: QToolTip.showText(
+                QCursor.pos(), url.replace('https://', ''))
+        )
 
     layout = QHBoxLayout()
     layout.addWidget(icon)


### PR DESCRIPTION
First merge following PRs
- #2363

Close #2315
Related to #1734

- Profile mode drop down widget does not show EncFS anymore as an option, making it impossible to create a fresh profile in that modes.
- Existing EncFS profiles 
- Modify and increase intense of all warnings and messages related to EncFS removal.
- The messages not translated anymore, because they are temporary. It lowers the translators burden.
- Removed EncFS creation warning because it is not possible anymore to create such profiles.
- Local EncFS and SSH EncFS profiles now have a "DEPRECATED" as prefix in their label. See last screenshot. Maybe "DEPRECATED" is not the correct term in that case?

# Mode drop down - Without EncFS

<img width="542" height="176" alt="image" src="https://github.com/user-attachments/assets/a41981e8-6f2b-4dde-b178-57ea16b2ee32" />

# Mode drop down - For existing EncFS profiles

Open an exiting profile that use EncFS, the mode is shown in the mode drop down widget but with "DEPRECATED" widget.

<img width="584" height="166" alt="image" src="https://github.com/user-attachments/assets/5a33a41d-8c80-4232-a854-19ff31799eba" />

# Syslog

This messages is modified from warning to an error and appears every 30 days in the syslog.

<img width="1382" height="68" alt="image" src="https://github.com/user-attachments/assets/9d71a70c-2c49-4e19-b740-c3a71ac6813a" />

# Starting BIT having EncFS profil

This messages appears only one time if an EncFS profile exist.

<img width="510" height="362" alt="image" src="https://github.com/user-attachments/assets/cb86bfb2-d25b-474e-a067-c4bcd4ddfab3" />


# Error label in General TAB in Manage Profiles dialog

<img width="613" height="765" alt="image" src="https://github.com/user-attachments/assets/b48fa56b-b7a6-40f9-bfee-be67edf3bd47" />
