### PR TITLE
chore(translation): User warning about removing Faroes, Georgian, Croation, Vietnamese, Icelanding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ distribution.
   - Optional but recommended:
     - `pylint` (>= 4.0.0)
     - `flake8`
-    - `ruff` (>= 0.12.0)
+    - `ruff` (>= 0.15.0)
     - `codespell`
     - `reuse` (>= 4.0.0)
  

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -185,7 +185,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
                 f'be {version_target} or higher.')
 
         if RUFF_AVAILABLE:
-            version_target = version.parse('0.12.0')
+            version_target = version.parse('0.15.0')
 
             proc = subprocess.run(
                 ['ruff', '--version'],

--- a/qt/app.py
+++ b/qt/app.py
@@ -396,16 +396,12 @@ class MainWindow(QMainWindow):
 
         # Issue: https://github.com/bit-team/backintime/issues/2080
         lang_planed_for_removal = [
-            'fo',  # Faroes
-            'hr',  # Croatian
-            'vi',  # Vietnamese
-            'is',  # Icelandic
-            'sl',  # Slovenian
-            'ro',  # Romanian
-            # On the edge. 40-50% completeness. inactive. But some
-            # activity not very long ago.
-            # 'ar',  # Arabic. Last activity 2025-10
-            # 'ru',  # Russian. Last activity 2025-07
+            'fo',  # Faroes 18
+            'ka',  # Georgian 23
+            'hr',  # Croatian 24
+            'vi',  # Vietnamese 35
+            'is',  # Icelandic 44
+            # 'ar',  # Arabic. Last activity 2025-10 45
         ]
 
         # Language removal message
@@ -422,7 +418,7 @@ class MainWindow(QMainWindow):
 
                 # Show the message only if the current used language is
                 # translated equal or less then {cutoff}%
-                self._open_approach_translator_dialog(cutoff=97)
+                self._open_approach_translator_dialog(cutoff=90)
 
         # BIT counts down how often the GUI was started. Until the end of that
         # countdown a dialog with a text about contributing to translating
@@ -1724,7 +1720,7 @@ class MainWindow(QMainWindow):
 
         txt = [
             f'The selected language ({name}) will be <strong>removed in the '
-            'release</strong>.',
+            'next version</strong>.',
             'Reason: No recent '
             f'<a href="{bitbase.URL_TRANSLATION}">translation activity</a> '
             'and no active maintainer.',

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -201,7 +201,7 @@ class MirrorMirrorOnTheWall(unittest.TestCase):
                 f'be {version_target} or higher.')
 
         if RUFF_AVAILABLE:
-            version_target = version.parse('0.12.0')
+            version_target = version.parse('0.15.0')
 
             proc = subprocess.run(
                 ['ruff', '--version'],


### PR DESCRIPTION
Message to users about removing the following languages in the next release (after 1.6.0): Faroes, Georgian, Croatian, Vietnamese, Icelandic. (#2080)
Lowered approach translator dialog threshold to 90% completeness.
Increased ruff version to 0.15.0.
