### PR TITLE
fix: block restore while backup is running

### DIFF
--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -483,6 +483,26 @@ class Snapshots:
                                         or are newer than those in destination.
                                         Using ``rsync --update`` option.
         """
+        # Backup already running?
+        # Using flock=True serializes this check with backup() creating its PID
+        # file so restore doesn't race with a just-starting backup process.
+        backup_instance = ApplicationInstance(
+            pidFile=self.config.takeSnapshotInstanceFile(),
+            autoExit=False,
+            flock=True)
+
+        backup_running = not backup_instance.check()
+        backup_instance.flockUnlock()
+
+        if backup_running:
+            logger.warning(
+                'A backup process is already running. Restore has been '
+                'stopped. The PID of the running backup is stored in '
+                f'{backup_instance.pidFile}. Consider deleting the PID file '
+                'if there is actually no backup process running.',
+                self)
+            return
+
         instance = ApplicationInstance(
             pidFile=self.config.restoreInstanceFile(),
             autoExit=False,

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -342,6 +342,55 @@ class Callbacks(generic.SnapshotsTestCase):
                 '"/foo/bar": Operation not permitted (1)\n',
                 f.read())
 
+    @patch('snapshots.ApplicationInstance')
+    @patch('snapshots.tools.Execute')
+    def test_restore_stops_if_backup_running(self, mock_execute, mock_app_instance):
+        backup_instance = unittest.mock.Mock()
+        backup_instance.check.return_value = False
+        backup_instance.pidFile = self.cfg.takeSnapshotInstanceFile()
+        mock_app_instance.return_value = backup_instance
+
+        sid = snapshots.SID('20151219-010324-123', self.cfg)
+        self.sn.restore(sid, '/foo')
+
+        mock_app_instance.assert_called_once_with(
+            pidFile=self.cfg.takeSnapshotInstanceFile(),
+            autoExit=False,
+            flock=True)
+        backup_instance.check.assert_called_once_with()
+        backup_instance.flockUnlock.assert_called_once_with()
+        backup_instance.startApplication.assert_not_called()
+        mock_execute.assert_not_called()
+
+    @patch('snapshots.ApplicationInstance')
+    @patch('snapshots.tools.Execute')
+    def test_restore_stops_if_restore_running(self, mock_execute, mock_app_instance):
+        backup_instance = unittest.mock.Mock()
+        backup_instance.check.return_value = True
+        backup_instance.pidFile = self.cfg.takeSnapshotInstanceFile()
+
+        restore_instance = unittest.mock.Mock()
+        restore_instance.check.return_value = False
+        restore_instance.pidFile = self.cfg.restoreInstanceFile()
+
+        mock_app_instance.side_effect = [backup_instance, restore_instance]
+
+        sid = snapshots.SID('20151219-010324-123', self.cfg)
+        self.sn.restore(sid, '/foo')
+
+        self.assertEqual(mock_app_instance.call_count, 2)
+        mock_app_instance.assert_any_call(
+            pidFile=self.cfg.takeSnapshotInstanceFile(),
+            autoExit=False,
+            flock=True)
+        mock_app_instance.assert_any_call(
+            pidFile=self.cfg.restoreInstanceFile(),
+            autoExit=False,
+            flock=True)
+        backup_instance.flockUnlock.assert_called_once_with()
+        restore_instance.startApplication.assert_not_called()
+        mock_execute.assert_not_called()
+
 
 class SnapshotWithSID(generic.SnapshotsWithSidTestCase):
     def test_backup_config(self):


### PR DESCRIPTION
## Summary
- check the backup instance lock at the beginning of `Snapshots.restore()`
- stop restore early with a clear warning when a backup for the same profile is already running
- keep the existing restore-instance guard unchanged
- add unit tests for:
  - restore aborts when backup is running
  - restore aborts when another restore is running

## Testing
- `python3 -m py_compile common/snapshots.py common/test/test_snapshots.py`
- focused unittest run for the two new tests (with local DBus stub in this macOS environment)

Fixes #1589
