### PR TITLE
build(make): remove deprecated test targets from generated Makefiles

### DIFF
--- a/common/configure
+++ b/common/configure
@@ -298,14 +298,6 @@ cat ${UNINSTALL_FILES} >> ${MAKEFILE}
 printf "uninstall_dirs:\n" >> ${MAKEFILE}
 cat ${UNINSTALL_DIRS} >> ${MAKEFILE}
 
-for target in test test-v unittest unittest-v; do
-    printf "\n\n%s:\n" "$target" >> ${MAKEFILE}
-    printf "\t@echo \"Target '%s' not available anymore. " "$target">> ${MAKEFILE}
-    printf "Use a test runner of your own choice " >> ${MAKEFILE}
-    printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
-    printf "\n\t@false" >> ${MAKEFILE}
-done
-
 # Copy Makefile
 mv ${MAKEFILE} Makefile
 chmod 644 Makefile

--- a/qt/configure
+++ b/qt/configure
@@ -278,14 +278,6 @@ cat ${UNINSTALL_FILES} >> ${MAKEFILE}
 printf "uninstall_dirs:\n" >> ${MAKEFILE}
 cat ${UNINSTALL_DIRS} >> ${MAKEFILE}
 
-for target in test test-v unittest unittest-v; do
-    printf "\n\n%s:\n" "$target" >> ${MAKEFILE}
-    printf "\t@echo \"Target '%s' not available anymore. " "$target">> ${MAKEFILE}
-    printf "Use a test runner of your own choice " >> ${MAKEFILE}
-    printf "(e.g. 'unittest' or 'pytest').\"" >> ${MAKEFILE}
-    printf "\n\t@false" >> ${MAKEFILE}
-done
-
 # copy Makefile
 mv ${MAKEFILE} Makefile
 chmod 644 Makefile


### PR DESCRIPTION
## Summary
- remove generation of `test`, `test-v`, `unittest`, and `unittest-v` Makefile targets
  from both `common/configure` and `qt/configure`
- this aligns generated Makefiles with the current workflow where tests are run
  directly via a test runner

## Testing
- `bash -n common/configure qt/configure`

Fixes #2374
