### PR TITLE
Fix missing man5 directory creation in configure

### DIFF
--- a/common/configure
+++ b/common/configure
@@ -234,6 +234,7 @@ addComment "man"
 addInstallDir                                            "/share/man/man1"
 addInstallFile "../doc/manpages/backintime.1.gz"         "/share/man/man1"
 addInstallFile "../doc/manpages/backintime-askpass.1.gz" "/share/man/man1"
+addInstallDir                                            "/share/man/man5"
 addInstallFile "../doc/manpages/backintime-config.5.gz"  "/share/man/man5"
 addUninstallDir                                          "/share/man"
 addNewline


### PR DESCRIPTION
Spotted after this lintian error:
E: backintime-common: odd-place-for-manual-page [usr/share/man/man5.gz]
