### PR TITLE
downgrade the missing-icons error message to a warning

### DIFF
--- a/qt/icon.py
+++ b/qt/icon.py
@@ -56,7 +56,7 @@ for theme in themes_to_try:
 if QIcon.fromTheme(ICON_NAME_TO_CHECK,
                    QIcon.fromTheme(ICON_NAME_TO_CHECK_SYMBOLIC)
                    ).isNull():
-    logger.error(
+    logger.warning(
         f'Icon theme missing or not supported. Icon "{ICON_NAME_TO_CHECK}" '
         f' and "{ICON_NAME_TO_CHECK_SYMBOLIC}" not found. An icon theme should'
         ' be installed. For example: tango-icon-theme, oxygen-icon-theme'


### PR DESCRIPTION
As suggested in https://github.com/bit-team/backintime/issues/2262#issuecomment-3761124721. I haven't added a changelog entry; I am not sure this minor change needs it.