### PR TITLE
fix: improve rsync exit-code-10 error reporting

### DIFF
--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1128,13 +1128,14 @@ class Snapshots:
             0, _('Take snapshot') + " (rsync: %s)" % line)
 
         # Did rsync report an error?
-        if line.endswith(')'):
-            if line.startswith('rsync:'):
-                if not line.startswith('rsync: chgrp ') and not line.startswith('rsync: chown '):
-                    # matches rsync error lines like:
-                    # rsync: [generator] link [...] failed: Invalid cross-device link (18)
-                    params[0] = True
-                    self.setTakeSnapshotMessage(1, 'Error: ' + line)
+        if line.startswith('rsync:') or line.startswith('rsync error:'):
+            if (not line.startswith('rsync: chgrp ')
+                    and not line.startswith('rsync: chown ')):
+                # matches rsync error lines like:
+                # rsync: [generator] link [...] failed: Invalid cross-device link (18)
+                # rsync error: error in socket I/O (code 10) at io.c(...)
+                params[0] = True
+                self.setTakeSnapshotMessage(1, 'Error: ' + line)
 
         if len(line) >= 13:
             # The prefix is created by rsync via the argument "--out-format=BACKINTIME: %i %n%L"
@@ -1521,6 +1522,12 @@ class Snapshots:
             24: _("Partial transfer due to vanished source files "
                   "(see 'man rsync')")
         }
+        # dict of exit codes (as keys) that are treated as errors with
+        # specific hints for the user.
+        rsync_error_exit_codes = {
+            10: _("Error in socket I/O. This can be caused by no free "
+                  "space on the destination.")
+        }
 
         rsync_exit_code_msg = _("'rsync' ended with exit code {exit_code}") \
             .format(exit_code=rsync_exit_code)
@@ -1535,7 +1542,9 @@ class Snapshots:
             params[0] = True
             self.setTakeSnapshotMessage(
                 1, rsync_exit_code_msg + ": "
-                   + _("See 'man rsync' for more details"))
+                   + rsync_error_exit_codes.get(
+                       rsync_exit_code,
+                       _("See 'man rsync' for more details")))
 
         elif rsync_exit_code < 0:  # an rsync error caused by a signal
             # HACK to fix #489 (params[0] and has_errors should be merged)

--- a/common/test/test_snapshots.py
+++ b/common/test/test_snapshots.py
@@ -342,6 +342,47 @@ class Callbacks(generic.SnapshotsTestCase):
                 '"/foo/bar": Operation not permitted (1)\n',
                 f.read())
 
+    def test_error_socket_io(self):
+        params = [False, False]
+
+        self.sn.rsyncCallback(
+            'rsync error: error in socket I/O (code 10) '
+            'at io.c(228) [Receiver=3.2.7]',
+            params)
+        self.assertListEqual([True, False], params)
+
+        with open(self.cfg.takeSnapshotMessageFile(), 'rt') as f:
+            self.assertEqual(
+                '1\nError: rsync error: error in socket I/O (code 10) '
+                'at io.c(228) [Receiver=3.2.7]',
+                f.read())
+
+        self.sn.snapshotLog.flush()
+
+        with open(self.cfg.takeSnapshotLogFile(), 'rt') as f:
+            self.assertEqual(
+                '[I] Take snapshot (rsync: rsync error: error in socket I/O '
+                '(code 10) at io.c(228) [Receiver=3.2.7])\n'
+                '[E] Error: rsync error: error in socket I/O (code 10) '
+                'at io.c(228) [Receiver=3.2.7]\n',
+                f.read())
+
+    def test_warning_line_not_marked_as_error(self):
+        params = [False, False]
+
+        self.sn.rsyncCallback(
+            'rsync warning: some files vanished before they could be '
+            'transferred (code 24) at main.c(1333) [sender=3.2.3]',
+            params)
+        self.assertListEqual([False, False], params)
+
+        with open(self.cfg.takeSnapshotMessageFile(), 'rt') as f:
+            self.assertEqual(
+                '0\nTake snapshot (rsync: rsync warning: some files vanished '
+                'before they could be transferred (code 24) at main.c(1333) '
+                '[sender=3.2.3])',
+                f.read())
+
 
 class SnapshotWithSID(generic.SnapshotsWithSidTestCase):
     def test_backup_config(self):


### PR DESCRIPTION
## Summary
- treat `rsync error:` lines as errors in `Snapshots.rsyncCallback()`
- keep `rsync warning:` lines as non-errors
- add a dedicated user hint for rsync exit code `10` (socket I/O), including the common "destination out of space" cause
- add callback tests for:
  - rsync socket I/O error line (`rsync error:`) -> marked as error
  - rsync warning line (`rsync warning:`) -> not marked as error

## Testing
- `python3 -m py_compile common/snapshots.py common/test/test_snapshots.py`
- focused callback tests (with local DBus stub in this macOS environment):
  - `test_error`
  - `test_error_socket_io`
  - `test_warning_line_not_marked_as_error`

Fixes #2037
