### PR TITLE
chore(gui): User message dialog centers to screen if no parent widget specified

### DIFF
--- a/qt/app.py
+++ b/qt/app.py
@@ -442,7 +442,7 @@ class MainWindow(QMainWindow):
             # EncFS deprecation warning (#1734, #1735)
             if encfs_profiles:
                 state_data.msg_encfs_global = bitbase.ENCFS_MSG_STAGE
-                dlg = encfsmsgbox.EncfsExistsWarning(self, encfs_profiles)
+                dlg = encfsmsgbox.EncfsExistsWarning(encfs_profiles)
                 dlg.exec()
 
     @property
@@ -1745,9 +1745,9 @@ class MainWindow(QMainWindow):
         html_contact_list = (
             '<ul>'
             '<li>{mastodon}</li>'
-            # '<li>{email}</li>'
             '<li>{mailinglist}</li>'
             '<li>{issue}</li>'
+            '<li>{email}</li>'
             '<li>{alternative}</li>'
             '</ul>').format(
                 mastodon=_('In the Fediverse at Mastodon: {link_and_label}.') \
@@ -1755,9 +1755,10 @@ class MainWindow(QMainWindow):
                                            '/@backintime">'
                                            '@backintime@fosstodon.org'
                                            '</a>'),
-                # email=_('Email to {link_and_label}.').format(
-                #     link_and_label='<a href="mailto:backintime@tuta.io">'
-                #                    'backintime@tuta.io</a>'),
+                email=_('Email to {link_and_label}.').format(
+                    link_and_label='<a href="mailto:backintime-project'
+                                   '@posteo.de">'
+                                   'backintime-project@posteo.de</a>'),
                 mailinglist=_('Mailing list {link_and_label}.').format(
                     link_and_label='<a href="https://mail.python.org/mailman3/'
                                    'lists/bit-dev.python.org/">'
@@ -1798,7 +1799,7 @@ class MainWindow(QMainWindow):
             'Your Back In Time Team').format(contact_list=html_contact_list)
 
         dlg = UserMessageDialog(
-            parent=self,
+            parent=None,
             title=_('Release Candidate'),
             full_label=rc_message)
         dlg.exec()
@@ -2313,7 +2314,7 @@ class MainWindow(QMainWindow):
         self._open_ssh_cipher_deprecation_dialog(self._cipher_using_profiles())
 
     def _slot_help_encryption(self):
-        dlg = encfsmsgbox.EncfsExistsWarning(self, ['(not determined)'])
+        dlg = encfsmsgbox.EncfsExistsWarning(['(not determined)'])
         dlg.exec()
 
     def _slot_edit_user_callback(self):

--- a/qt/encfsmsgbox.py
+++ b/qt/encfsmsgbox.py
@@ -19,8 +19,8 @@ class _EncfsWarningBase(QMessageBox):
     """
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, parent, text, informative_text, button_label=None):
-        super().__init__(parent)
+    def __init__(self, text, informative_text, button_label=None):
+        super().__init__()
 
         self.setWindowTitle(_('Warning'))
         self.setIcon(QMessageBox.Icon.Warning)
@@ -68,7 +68,7 @@ class EncfsExistsWarning(_EncfsWarningBase):
     """
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, parent, profiles):
+    def __init__(self, profiles):
 
         whitepaper = f'<a href="{URL_ENCRYPT_TRANSITION}">' \
             + 'whitepaper' + '</a>'
@@ -98,4 +98,4 @@ class EncfsExistsWarning(_EncfsWarningBase):
         informative_text = ''.join(
             [f'<p>{par}</p>' for par in info_paragraphs])
 
-        super().__init__(parent, text, informative_text, 'Got it')
+        super().__init__(text, informative_text, 'Got it')

--- a/qt/languagedialog.py
+++ b/qt/languagedialog.py
@@ -25,6 +25,7 @@ LOW_RESOLUTION_WIDTH = 1024
 
 class LanguageDialog(QDialog):
     """Dialog to choose GUI language."""
+
     def __init__(self, used_language_code: str, configured_language_code: str):
         super().__init__()
 

--- a/qt/usermessagedialog.py
+++ b/qt/usermessagedialog.py
@@ -6,8 +6,9 @@
 # General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """Module about UserMessageDialog"""
+from typing import Optional
 from PyQt6.QtCore import Qt, QSize, QTimer
-from PyQt6.QtGui import QCursor
+from PyQt6.QtGui import QCursor, QGuiApplication
 from PyQt6.QtWidgets import (QDialog,
                              QLayout,
                              QVBoxLayout,
@@ -27,11 +28,13 @@ class UserMessageDialog(QDialog):
     HTML tags supported because of Qt rich text feature. Text between Newline
     characters ``\n`` will be converted into ``<p>`` paragraphs.
 
+    The dialog is centered relative to its parent if present, otherwise to the
+    screen.
     """
 
     def __init__(
             self,
-            parent: QWidget,
+            parent: Optional[QWidget],
             title: str,
             full_label: str,
     ):
@@ -76,16 +79,32 @@ class UserMessageDialog(QDialog):
         if self.height() < best.height():
             self.resize(best)
 
-        QTimer.singleShot(0, self._center_to_parent)
+        QTimer.singleShot(0, self._center)
+
+    def _center(self):
+        if self.parentWidget():
+            self._center_to_parent()
+
+        else:
+            self._center_to_screen()
 
     def _center_to_parent(self):
-        parent = self.parentWidget()
-        if parent is None:
-            return
-
         geo = self.frameGeometry()
-        geo.moveCenter(parent.frameGeometry().center())
+        geo.moveCenter(self.parentWidget().frameGeometry().center())
         self.move(geo.topLeft())
+
+    def _center_to_screen(self):
+        """Center the dialog to
+        """
+        screen = QGuiApplication.screenAt(self.pos())
+        geom = screen.availableGeometry()
+
+        self.move(
+            # center horizontal
+            geom.center().x() - (self.geometry().width() // 2),
+            # center vertical
+            geom.center().y() - (self.geometry().height() // 2),
+        )
 
     # pylint: disable-next=invalid-name
     def resizeEvent(self, event):  # noqa: N802


### PR DESCRIPTION
The user message dialog's positioin centers to the screen if no parent widget is specified. For example relevant to release candidate message.