### PR TITLE
fix: More robust license links in about dialog

### DIFF
--- a/common/bitlicense.py
+++ b/common/bitlicense.py
@@ -66,3 +66,6 @@ def _determine_licenses_dir() -> str | None:
 
 
 DIR_LICENSES = _determine_licenses_dir()
+
+FALLBACK_DIR_LICENSES = f'{bitbase.URL_SOURCE}/tree/dev/LICENSES'
+FALLBACK_LICENSES_MD = f'{bitbase.URL_SOURCE}/blob/-/LICENSES.md'

--- a/common/tools.py
+++ b/common/tools.py
@@ -2035,6 +2035,22 @@ def escapeIPv6Address(address):
     return address
 
 
+def xdg_open(uri: str) -> bool:
+    """Use xdg-open command to open a resource (file, url, ...) with the
+    systems default application.
+
+    Errors are logged as critical.
+    """
+    try:
+        subprocess.run(['xdg-open', str(uri)], check=True)
+
+    except subprocess.CalledProcessError as exc:
+        logger.critical(str(exc))
+        return False
+
+    return True
+
+
 class Alarm:
     """Establish a callback function that is called after a timeout using
     SIGALRM signal.

--- a/common/version.py
+++ b/common/version.py
@@ -13,7 +13,7 @@ See Issue #1575 for details about that migration.
 import re
 
 # Version string regularyly used by the application and presented to users.
-__version__ = '1.6.2-dev.2644d885'
+__version__ = '1.6.2-dev.13eda139'
 
 # Version string ends with lower case ``rc`` and optionally with a number.
 # e.g. "1.6.0rc", "1.6.0-rc", "1.6.0-rc2"

--- a/common/version.py
+++ b/common/version.py
@@ -13,7 +13,7 @@ See Issue #1575 for details about that migration.
 import re
 
 # Version string regularyly used by the application and presented to users.
-__version__ = '1.6.2-dev.13eda139'
+__version__ = '1.6.2-dev.2644d885'
 
 # Version string ends with lower case ``rc`` and optionally with a number.
 # e.g. "1.6.0rc", "1.6.0-rc", "1.6.0-rc2"

--- a/qt/aboutdlg.py
+++ b/qt/aboutdlg.py
@@ -163,6 +163,20 @@ class AboutDlg(QDialog):
 
         return gpl
 
+    def _slot_license_link_acivated(self, link):
+        if link == _HREF_LICENSES_MD:
+            self._show_licenses_md_file()
+
+        elif link == _HREF_LICENSES_DIR:
+            self._show_licenses_dir()
+
+        elif link == _HREF_SPDX_GPL:
+            qttools.open_url(bitlicense.URL_GPL_TWO)
+
+        else:
+            logger.critical(
+                f'Unknown link "{link}". Please open a bug report.')
+
     def _show_licenses_dir(self):
         fp = bitlicense.DIR_LICENSES
 
@@ -196,20 +210,6 @@ class AboutDlg(QDialog):
                 f'Unable to open {fp} using "xdg-open". Please contact the '
                 'Back In Time team and report a bug.'
             )
-
-    def _slot_license_link_acivated(self, link):
-        if link == _HREF_LICENSES_MD:
-            self._show_licenses_md_file()
-
-        elif link == _HREF_LICENSES_DIR:
-            self._show_licenses_dir()
-
-        elif link == _HREF_SPDX_GPL:
-            qttools.open_url(bitlicense.URL_GPL_TWO)
-
-        else:
-            logger.critical(
-                f'Unknown link "{link}". Please open a bug report.')
 
     def _get_authors(self):
         fp = Path('/usr/share/doc') / bitbase.PACKAGE_NAME_CLI / 'AUTHORS'

--- a/qt/aboutdlg.py
+++ b/qt/aboutdlg.py
@@ -10,7 +10,6 @@
 # General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 """The About dialog."""
-import subprocess
 from pathlib import Path
 from PyQt6.QtWidgets import (QDialog,
                              QDialogButtonBox,
@@ -164,32 +163,53 @@ class AboutDlg(QDialog):
 
         return gpl
 
+    def _show_licenses_dir(self):
+        fp = bitlicense.DIR_LICENSES
+
+        if fp is None:
+            # Fallback to online resources
+            qttools.open_url(bitlicense.FALLBACK_DIR_LICENSES)
+            return
+
+        # systems default application
+        if not tools.xdg_open(str(fp)):
+            messagebox.critical(
+                self,
+                f'Unable to open {fp} using "xdg-open". Please contact the '
+                'Back In Time team and report a bug.'
+            )
+
+    def _show_licenses_md_file(self):
+        fp = bitlicense.DIR_LICENSES
+
+        if fp is None:
+            # Fallback to online resources
+            qttools.open_url(bitlicense.FALLBACK_LICENSES_MD)
+            return
+
+        fp = fp.parent / 'LICENSES.md'
+
+        # systems default application
+        if not tools.xdg_open(str(fp)):
+            messagebox.critical(
+                self,
+                f'Unable to open {fp} using "xdg-open". Please contact the '
+                'Back In Time team and report a bug.'
+            )
+
     def _slot_license_link_acivated(self, link):
-        if link in (_HREF_LICENSES_DIR, _HREF_LICENSES_MD):
-            fp = bitlicense.DIR_LICENSES
+        if link == _HREF_LICENSES_MD:
+            self._show_licenses_md_file()
 
-            if link == _HREF_LICENSES_MD:
-                fp = fp.parent / 'LICENSES.md'
+        elif link == _HREF_LICENSES_DIR:
+            self._show_licenses_dir()
 
-            if fp:
-                try:
-                    subprocess.run(['xdg-open', str(fp)], check=True)
-                except subprocess.CalledProcessError as exc:
-                    logger.critical(str(exc))
-                else:
-                    return
-
-            msg = f'Unable to find {fp}. Please contact the ' \
-                  'Back In Time team and report a bug.'
-            messagebox.critical(self, msg)
-            logger.critical(msg)
-            return
-
-        if link == _HREF_SPDX_GPL:
+        elif link == _HREF_SPDX_GPL:
             qttools.open_url(bitlicense.URL_GPL_TWO)
-            return
 
-        logger.critical(f'Unknown link "{link}". Please open a bug report.')
+        else:
+            logger.critical(
+                f'Unknown link "{link}". Please open a bug report.')
 
     def _get_authors(self):
         fp = Path('/usr/share/doc') / bitbase.PACKAGE_NAME_CLI / 'AUTHORS'

--- a/qt/manageprofiles/excludesuggestions.py
+++ b/qt/manageprofiles/excludesuggestions.py
@@ -29,7 +29,7 @@ Example:
         )
     }
 """
-EXCLUDE_SUGGESTIONS = {
+EXCLUDE_SUGGESTIONS = {  # pylint: disable=invalid-name
     _('Editor & Office temporary files'): (
         ['*~', _('Emacs backup files'), False],
         ['#*#', _('Emacs autosave files'), True],

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -442,12 +442,12 @@ def open_url(url: str) -> None:
         )
 
     except (subprocess.CalledProcessError, FileNotFoundError) as exc:
-        logger.error(f'Problem while opening "{url}" in as user '
+        logger.error(f'Problem while opening "{url}" as user '
                      f'"{user_name}" while in root-mode. '
                      f'Error was: {exc}')
 
     except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.critical(f'Unknown problem while opening "{url}" in as user '
+        logger.critical(f'Unknown problem while opening "{url}" as user '
                         f'"{user_name}" while in root-mode. '
                         f'Error was: {exc}')
 


### PR DESCRIPTION
Links to LICENSE.md file and LICENSES directory in about dialog will fallback to online resource.

Fix #2414