### PR TITLE
fix: SSH Key Selector handling missing, binary and other special key files

### DIFF
--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -164,7 +164,7 @@ class SSH(MountControl):
 
                 logger.warning("Couldn't get fingerprint for private key "
                                f'{self.private_key_file}. Most likely because'
-                               f' the public key {self.private_key_file.pub} '
+                               f' the public key {self.private_key_file}.pub '
                                "wasn't found. Using fallback to private keys "
                                'path instead. But this can make troubles with '
                                'passphrase-less keys.',

--- a/common/sshtools.py
+++ b/common/sshtools.py
@@ -1373,7 +1373,7 @@ def get_private_ssh_key_files() -> list[Path]:
                 'backup'
             )
             # no public keys
-            and fp.suffix  != '.pub',
+            and fp.suffix != '.pub',
             ssh_path.iterdir()
         )
     except FileNotFoundError:
@@ -1382,16 +1382,30 @@ def get_private_ssh_key_files() -> list[Path]:
     result = []
 
     # e.g. "-----BEGIN OPENSSH PRIVATE KEY-----"
-    rex = re.compile(r'^-+BEGIN\s\S+\sPRIVATE KEY-+$')
+    # rex = re.compile(r'^-+BEGIN\s\S+\sPRIVATE KEY-+$')
+    rex = re.compile(br'^-+BEGIN\s+\S+\s+PRIVATE KEY-+')
 
     # check content
     for fp in potential_key_files:
         if not fp.is_file():
             continue
+
         try:
-            with fp.open('r', encoding='utf-8') as handle:
-                if rex.match(handle.readline().strip()):
+            with fp.open('rb') as handle:
+                data = handle.read(4096)  # read max. 4 KB
+
+                # PEM (text based)
+                if rex.search(data):
                     result.append(fp)
+
+                # DER / ASN.1 (binary key file) with long keys
+                elif data[:2] in (b'\x30\x82', b'\x30\x81'):
+                    result.append(fp)
+
+                # DER / ASN.1 (binary key file) with short keys
+                elif data[:1] == b'\x30':
+                    result.append(fp)
+
         except OSError:
             # ignore files that cannot be opened (e.g. sockets)
             continue

--- a/qt/icon.py
+++ b/qt/icon.py
@@ -172,3 +172,4 @@ DEFAULT_EXCLUDE = load_icon('emblem-important')
 INVALID_EXCLUDE = load_icon_alt(['emblem-ohno', 'face-surprise'])
 ENCRYPT = load_icon_alt(['lock', 'security-high'])
 LANGUAGE = load_icon('preferences-desktop-locale')
+SSH_KEY_INVALID = INVALID_EXCLUDE

--- a/qt/manageprofiles/sshkeyselector.py
+++ b/qt/manageprofiles/sshkeyselector.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import (QButtonGroup,
                              QWidget)
 from PyQt6.QtGui import QColor, QPalette
 import sshtools
+import logger
 import qttools
 from manageprofiles.combobox import BitComboBox
 
@@ -100,27 +101,46 @@ class SshKeyCombo(BitComboBox):
 
         handler()
 
-    def add_and_select(self, key_path: Path):
+    def add_and_select(self, key_path: Path, is_invalid: bool = False):
         """Add a new entry and select it after that."""
-        # pylint: disable-next=import-outside-toplevel
-        import icon  # noqa: PLC0415
 
         with qttools.block_signals(self):
 
-            # still exists?
             if self.has_data(key_path):
                 self.select_by_data(key_path)
 
             else:
-                self.insertItem(
-                    0, icon.ENCRYPT, key_path.name, userData=key_path)
-                self.setItemData(
-                    0,
-                    SshKeyCombo._key_tooltip(key_path),
-                    Qt.ItemDataRole.ToolTipRole)
+                if is_invalid:
+                    self._add_on_top(
+                        key_path,
+                        'Invalid or missing: ',
+                        'The key file is missing or somehow invalid.\n'
+                    )
+                else:
+                    self._add_on_top(key_path)
+
                 self.setCurrentIndex(0)
 
         self._fade_background()
+
+    def _add_on_top(self,
+                    key_path: Path,
+                    prefix: str = '',
+                    tooltip_prefix: str = ''):
+        # pylint: disable-next=import-outside-toplevel
+        import icon  # noqa: PLC0415
+
+        self.insertItem(
+            0,
+            icon.SSH_KEY_INVALID if prefix else icon.ENCRYPT,
+            f'{prefix}{key_path.name}',
+            userData=key_path
+        )
+        self.setItemData(
+            0,
+            SshKeyCombo._key_tooltip(f'{tooltip_prefix}{key_path}'),
+            Qt.ItemDataRole.ToolTipRole
+        )
 
     def _fade_background(self, duration_ms=1200, steps=30):
         palette = self.palette()
@@ -231,11 +251,26 @@ class SshKeySelector(QWidget):
         """Select an existing key based on its path.
 
         If not enabled this will also enable the drop down. If path is ``None``
-        the drop down widget is disabled."""
+        the drop down widget is disabled.
+        """
+
         if key_path:
-            self.selector.select_by_data(key_path)
+            try:
+                self.selector.select_by_data(key_path)
+            except ValueError:
+                # Edge case that should not happen
+                if key_path.exists():
+                    logger.critical(
+                        'Undefined situation: Key path exists but is not '
+                        'present in the key select widget. '
+                        f'{key_path=}'
+                    )
+                # Add this entry but mark it es invalid
+                self.selector.add_and_select(key_path, True)
+
             self.radio_key.setChecked(True)
             self.btn_group.buttonClicked.emit(self.radio_key)
+
         else:
             self.radio_no.setChecked(True)
             self.btn_group.buttonClicked.emit(self.radio_no)


### PR DESCRIPTION
- Binary key files now recognized.
- Other invalid files now shouldn't cause a crash. They are just ignored.
- A configured but missing key is highlighted in the SSH Key Selector widget.

Fix #2399
Fix #2400

Thank you to @graysky2 for reporting this issues.