### PR TITLE
fix(udev): avoid crash when polkit dialog times out

### DIFF
--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -18,6 +18,7 @@ import random
 import pathlib
 import stat
 import signal
+import types
 import unittest
 from datetime import datetime
 from time import sleep
@@ -30,6 +31,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import tools
 import configfile
 from bitbase import TimeUnit
+from exceptions import PermissionDeniedByPolicy
 
 # chroot jails used for building may have no UUID devices (because of tmpfs)
 # we need to skip tests that require UUIDs
@@ -844,3 +846,69 @@ class NestedDictUpdate(unittest.TestCase):
         self.assertDictEqual(
             tools.nested_dict_update(org, update),
             expect)
+
+
+class SetupUdev(unittest.TestCase):
+    class DummyDBusException(Exception):
+        def __init__(self, name, message='dummy error'):
+            super().__init__(message)
+            self._dbus_error_name = name
+
+    class DummyIface:
+        def __init__(self, exc):
+            self.exc = exc
+
+        def save(self):
+            raise self.exc
+
+    def test_save_noreply_raises_permission_denied(self):
+        err = self.DummyDBusException('org.freedesktop.DBus.Error.NoReply')
+        sut = tools.SetupUdev.__new__(tools.SetupUdev)
+        sut.isReady = True
+        sut.iface = self.DummyIface(err)
+
+        fake_dbus = types.SimpleNamespace(
+            exceptions=types.SimpleNamespace(
+                DBusException=self.DummyDBusException
+            )
+        )
+
+        with patch.object(tools, 'dbus', fake_dbus):
+            with self.assertRaises(PermissionDeniedByPolicy):
+                sut.save()
+
+    def test_save_permission_denied_raises_permission_denied(self):
+        err = self.DummyDBusException(
+            'com.ubuntu.DeviceDriver.PermissionDeniedByPolicy'
+        )
+        sut = tools.SetupUdev.__new__(tools.SetupUdev)
+        sut.isReady = True
+        sut.iface = self.DummyIface(err)
+
+        fake_dbus = types.SimpleNamespace(
+            exceptions=types.SimpleNamespace(
+                DBusException=self.DummyDBusException
+            )
+        )
+
+        with patch.object(tools, 'dbus', fake_dbus):
+            with self.assertRaises(PermissionDeniedByPolicy):
+                sut.save()
+
+    def test_save_unknown_dbus_error_reraised(self):
+        err = self.DummyDBusException(
+            'org.freedesktop.DBus.Error.ServiceUnknown'
+        )
+        sut = tools.SetupUdev.__new__(tools.SetupUdev)
+        sut.isReady = True
+        sut.iface = self.DummyIface(err)
+
+        fake_dbus = types.SimpleNamespace(
+            exceptions=types.SimpleNamespace(
+                DBusException=self.DummyDBusException
+            )
+        )
+
+        with patch.object(tools, 'dbus', fake_dbus):
+            with self.assertRaises(self.DummyDBusException):
+                sut.save()

--- a/common/tools.py
+++ b/common/tools.py
@@ -2200,6 +2200,11 @@ class SetupUdev:
                     == 'com.ubuntu.DeviceDriver.PermissionDeniedByPolicy'):
                 raise PermissionDeniedByPolicy(str(err)) from err
 
+            if err._dbus_error_name == 'org.freedesktop.DBus.Error.NoReply':
+                raise PermissionDeniedByPolicy(
+                    _('Authorization timed out or was cancelled.')
+                ) from err
+
             raise err
 
     def clean(self):


### PR DESCRIPTION
## Summary
- handle `org.freedesktop.DBus.Error.NoReply` in `SetupUdev.save()`
- convert that timeout/cancel path into `PermissionDeniedByPolicy` so UI code handles it gracefully
- add focused tests for `SetupUdev.save()` covering:
  - NoReply timeout -> `PermissionDeniedByPolicy`
  - existing policy denial mapping remains unchanged
  - unknown DBus errors are still re-raised

## Testing
- `python3 -m py_compile common/tools.py common/test/test_tools.py`
- focused runtime check script for `SetupUdev.save()` paths (NoReply / policy denied / unknown)

Fixes #2375
