### PR TITLE
refactor: Timeline widget

### DIFF
--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2150,6 +2150,10 @@ class Snapshots:
         Returns:
             list:                   filtered list of :py:class:`SID` objects
         """
+        print(f'Snapshots.filter() :: {base_sid=} {base_path=} '
+              f'{snapshotsList=} {list_diff_only=} {flag_deep_check=} '
+              f'{list_equal_to=}')
+
         snapshotsFiltered = []
 
         base_full_path = base_sid.pathBackup(base_path)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2563,6 +2563,12 @@ class SID:
             raise TypeError("'date' must be an instance of str, datetime.date "
                             f"or datetime.datetime but is '{date}'")
 
+    def get_descriptor(self):
+        return self.sid
+
+    def get_timestamp(self):
+        return self.date
+
     def __repr__(self):
         return self.sid
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -3240,9 +3240,8 @@ class RootSnapshot(GenericNonSnapshot):
         Returns:
             str:                full snapshot path
         """
-
-        # return self.path('backup', *path, **kwargs)
         current_mode = self.config.snapshotsMode(self.profileID)
+
         if 'ssh_encfs' in use_mode and current_mode == 'ssh_encfs':
             if path:
                 path = self.config.ENCODE.remote(os.path.join(*path))

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2499,7 +2499,7 @@ class FileInfoDict(dict):
         super(FileInfoDict, self).__setitem__(key, value)
 
 
-class SID:
+class SID:  # -> "BackupID" will be its new name
     """
     Snapshot ID object used to gather all information for a snapshot
 
@@ -2518,6 +2518,14 @@ class SID:
         TypeError:              if ``date`` is not :py:class:`str`,
                                 :py:class:`datetime.date` or
                                 :py:class:`datetime.datetime` type
+
+    TODO dev note (2026-03 buhtz):
+    The class is doing to much. Path management and helper methods should go
+    elsewhere. Keep it dump. At its core it is a bakcup meta data class
+    encapsulate the meta data of one specific backup. BackupMetadata make sense
+    as name but is a bit to long. Maybe BackupID as a compromise? "self.sid"
+    will become "backup_descriptor", the identification string based on the
+    timestamp of that backup.
     """
     __cValidSID = re.compile(r'^\d{8}-\d{6}(?:-\d{3})?$')
 
@@ -3232,6 +3240,8 @@ class RootSnapshot(GenericNonSnapshot):
         Returns:
             str:                full snapshot path
         """
+
+        # return self.path('backup', *path, **kwargs)
         current_mode = self.config.snapshotsMode(self.profileID)
         if 'ssh_encfs' in use_mode and current_mode == 'ssh_encfs':
             if path:

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2132,6 +2132,10 @@ class Snapshots:
         ``base_path`` file is included and optional if the snapshot is unique
         or equal to ``list_equal_to``.
 
+        Dev note (buhtz, 2026-03): Purpose seems to be to get only these
+        backups which contain a specific path/file (the current selected in
+        fileview maybe).
+
         Args:
             base_sid (SID):         snapshot ID that contained the original
                                     file ``base_path``
@@ -2150,9 +2154,9 @@ class Snapshots:
         Returns:
             list:                   filtered list of :py:class:`SID` objects
         """
-        print(f'Snapshots.filter() :: {base_sid=} {base_path=} '
-              f'{snapshotsList=} {list_diff_only=} {flag_deep_check=} '
-              f'{list_equal_to=}')
+        # print(f'Snapshots.filter() :: {base_sid=} {base_path=} '
+        #       f'{snapshotsList=} {list_diff_only=} {flag_deep_check=} '
+        #       f'{list_equal_to=}')
 
         snapshotsFiltered = []
 
@@ -2160,7 +2164,14 @@ class Snapshots:
         if not os.path.lexists(base_full_path):
             return []
 
-        allSnapshotsList = [RootSnapshot(self.config)]
+        # Dev note (2026-03, buhtz): Keep in mind that "Now" will appear in
+        # each snapshots dialog because its timeline widget add it by
+        # default. But the related dir/file (base_path) might not be
+        # present anymore in "Now" but only in the backups.
+        # This will cause rare bugs. But we accepting this until refactoring.
+        # See https://github.com/bit-team/backintime/issues/2434
+        # allSnapshotsList = [RootSnapshot(self.config)]
+        allSnapshotsList = []
         allSnapshotsList.extend(snapshotsList)
 
         # links

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2521,7 +2521,7 @@ class SID:  # -> "BackupID" will be its new name
 
     TODO dev note (2026-03 buhtz):
     The class is doing to much. Path management and helper methods should go
-    elsewhere. Keep it dump. At its core it is a bakcup meta data class
+    elsewhere. Keep it dump. At its core it is a backup meta data class
     encapsulate the meta data of one specific backup. BackupMetadata make sense
     as name but is a bit to long. Maybe BackupID as a compromise? "self.sid"
     will become "backup_descriptor", the identification string based on the

--- a/qt/app.py
+++ b/qt/app.py
@@ -139,9 +139,6 @@ class MainWindow(QMainWindow):
 
         # timeline (left widget)
         self.timeline = timeline.TimeLine(self)
-        self.timeline.event_selection_changed.register(
-            self._on_timeline_selection_changed
-        )
 
         # right widget
         self.filesWidget = QGroupBox(self)
@@ -241,8 +238,6 @@ class MainWindow(QMainWindow):
                           .connect(self.comboProfileChanged)
 
         self.filesView.setFocus()
-
-        # self.updateSnapshotActions()
 
         self.timeline.event_now_selected.register([
             self._on_now_selected,
@@ -953,7 +948,6 @@ class MainWindow(QMainWindow):
 
         return label_now, label_backup
 
-
     def _files_view_toolbar(self):
         """Create the filesview toolbar object, connect it to actions and
         return it for later use.
@@ -1504,9 +1498,6 @@ class MainWindow(QMainWindow):
 
         self.filesWidget.setTitle(text)
 
-    def _on_timeline_selection_changed(self):
-        self.updateFilesView(2)
-
     # @pyqtSlot(int)
     def updateFilesView(self,
                         changed_from,
@@ -1568,7 +1559,9 @@ class MainWindow(QMainWindow):
 
         self.toolbar_filesview.setEnabled(enable_flag)
         self._enable_restore_ui_elements(enable_flag, self.path)
-        self.act_snapshots_dialog.setEnabled(enable_flag)
+        self.act_snapshots_dialog.setEnabled(
+            False if self.is_now_selected() else enable_flag
+        )
 
         # show current path
         self.widget_current_path.setText(self.path)
@@ -1604,36 +1597,6 @@ class MainWindow(QMainWindow):
                 _('Restore {path}').format(path=path))
             self.act_restore_parent_to.setText(
                 _('Restore {path} to …').format(path=path))
-
-
-    def fileSelected(self, fullPath=False):
-        """Return path and index of the currently in Files View highlighted
-        (selected) file.
-
-        Args:
-            fullPath(bool): Resolve relative to a full path.
-
-        Returns:
-            (tuple): Path as a string and the index.
-        """
-        model_index = self.filesView.currentIndex()
-
-        if model_index.column() > 0:
-            model_index = model_index.sibling(model_index.row(), 0)
-
-        selected_file = str(self.filesView.proxy.data(model_index))
-
-        if selected_file == '/':
-            # nothing is selected
-            selected_file = ''
-            model_index = self.filesView.proxy.mapFromSource(
-                self.filesView.model.index(self.path, 0))
-
-        if fullPath:
-            # resolve to full path
-            selected_file = os.path.join(self.path, selected_file)
-
-        return (selected_file, model_index)
 
     @contextmanager
     def suspend_mouse_button_navigation(self):
@@ -2066,7 +2029,7 @@ class MainWindow(QMainWindow):
             self.updateFilesView(0)
 
     def _slot_files_view_open_current_item(self):
-        path, _idx = self.fileSelected()
+        path = self.filesView.get_current_path()
 
         if not path:
             return
@@ -2113,18 +2076,14 @@ class MainWindow(QMainWindow):
         self.shutdown.activate_shutdown = checked
 
     def _slot_snapshots_dialog(self):
-        path, _idx = self.fileSelected(fullPath = True)
+        #  path = self.filesView.get_current_path()
+        # print(f'slot_snapshots_dialog() :: {path=} {self.path=}')
 
         with self.suspend_mouse_button_navigation():
-            # TODO: self.sid or "Now"
-            backup_id = self.selected_backup_id()
-            # WORKAROUND
-            if not backup_id:
-                backup_id = snapshots.RootSnapshot(self.config)
             dlg = snapshotsdialog.SnapshotsDialog(
                 self,
-                backup_id,
-                path
+                self.selected_backup_id(),
+                self.path
             )
 
             if dlg.exec() == QDialog.DialogCode.Accepted:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1370,7 +1370,7 @@ class MainWindow(QMainWindow):
         """Get a fresh list of backups/snapshots and initiate update of the
         timeline content with that list."""
 
-        previous_selection = self.selected_backup_descriptor()
+        previous_selection = self.timeline.selected_backup_descriptor()
 
         self.timeline.clear_and_reset()
 
@@ -1462,20 +1462,17 @@ class MainWindow(QMainWindow):
         rel_path = os.path.join(self.path, rel_path)
 
         if self.timeline.is_now_selected():
-            raise NotImplementedError('Check it out. Report as bug.')
+            full_path = rel_path
 
-        backup_id = self.selected_backup_id()
+        else:
+            backup_id = self.selected_backup_id()
 
-        if not backup_id:
-            raise RuntimeError(
-                'Should not happen. No backup_id means that "Now" is '
-                'selected. There should not be something else.'
-            )
+            if not backup_id.isExistingPathInsideSnapshotFolder(rel_path):
+                return
 
-        full_path = backup_id.pathBackup(rel_path)
+            full_path = backup_id.pathBackup(rel_path)
 
-        if (not backup_id.isExistingPathInsideSnapshotFolder(rel_path)
-                and not os.path.exists(full_path)):
+        if not os.path.exists(full_path):
             return
 
         if os.path.isdir(full_path):

--- a/qt/app.py
+++ b/qt/app.py
@@ -209,6 +209,7 @@ class MainWindow(QMainWindow):
         self.status_bar.set_status_message(_('Done'))
 
         self.snapshotsList = []
+        # ???
         self.sid = snapshots.RootSnapshot(self.config)
 
         # ???
@@ -260,6 +261,12 @@ class MainWindow(QMainWindow):
             target=self.config.setup_automation, daemon=True).start()
 
         self._handle_user_messages()
+
+    def get_selected_backup_descriptor(self) -> snapshots.SID:
+        """Return the identiy of the current selected backup in the timeline.
+        A replacement for self.sid
+        """
+        return self.timeline.current_backup_descriptor()
 
     def _setup_timers(self):
         raise_application = QTimer(self)
@@ -2013,6 +2020,7 @@ class MainWindow(QMainWindow):
         path, _idx = self.fileSelected(fullPath = True)
 
         with self.suspend_mouse_button_navigation():
+            # TODO: self.sid or "Now"
             dlg = snapshotsdialog.SnapshotsDialog(self, self.sid, path)
 
             if dlg.exec() == QDialog.DialogCode.Accepted:

--- a/qt/app.py
+++ b/qt/app.py
@@ -2080,13 +2080,12 @@ class MainWindow(QMainWindow):
         # print(f'slot_snapshots_dialog() :: {path=} {self.path=}')
 
         with self.suspend_mouse_button_navigation():
-            dlg = snapshotsdialog.SnapshotsDialog(
-                self,
-                self.selected_backup_id(),
-                self.path
-            )
+            backup_id = self.selected_backup_id()
+            dlg = snapshotsdialog.SnapshotsDialog(self, backup_id, self.path)
 
             if dlg.exec() == QDialog.DialogCode.Accepted:
+                # ToDo: MainWindow (or its timeline) should describe to the
+                # dialogs event_backup_selected
                 if dlg.sid != backup_id:
                     self.timeline.select_by_descriptor(
                         dlg.sid.get_descriptor()

--- a/qt/app.py
+++ b/qt/app.py
@@ -18,6 +18,7 @@ if not os.getenv('DISPLAY', ''):
 import pathlib
 import json
 import threading
+import queue
 import shutil
 import textwrap
 import signal
@@ -1339,18 +1340,52 @@ class MainWindow(QMainWindow):
         """Initiate update of the timeline content"""
         self.timeline.clear_and_reset()
 
-        if refreshSnapshotsList:
-            self.snapshotsList = []
-            thread = FillTimeLineThread(self)
-            thread.addSnapshot.connect(self.timeline.addSnapshot)
-            # Select "Now" if previous backup item is goe
-            thread.finished.connect(self.timeline.checkSelection)
-            thread.start()
-
-        else:
+        if not refreshSnapshotsList:
             for sid in self.snapshotsList:
-                self.timeline.addSnapshot(sid)
+                self.timeline.create_backup_entry(
+                    descriptor=sid.get_descriptor(),
+                    tiemstamp=sid.get_timestamp(),
+                    last_checked=sid.lastChecked,
+                    label=sid.displayName
+                )
+            # ??? useless I think
             self.timeline.checkSelection()
+            return
+
+        self.snapshotsList = []  # TODO: -> backup_list ???
+        backup_queue = queue.Queue()
+
+        def _worker():
+            for sid in snapshots.iterSnapshots(self.config):
+                self.snapshotsList.append(sid)
+                backup_queue.put(
+                    (
+                        sid.get_descriptor(),
+                        sid.get_timestamp(),
+                        sid.lastChecked,
+                        sid.displayName
+                    )
+                )
+            backup_queue.put(None)  # Finished signal
+
+        threading.Thread(target=_worker, daemon=True).start()
+
+        def _process_queue():
+            while not backup_queue.empty():
+                entry = backup_queue.get()
+                if entry is None:
+                    self.timeline.checkSelection()
+                    return
+
+                self.timeline.create_backup_entry(
+                    descriptor=entry[0],
+                    timestamp=entry[1],
+                    last_checked=entry[2],
+                    label=entry[3]
+                )
+
+        QTimer.singleShot(250, _process_queue)
+
 
     def _create_temporary_copy(self, full_path: str, sid=None):
         """Create a temporary local copy a file or directory.
@@ -2250,23 +2285,23 @@ class RemoveSnapshotThread(QThread):
                     snapshots.lastSnapshot(self.config))
 
 
-class FillTimeLineThread(QThread):
-    """
-    add snapshot IDs to timeline in background
-    """
-    addSnapshot = pyqtSignal(snapshots.SID)
+# class FillTimeLineThread(QThread):
+#     """
+#     add snapshot IDs to timeline in background
+#     """
+#     addSnapshot = pyqtSignal(snapshots.SID)
 
-    def __init__(self, parent):
-        self.parent = parent
-        self.config = parent.config
-        super(FillTimeLineThread, self).__init__(parent)
+#     def __init__(self, parent):
+#         self.parent = parent
+#         self.config = parent.config
+#         super(FillTimeLineThread, self).__init__(parent)
 
-    def run(self):
-        for sid in snapshots.iterSnapshots(self.config):
-            self.addSnapshot.emit(sid)
-            self.parent.snapshotsList.append(sid)
+#     def run(self):
+#         for sid in snapshots.iterSnapshots(self.config):
+#             self.addSnapshot.emit(sid)
+#             self.parent.snapshotsList.append(sid)
 
-        self.parent.snapshotsList.sort()
+#         self.parent.snapshotsList.sort()
 
 
 def _get_state_data_from_config(cfg: config.Config) -> StateData:

--- a/qt/app.py
+++ b/qt/app.py
@@ -69,6 +69,7 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import (
                           QPoint,
                           pyqtSignal,
+                          QSignalBlocker,
                           Qt,
                           QTimer,
                           QThread,
@@ -78,6 +79,7 @@ import logviewdialog
 import languagedialog
 import messagebox
 import version
+import timeline
 from confirmrestoredialog import ConfirmRestoreDialog
 from editusercallback import EditUserCallback
 from shutdownagent import ShutdownAgent
@@ -86,7 +88,6 @@ from restoredialog import RestoreDialog
 from restoreconfigdialog import RestoreConfigDialog
 from usermessagedialog import UserMessageDialog
 from aboutdlg import AboutDlg
-from timeline import TimeLine, SnapshotItem
 from bitwidgets import ProfileCombo
 from shutdowndlg import get_shutdown_confirmation
 from statusbar import StatusBar
@@ -139,7 +140,7 @@ class MainWindow(QMainWindow):
         self._create_main_toolbar()
 
         # timeline (left widget)
-        self.timeline = TimeLine(self)
+        self.timeline = timeline.TimeLine(self)
         self.timeline.event_selection_changed.register(
             self._on_timeline_selection_changed
         )
@@ -1325,8 +1326,7 @@ class MainWindow(QMainWindow):
 
     def _on_now_selected(self):
         self._enable_snapshot_actions(False)
-        # Workaround
-        self.sid = self.timeline.get_now_sid()
+        # self.sid = self.timeline.get_now_sid()
         # IDEE: sid should stay in the timeline and nowhere else
         self.updateFilesView(2)
 
@@ -1337,8 +1337,7 @@ class MainWindow(QMainWindow):
 
     def updateTimeLine(self, refreshSnapshotsList=True):
         """Initiate update of the timeline content"""
-        self.timeline.clear()
-        self.timeline.add_root(snapshots.RootSnapshot(self.config))
+        self.timeline.clear_and_rebuild_header()
 
         if refreshSnapshotsList:
             self.snapshotsList = []
@@ -1410,11 +1409,11 @@ class MainWindow(QMainWindow):
             QDesktopServices.openUrl(file_url)
 
     def _update_files_widget(self):
-        if self.sid.isRoot:
+        if self.timeline.is_now_selected():
             text = _('Now')
 
         else:
-            name = self.sid.displayName
+            name = self.timeline.current_backup_label()
             # buhtz (2023-07)3 blanks at the end of that string as a
             # workaround to a visual issue where the last character was
             # cutoff. Not sure if this is DE and/or theme related.
@@ -2222,7 +2221,7 @@ class RemoveSnapshotThread(QThread):
     remove snapshots in background thread so GUI will not freeze
     """
     refreshSnapshotList = pyqtSignal()
-    hideTimelineItem = pyqtSignal(SnapshotItem)
+    hideTimelineItem = pyqtSignal(timeline.BackupEntry)
 
     def __init__(self, parent, items):
         self.config = parent.config

--- a/qt/app.py
+++ b/qt/app.py
@@ -246,11 +246,11 @@ class MainWindow(QMainWindow):
 
         # self.updateSnapshotActions()
 
-        self.timeline.event_now_item_selected.register([
+        self.timeline.event_now_selected.register([
             self._on_now_selected,
             self.places.on_now_selected,
         ])
-        self.timeline.event_backup_item_selected.register([
+        self.timeline.event_backup_selected.register([
             self._on_backup_selected,
             self.places.on_backup_changed
         ])
@@ -1532,8 +1532,6 @@ class MainWindow(QMainWindow):
                     break
 
         self._update_files_widget()
-
-        # update files view
 
         backup_id = self.selected_backup_id()
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -51,8 +51,7 @@ from PyQt6.QtGui import (QAction,
                          QDesktopServices,
                          QIcon,
                          QShortcut)
-from PyQt6.QtWidgets import (
-                             QApplication,
+from PyQt6.QtWidgets import (QApplication,
                              QDialog,
                              QFrame,
                              QGroupBox,
@@ -67,10 +66,8 @@ from PyQt6.QtWidgets import (
                              QToolButton,
                              QVBoxLayout,
                              QWidget)
-from PyQt6.QtCore import (
-                          QPoint,
+from PyQt6.QtCore import (QPoint,
                           pyqtSignal,
-                          QSignalBlocker,
                           Qt,
                           QTimer,
                           QThread,
@@ -1354,7 +1351,7 @@ class MainWindow(QMainWindow):
         # IDEE: sid should stay in the timeline and nowhere else
         self.updateFilesView(2)
 
-    def _on_backup_selected(self, sid):
+    def _on_backup_selected(self, _sid):
         self._enable_snapshot_actions(True)
         # self.sid = sid
         self.updateFilesView(2)
@@ -1368,7 +1365,7 @@ class MainWindow(QMainWindow):
         for sid in self.snapshotsList:
             self.timeline.create_backup_entry(
                 descriptor=sid.get_descriptor(),
-                tiemstamp=sid.get_timestamp(),
+                timestamp=sid.get_timestamp(),
                 last_checked=sid.lastChecked,
                 label=sid.displayName
             )

--- a/qt/app.py
+++ b/qt/app.py
@@ -1055,7 +1055,7 @@ class MainWindow(QMainWindow):
         self.disableProfileChanged = False
 
     def updateProfile(self):
-        self.updateTimeLine()
+        self.rebuild_timeline()
         self.places.do_update()
         self._update_files_widget()
         self.updateFilesView(0)
@@ -1174,7 +1174,7 @@ class MainWindow(QMainWindow):
 
             if snapshotsList != self.snapshotsList:
                 self.snapshotsList = snapshotsList
-                self.updateTimeLine(False)
+                self._rebuild_timeline_without_refresh()
                 takeSnapshotMessage = (0, _('Done'))
             else:
                 if takeSnapshotMessage[0] == 0:
@@ -1336,26 +1336,33 @@ class MainWindow(QMainWindow):
         self.sid = sid
         self.updateFilesView(2)
 
-    def updateTimeLine(self, refreshSnapshotsList=True):
-        """Initiate update of the timeline content"""
+    def _rebuild_timeline_without_refresh(self):
+        """Initiate recreation of the timeline content based on the existing
+        list of backups/snapshots without refreshing the snapshot list via
+        a thread."""
         self.timeline.clear_and_reset()
 
-        if not refreshSnapshotsList:
-            for sid in self.snapshotsList:
-                self.timeline.create_backup_entry(
-                    descriptor=sid.get_descriptor(),
-                    tiemstamp=sid.get_timestamp(),
-                    last_checked=sid.lastChecked,
-                    label=sid.displayName
-                )
-            # ??? useless I think
-            self.timeline.checkSelection()
-            return
+        for sid in self.snapshotsList:
+            self.timeline.create_backup_entry(
+                descriptor=sid.get_descriptor(),
+                tiemstamp=sid.get_timestamp(),
+                last_checked=sid.lastChecked,
+                label=sid.displayName
+            )
+        # ??? useless I think
+        self.timeline.checkSelection()
+
+    def rebuild_timeline(self):
+        """Get a fresh list of backups/snapshots and initiate update of the
+        timeline content with that list."""
+        self.timeline.clear_and_reset()
 
         self.snapshotsList = []  # TODO: -> backup_list ???
         backup_queue = queue.Queue()
 
         def _worker():
+            """Proceed all backups and put their timline related information
+            into a thread-safe queue."""
             for sid in snapshots.iterSnapshots(self.config):
                 self.snapshotsList.append(sid)
                 backup_queue.put(
@@ -1368,9 +1375,8 @@ class MainWindow(QMainWindow):
                 )
             backup_queue.put(None)  # Finished signal
 
-        threading.Thread(target=_worker, daemon=True).start()
-
         def _process_queue():
+            """Read backup data from the queue and add them to the timeline"""
             while not backup_queue.empty():
                 entry = backup_queue.get()
                 if entry is None:
@@ -1384,6 +1390,10 @@ class MainWindow(QMainWindow):
                     label=entry[3]
                 )
 
+        # Start getting backups
+        threading.Thread(target=_worker, daemon=True).start()
+
+        # Start updating the timeline widget with backups
         QTimer.singleShot(250, _process_queue)
 
 
@@ -2020,7 +2030,7 @@ class MainWindow(QMainWindow):
     # | some more Slots |
     # |-----------------|
     def _slot_timeline_refresh(self):
-        self.updateTimeLine()
+        self.rebuild_timeline()
         self.updateFilesView(2)
 
     def _slot_backup_open_last_log(self):
@@ -2125,7 +2135,7 @@ class MainWindow(QMainWindow):
                 self.timeline.select_root_item()
 
         thread = RemoveSnapshotThread(self, items)
-        thread.refreshSnapshotList.connect(self.updateTimeLine)
+        thread.refreshSnapshotList.connect(self.rebuild_timeline)
         thread.hideTimelineItem.connect(hideItem)
         thread.start()
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -262,7 +262,7 @@ class MainWindow(QMainWindow):
         self._handle_user_messages()
 
     def selected_backup_id(self) -> snapshots.SID | None:
-        """Return the identiy of the backup that is currently selected in the
+        """Return the identity of the backup that is currently selected in the
         timeline widget.
         """
         backup_descriptor = self.timeline.selected_backup_descriptor()

--- a/qt/app.py
+++ b/qt/app.py
@@ -210,8 +210,6 @@ class MainWindow(QMainWindow):
         self.status_bar.set_status_message(_('Done'))
 
         self.snapshotsList = []
-        # ???
-        # self.sid = snapshots.RootSnapshot(self.config)
 
         # ???
         self.path = self.config.profileStrValue('qt.last_path', '/')
@@ -1347,34 +1345,33 @@ class MainWindow(QMainWindow):
 
     def _on_now_selected(self):
         self._enable_snapshot_actions(False)
-        # self.sid = self.timeline.get_now_sid()
-        # IDEE: sid should stay in the timeline and nowhere else
         self.updateFilesView(2)
 
     def _on_backup_selected(self, _sid):
         self._enable_snapshot_actions(True)
-        # self.sid = sid
         self.updateFilesView(2)
 
     def _rebuild_timeline_without_refresh(self):
         """Initiate recreation of the timeline content based on the existing
         list of backups/snapshots without refreshing the snapshot list via
         a thread."""
-        self.timeline.clear_and_reset()
+        with self.timeline.preserve_selection():
+            self.timeline.clear_and_reset()
 
-        for sid in self.snapshotsList:
-            self.timeline.create_backup_entry(
-                descriptor=sid.get_descriptor(),
-                timestamp=sid.get_timestamp(),
-                last_checked=sid.lastChecked,
-                label=sid.displayName
-            )
-        # ??? useless I think
-        self.timeline.checkSelection()
+            for sid in self.snapshotsList:
+                self.timeline.create_backup_entry(
+                    descriptor=sid.get_descriptor(),
+                    timestamp=sid.get_timestamp(),
+                    last_checked=sid.lastChecked,
+                    label=sid.displayName
+                )
 
     def rebuild_timeline(self):
         """Get a fresh list of backups/snapshots and initiate update of the
         timeline content with that list."""
+
+        previous_selection = self.selected_backup_descriptor()
+
         self.timeline.clear_and_reset()
 
         self.snapshotsList = []  # TODO: -> backup_list ???
@@ -1396,11 +1393,25 @@ class MainWindow(QMainWindow):
             backup_queue.put(None)  # Finished signal
 
         def _process_queue():
-            """Read backup data from the queue and add them to the timeline"""
-            while not backup_queue.empty():
-                entry = backup_queue.get()
+            """Read backup data from the queue and add them to the timeline.
+
+            The queue processing is finished when the sentinel value `None` is
+            received.
+            """
+            while True:
+                try:
+                    entry = backup_queue.get_nowait()
+                except queue.Empty:
+                    # Queue is empty (but not finished). Try again later.
+                    QTimer.singleShot(100, _process_queue)
+                    return
+
+                # Queue finished?
                 if entry is None:
-                    self.timeline.checkSelection()
+                    if previous_selection:
+                        self.timeline.select_by_descriptor(previous_selection)
+                    else:
+                        self.timeline.select_now()
                     return
 
                 self.timeline.create_backup_entry(
@@ -1415,7 +1426,6 @@ class MainWindow(QMainWindow):
 
         # Start updating the timeline widget with backups
         QTimer.singleShot(250, _process_queue)
-
 
     def _create_temporary_copy(self, full_path: str, sid=None):
         """Create a temporary local copy a file or directory.

--- a/qt/app.py
+++ b/qt/app.py
@@ -1352,6 +1352,7 @@ class MainWindow(QMainWindow):
         with self.timeline.preserve_selection():
             self.timeline.clear_and_reset()
 
+            # pylint: disable-next=duplicate-code
             for sid in self.snapshotsList:
                 self.timeline.create_backup_entry(
                     descriptor=sid.get_descriptor(),

--- a/qt/app.py
+++ b/qt/app.py
@@ -214,7 +214,7 @@ class MainWindow(QMainWindow):
 
         self.snapshotsList = []
         # ???
-        self.sid = snapshots.RootSnapshot(self.config)
+        # self.sid = snapshots.RootSnapshot(self.config)
 
         # ???
         self.path = self.config.profileStrValue('qt.last_path', '/')
@@ -255,7 +255,7 @@ class MainWindow(QMainWindow):
         ])
         self.timeline.event_backup_item_selected.register([
             self._on_backup_selected,
-            # self.on_backup_changed,
+            self.places.on_backup_changed
         ])
 
         self.forceWaitLockCounter = 0
@@ -266,11 +266,15 @@ class MainWindow(QMainWindow):
 
         self._handle_user_messages()
 
-    def get_selected_backup_descriptor(self) -> snapshots.SID:
-        """Return the identiy of the current selected backup in the timeline.
-        A replacement for self.sid
+    def selected_backup_id(self) -> snapshots.SID | None:
+        """Return the identiy of the backup that is currently selected in the
+        timeline widget.
         """
-        return self.timeline.current_backup_descriptor()
+        backup_descriptor = self.timeline.selected_backup_descriptor()
+        if not backup_descriptor:
+            return None
+
+        return snapshots.SID(date=backup_descriptor, cfg=self.config)
 
     def _setup_timers(self):
         raise_application = QTimer(self)
@@ -1340,6 +1344,10 @@ class MainWindow(QMainWindow):
         self.act_remove_snapshot.setEnabled(enable)
         self.act_snapshot_logview.setEnabled(enable)
 
+    def is_now_selected(self) -> bool:
+        """Workaround"""
+        return self.timeline.is_now_selected()
+
     def _on_now_selected(self):
         self._enable_snapshot_actions(False)
         # self.sid = self.timeline.get_now_sid()
@@ -1348,7 +1356,7 @@ class MainWindow(QMainWindow):
 
     def _on_backup_selected(self, sid):
         self._enable_snapshot_actions(True)
-        self.sid = sid
+        # self.sid = sid
         self.updateFilesView(2)
 
     def _rebuild_timeline_without_refresh(self):
@@ -1445,35 +1453,45 @@ class MainWindow(QMainWindow):
 
     def _open_path(self, rel_path: str):
         rel_path = os.path.join(self.path, rel_path)
-        full_path = self.sid.pathBackup(rel_path)
 
-        # The class "GenericNonSnapshot" indicates that "Now" is selected
-        # in the snapshots timeline widget.
-        if (os.path.exists(full_path)
-            and (isinstance(self.sid, snapshots.GenericNonSnapshot)  # "Now"
-                 or self.sid.isExistingPathInsideSnapshotFolder(rel_path))):
+        if self.timeline.is_now_selected():
+            raise NotImplementedError('Check it out')
 
-            if os.path.isdir(full_path):
-                self.path = rel_path
-                self.path_history.append(rel_path)
-                self.updateFilesView(0)
+        backup_id = self.selected_backup_id()
 
-                return
+        if not backup_id:
+            raise RuntimeError(
+                'Should happen. No backup_id means that "Now" is selected. '
+                'There should not be something else.'
+            )
 
-            # prevent backup data from being accidentally overwritten
-            # by create a temporary local copy and only open that one
-            if not isinstance(self.sid, snapshots.RootSnapshot):
-                full_path = self._create_temporary_copy(full_path, self.sid)
+        full_path = backup_id.pathBackup(rel_path)
 
-            file_url = QUrl('file://' + full_path)
-            QDesktopServices.openUrl(file_url)
+        if (not backup_id.isExistingPathInsideSnapshotFolder(rel_path)
+                and not os.path.exists(full_path)):
+            return
+
+        if os.path.isdir(full_path):
+            self.path = rel_path
+            self.path_history.append(rel_path)
+            self.updateFilesView(0)
+
+            return
+
+        # prevent backup data from being accidentally overwritten
+        # by create a temporary local copy and only open that one
+        if not self.timeline.is_now_selected():
+            full_path = self._create_temporary_copy(full_path, backup_id)
+
+        file_url = QUrl('file://' + full_path)
+        QDesktopServices.openUrl(file_url)
 
     def _update_files_widget(self):
         if self.timeline.is_now_selected():
             text = _('Now')
 
         else:
-            name = self.timeline.current_backup_label()
+            name = self.timeline.selected_backup_label()
             # buhtz (2023-07)3 blanks at the end of that string as a
             # workaround to a visual issue where the last character was
             # cutoff. Not sure if this is DE and/or theme related.
@@ -1519,7 +1537,17 @@ class MainWindow(QMainWindow):
         self._update_files_widget()
 
         # update files view
-        full_path = self.sid.pathBackup(self.path)
+
+        backup_id = self.selected_backup_id()
+
+        if backup_id:
+            full_path = backup_id.pathBackup(self.path)
+        else:
+            # Dev note (2026-03, buhtz): Dirty WORKAROUND.
+            # RootSnapshot need to be deleted. Its features
+            # might go into ProfileOperations
+            root_now_sid = snapshots.RootSnapshot(self.config)
+            full_path = root_now_sid.pathBackup(self.path)
 
         # Dev note: Places (and timeline) should emit a select change event.
         # the handler in mainwindow than should decide about enable or disable
@@ -1920,7 +1948,7 @@ class MainWindow(QMainWindow):
                 return
 
         rd = RestoreDialog(self,
-                           self.sid,
+                           self.selected_backup_id(),
                            paths if len(paths) > 1 else paths[0],
                            path_restore_to,
                            **opt)
@@ -1928,7 +1956,7 @@ class MainWindow(QMainWindow):
         rd.exec()
 
     def _slot_restore_this(self):
-        if self.sid.isRoot:
+        if self.is_now_selected():
             return
 
         paths = self.filesView.get_selected_paths()
@@ -1954,7 +1982,7 @@ class MainWindow(QMainWindow):
 
         rd = RestoreDialog(
             parent=self,
-            sid=self.sid,
+            sid=self.selected_backup_id(),
             what=paths,
             **opt)
         rd.exec()
@@ -1968,7 +1996,7 @@ class MainWindow(QMainWindow):
         self._restore_to(paths)
 
     def _slot_restore_parent(self):
-        if self.sid.isRoot:
+        if self.is_now_selected():
             return
 
         confirm_dlg = ConfirmRestoreDialog(
@@ -1989,12 +2017,12 @@ class MainWindow(QMainWindow):
                     warnRoot=self.path == '/'):
                 return
 
-        rd = RestoreDialog(self, self.sid, self.path, **opt)
+        rd = RestoreDialog(self, self.selected_backup_id(), self.path, **opt)
         rd.exec()
 
     def _slot_restore_parent_to(self):
         """Restore parent folder (of current selected) to ..."""
-        if self.sid.isRoot:
+        if self.is_now_selected():
             return
 
         self._restore_to([self.path])
@@ -2023,10 +2051,15 @@ class MainWindow(QMainWindow):
         self._dir_history(self.path_history.next())
 
     def _dir_history(self, path):
-        full_path = self.sid.pathBackup(path)
+        backup_id = self.selected_backup_id()
+
+        if backup_id is None:
+            raise NotImplementedError('Now is selected!?')
+
+        full_path = backup_id.pathBackup(path)
 
         if (os.path.isdir(full_path)
-                and self.sid.isExistingPathInsideSnapshotFolder(path)):
+                and backup_id.isExistingPathInsideSnapshotFolder(path)):
             self.path = path
             self.updateFilesView(0)
 
@@ -2082,12 +2115,21 @@ class MainWindow(QMainWindow):
 
         with self.suspend_mouse_button_navigation():
             # TODO: self.sid or "Now"
-            dlg = snapshotsdialog.SnapshotsDialog(self, self.sid, path)
+            backup_id = self.selected_backup_id()
+            # WORKAROUND
+            if not backup_id:
+                backup_id = snapshots.RootSnapshot(self.config)
+            dlg = snapshotsdialog.SnapshotsDialog(
+                self,
+                backup_id,
+                path
+            )
 
             if dlg.exec() == QDialog.DialogCode.Accepted:
-
-                if dlg.sid != self.sid:
-                    self.timeline.set_current_snapshot_id(dlg.sid)
+                if dlg.sid != backup_id:
+                    self.timeline.select_by_descriptor(
+                        dlg.sid.get_descriptor()
+                    )
 
     def _slot_backup_name(self):
         item = self.timeline.currentItem()

--- a/qt/app.py
+++ b/qt/app.py
@@ -1462,14 +1462,14 @@ class MainWindow(QMainWindow):
         rel_path = os.path.join(self.path, rel_path)
 
         if self.timeline.is_now_selected():
-            raise NotImplementedError('Check it out')
+            raise NotImplementedError('Check it out. Report as bug.')
 
         backup_id = self.selected_backup_id()
 
         if not backup_id:
             raise RuntimeError(
-                'Should happen. No backup_id means that "Now" is selected. '
-                'There should not be something else.'
+                'Should not happen. No backup_id means that "Now" is '
+                'selected. There should not be something else.'
             )
 
         full_path = backup_id.pathBackup(rel_path)
@@ -2357,25 +2357,6 @@ class RemoveSnapshotThread(QThread):
             if renew_last_snapshot:
                 self.snapshots.createLastSnapshotSymlink(
                     snapshots.lastSnapshot(self.config))
-
-
-# class FillTimeLineThread(QThread):
-#     """
-#     add snapshot IDs to timeline in background
-#     """
-#     addSnapshot = pyqtSignal(snapshots.SID)
-
-#     def __init__(self, parent):
-#         self.parent = parent
-#         self.config = parent.config
-#         super(FillTimeLineThread, self).__init__(parent)
-
-#     def run(self):
-#         for sid in snapshots.iterSnapshots(self.config):
-#             self.addSnapshot.emit(sid)
-#             self.parent.snapshotsList.append(sid)
-
-#         self.parent.snapshotsList.sort()
 
 
 def _get_state_data_from_config(cfg: config.Config) -> StateData:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1337,7 +1337,7 @@ class MainWindow(QMainWindow):
 
     def updateTimeLine(self, refreshSnapshotsList=True):
         """Initiate update of the timeline content"""
-        self.timeline.clear_and_rebuild_header()
+        self.timeline.clear_and_reset()
 
         if refreshSnapshotsList:
             self.snapshotsList = []

--- a/qt/app.py
+++ b/qt/app.py
@@ -183,9 +183,11 @@ class MainWindow(QMainWindow):
         self.stackFilesView = QStackedLayout(widget)
         self.secondSplitter.addWidget(widget)
 
-        # directory don't exist label
-        self._label_not_a_dir = self._label_dir_dont_exist()
-        self.stackFilesView.addWidget(self._label_not_a_dir)
+        # label: directory don't exist
+        self._label_not_a_now_dir, self._label_not_a_backup_dir \
+            = self._label_dir_dont_exist()
+        self.stackFilesView.addWidget(self._label_not_a_now_dir)
+        self.stackFilesView.addWidget(self._label_not_a_backup_dir)
 
         # files view
         sort_column, sort_order = state_data.files_view_sorting
@@ -927,18 +929,31 @@ class MainWindow(QMainWindow):
         toolbar.insertSeparator(self.act_settings)
         toolbar.insertSeparator(self.act_shutdown)
 
-    def _label_dir_dont_exist(self) -> QLabel:
-        label = QLabel('<strong>{}</strong>'.format(
-            _("This directory doesn't exist\n"
-              "in the current selected backup.")),
-            self)
+    def _label_dir_dont_exist(self) -> tuple[QLabel, QLabel]:
+        """The labels will replace the filesview if a directory, selected
+        in the places widget, does not exist in the backup (if selected) or
+        the current file system ("Now" is selected).
+        """
+        def _setup_label(label_text: str) -> QLabel:
+            label = QLabel(f'<strong>{label_text}</strong>', self)
+            label.setWordWrap(True)
 
-        label.setFrameShadow(QFrame.Shadow.Sunken)
-        label.setFrameShape(QFrame.Shape.Panel)
-        label.setAlignment(
-            Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter)
+            label.setFrameShadow(QFrame.Shadow.Sunken)
+            label.setFrameShape(QFrame.Shape.Panel)
+            label.setAlignment(
+                Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignVCenter)
 
-        return label
+            return label
+
+        label_backup = _setup_label(_(
+            "This directory doesn't exist in the selected backup."
+        ))
+        label_now = _setup_label(_(
+            "This directory doesn't exist on the computer."
+        ))
+
+        return label_now, label_backup
+
 
     def _files_view_toolbar(self):
         """Create the filesview toolbar object, connect it to actions and
@@ -1510,18 +1525,20 @@ class MainWindow(QMainWindow):
         # the handler in mainwindow than should decide about enable or disable
         # all this other UI elements.
         if os.path.isdir(full_path):
+            enable_flag = True
             self.filesView.show_hidden(self.showHiddenFiles)
             self.filesView.set_root_path(full_path)
-            enable_flag = True
+            self.stackFilesView.setCurrentWidget(self.filesView)
         else:
             enable_flag = False
+            self.stackFilesView.setCurrentWidget(
+                self._label_not_a_now_dir if self.timeline.is_now_selected()
+                else self._label_not_a_backup_dir
+            )
 
         self.toolbar_filesview.setEnabled(enable_flag)
         self._enable_restore_ui_elements(enable_flag, self.path)
         self.act_snapshots_dialog.setEnabled(enable_flag)
-        self.stackFilesView.setCurrentWidget(
-            self.filesView if enable_flag else self._label_not_a_dir
-        )
 
         # show current path
         self.widget_current_path.setText(self.path)

--- a/qt/event.py
+++ b/qt/event.py
@@ -48,6 +48,7 @@ class Event:
     Inspired by discussion and code in
     https://stackoverflow.com/a/48339861/4865723
     """
+
     def __init__(self):
         self._callbacks = []
 

--- a/qt/fileview.py
+++ b/qt/fileview.py
@@ -155,6 +155,8 @@ class FilesView(QTreeView):
             )
 
     def set_root_path(self, path: str):
+        # self.selectionModel().clear()
+
         # model: path to read from
         model_index = self.model.setRootPath(path)
         proxy_model_index = self.proxy.mapFromSource(model_index)
@@ -217,6 +219,12 @@ class FilesView(QTreeView):
         for path in paths:
             src_idx = self.model.index(path)
             proxy_idx = self.proxy.mapFromSource(src_idx)
+
+            if not proxy_idx.isValid():
+                # Don't select if it isn't visible
+                print(f'dont select ::{path=}')
+                continue
+
             self.selectionModel().select(proxy_idx, flag)
 
     def show_hidden(self, show: bool):
@@ -224,7 +232,10 @@ class FilesView(QTreeView):
             self.proxy.show_hidden(show)
 
     def get_selected_paths(self) -> list[str]:
+        """All selected paths
 
+        Returns: Path list as strings
+        """
         selection = []
 
         for proxy_idx in self.selectionModel().selectedRows(0):
@@ -232,21 +243,26 @@ class FilesView(QTreeView):
             path = self.model.filePath(src_idx)
             selection.append(path)
 
-        # # ???
-        # if len(selection) == 0:
-        #     # Does it mean to return the current path instead of nothing?
-        #     raise RuntimeError(
-        #         'FilesView.multiFileSelected() nothing selected, not count')
-
-        #     # # nothing is selected
-        #     # idx = self.proxy.mapFromSource(
-        #     #     self.model.index(self.path, 0))
-
-        #     # selected_file = self.path if fullPath else ''
-
-        #     # yield (selected_file, idx)
-
         return selection
+
+    def get_current_path(self) -> str | None:
+        """Current selcted path.
+
+        Returns: The path as string.
+        """
+        proxy_idx = self.selectionModel().currentIndex()
+
+        if not proxy_idx.isValid():
+            return None
+
+        src_idx = self.proxy.mapToSource(proxy_idx)
+
+        # visible in proxy?
+        if self.proxy.mapFromSource(src_idx) != proxy_idx:
+            # no it is hidden
+            return None
+
+        return self.model.filePath(src_idx)
 
     def _slot_context_menu(self, point):
         self._context_menu.exec(self.mapToGlobal(point))

--- a/qt/fileview.py
+++ b/qt/fileview.py
@@ -222,7 +222,6 @@ class FilesView(QTreeView):
 
             if not proxy_idx.isValid():
                 # Don't select if it isn't visible
-                print(f'dont select ::{path=}')
                 continue
 
             self.selectionModel().select(proxy_idx, flag)

--- a/qt/fileview.py
+++ b/qt/fileview.py
@@ -246,7 +246,7 @@ class FilesView(QTreeView):
         return selection
 
     def get_current_path(self) -> str | None:
-        """Current selcted path.
+        """Current selected path.
 
         Returns: The path as string.
         """

--- a/qt/manageprofiles/tab_exclude.py
+++ b/qt/manageprofiles/tab_exclude.py
@@ -370,7 +370,7 @@ class ExcludeTab(QWidget):
         self._remove_entries(unchecked)
 
     def _remove_entries(self, entries: list[str]) -> None:
-        """Remove entries from the exlucde list if existent."""
+        """Remove entries from the exclude list if existent."""
         for entry in entries:
             # find item
             items = self.list_exclude.findItems(entry, MATCH_FLAGS)

--- a/qt/placeswidget.py
+++ b/qt/placeswidget.py
@@ -103,6 +103,7 @@ class PlacesWidget(QTreeWidget):
             str(fp_home),
             'user-home')
 
+        # formally known as self.sid
         backup_id = self.parent.selected_backup_id()
 
         # "Now" or a specific snapshot selected?
@@ -114,9 +115,6 @@ class PlacesWidget(QTreeWidget):
             # Dev note (2026-03): I wonder why this is needed. Isn't the
             # profile config stored within each backup. Why not parse
             # that config file instead of scanning the real filesystem?
-
-            # formally known as self.sid
-            backup_id = self.parent.selected_backup_id()
 
             # Determine directories from the backup itself
             base = os.path.expanduser('~')

--- a/qt/placeswidget.py
+++ b/qt/placeswidget.py
@@ -115,7 +115,7 @@ class PlacesWidget(QTreeWidget):
             # profile config stored within each backup. Why not parse
             # that config file instead of scanning the real filesystem?
 
-            # formaly known as self.sid
+            # formally known as self.sid
             backup_id = self.parent.selected_backup_id()
 
             # Determine directories from the backup itself

--- a/qt/placeswidget.py
+++ b/qt/placeswidget.py
@@ -16,12 +16,11 @@
 """
 import os
 import pathlib
-from PyQt6.QtWidgets import (
-                             QAbstractItemView,
+from typing import Optional
+from PyQt6.QtWidgets import (QAbstractItemView,
                              QTreeWidget,
                              QTreeWidgetItem,
-                             QWidget
-                             )
+                             QWidget)
 from PyQt6.QtGui import QFont, QIcon, QPalette
 from PyQt6.QtCore import Qt
 import bitbase
@@ -55,10 +54,14 @@ class PlacesWidget(QTreeWidget):
         self.header().setSortIndicatorShown(True)
         self.header().setSectionHidden(1, True)
 
-        self.header().sortIndicatorChanged.connect(self.do_update)
+        self.header().sortIndicatorChanged.connect(
+            self._on_sort_indicator_changed)
 
         # previous and new item given as arguments
         self.currentItemChanged.connect(self._slot_changed)
+
+    def _on_sort_indicator_changed(self, _column: int):
+        self.do_update()
 
     def set_profile_operations(self, pop: ProfileOperations) -> None:
         """Connect an `ProfileOperations` instance and register
@@ -74,14 +77,20 @@ class PlacesWidget(QTreeWidget):
 
     def on_now_selected(self):
         """Event handler if 'Now' entry in timeline was selected"""
-        self.do_update()
+        self.do_update(now_selected=True)
 
     def on_backup_changed(self, _sid):
         """Event handler if a backup entry in timeline was selected"""
-        self.do_update()
+        self.do_update(now_selected=False)
 
-    def do_update(self, _col: int = None, _order: Qt.SortOrder = None) -> None:
+    def do_update(self, now_selected: Optional[bool] = None) -> None:
         """Update the places view"""
+        # print(f'places.do_update({now_selected=})')
+
+        # Workaround
+        if now_selected is None:
+            now_selected = self.parent.is_now_selected()
+
         self.clear()
 
         # name, path, icon
@@ -95,22 +104,31 @@ class PlacesWidget(QTreeWidget):
             str(fp_home),
             'user-home')
 
+        backup_id = self.parent.selected_backup_id()
+
         # "Now" or a specific snapshot selected?
-        if self.parent.sid.isRoot:
+        if now_selected or backup_id is None:
             # Use snapshots profiles list of include files and folders
             include_entries = self.config.include()
 
         else:
-            # Determine folders from the snapshot itself
+            # Dev note (2026-03): I wonder why this is needed. Isn't the
+            # profile config stored within each backup. Why not parse
+            # that config file instead of scanning the real filesystem?
+
+            # formaly known as self.sid
+            backup_id = self.parent.selected_backup_id()
+
+            # Determine directories from the backup itself
             base = os.path.expanduser('~')
-            if not os.path.isdir(self.parent.sid.pathBackup(base)):
+            if not os.path.isdir(backup_id.pathBackup(base)):
                 # Folder not mounted. We can skip for the next updatePlaces()
                 return
 
             folders = [
                 i.name
                 for i
-                in os.scandir(self.parent.sid.pathBackup(base))
+                in os.scandir(backup_id.pathBackup(base))
                 if i.is_dir()
             ]
 

--- a/qt/placeswidget.py
+++ b/qt/placeswidget.py
@@ -85,7 +85,6 @@ class PlacesWidget(QTreeWidget):
 
     def do_update(self, now_selected: Optional[bool] = None) -> None:
         """Update the places view"""
-        # print(f'places.do_update({now_selected=})')
 
         # Workaround
         if now_selected is None:
@@ -98,7 +97,7 @@ class PlacesWidget(QTreeWidget):
         self._add_place(_('File System'), '/', 'computer')
 
         fp_home = pathlib.Path.home()
-        self._add_place(
+        home_item = self._add_place(
             # Use full path in root mode ("/root") otherwise users name only
             str(fp_home) if bitbase.IS_IN_ROOT_MODE else fp_home.name,
             str(fp_home),
@@ -151,7 +150,11 @@ class PlacesWidget(QTreeWidget):
         for folder in include_folders:
             self._add_place(folder, folder, 'document-save')
 
-    def _add_place(self, name, path, icon):
+        # Select "home" if nothing is selected
+        if self.currentItem() is None:
+            self.setCurrentItem(home_item)
+
+    def _add_place(self, name, path, icon) -> QTreeWidgetItem:
         """
         Dev note (buhtz, 2024-01-14): Parts of that code are redundant with
         timeline.py::HeaderItem.__init__().

--- a/qt/profile_operations.py
+++ b/qt/profile_operations.py
@@ -44,6 +44,10 @@ class ProfileOperations:
 
         return duplicates, to_add
 
+    # def get_includes(self) -> list:
+    #     """Return the list of include entries."""
+    #     includes = self._config.include(profile_id=self._profile_id)
+
     def add_include(self, paths: list[str] | list[Path]) -> None:
         """Add entries to the include list.
 

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -694,6 +694,18 @@ def block_signals(widget: QWidget) -> None:
     """Context manager to temporary block Qt signals"""
     widget.blockSignals(True)
 
-    yield
+    try:
+        yield
+    finally:
+        widget.blockSignals(False)
 
-    widget.blockSignals(False)
+
+@contextmanager
+def block_paint_updates(widget: QWidget) -> None:
+    """Context manager to temporary block Qt paintng"""
+    widget.setUpdatesEnabled(False)
+
+    try:
+        yield
+    finally:
+        widget.setUpdatesEnabled(True)

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -279,9 +279,6 @@ class SnapshotsDialog(QDialog):
         self.comboDiff.check_selection()
 
     def updateSnapshots(self):
-        # print('X'*100)
-        # print(f'{self.snapshots=}')
-        # print(f'{self.snapshotsList=}')
         self.timeline.clear_and_reset()
         self.comboDiff.clear()
 
@@ -300,11 +297,8 @@ class SnapshotsDialog(QDialog):
             flag_deep_check=self.cbDeepCheck.isChecked(),
             list_equal_to=equal_to
         )
-        WEITER HIER: filter liefert ein "/" zurück. bullshit
 
-        print(f'{snapshotsFiltered=}')
         for sid in snapshotsFiltered:
-            print(f'{sid=}')
             self.addSnapshot(sid)
 
         self.updateToolbar()
@@ -387,30 +381,38 @@ class SnapshotsDialog(QDialog):
     def timeLineChanged(self):
         self.updateToolbar()
 
-    def _deprecated_timeLineExecute(self, _item, _column):
-        # Ctrl button pressed, indicates ongoing multiselection?
-        modifiers = self.qapp.keyboardModifiers()
-        if Qt.KeyboardModifier.ControlModifier in modifiers:
-            return
+    # def _deprecated_timeLineExecute(self, _item, _column):
+    #     # Ctrl button pressed, indicates ongoing multiselection?
+    #     modifiers = self.qapp.keyboardModifiers()
+    #     if Qt.KeyboardModifier.ControlModifier in modifiers:
+    #         return
 
-        sid = self.timeline.current_snapshot_id()
-        if not sid:
-            return
+    #     sid = self.timeline.current_snapshot_id()
+    #     if not sid:
+    #         return
 
-        full_path = sid.pathBackup(self.path)
-        if not os.path.exists(full_path):
-            return
+    #     full_path = sid.pathBackup(self.path)
+    #     if not os.path.exists(full_path):
+    #         return
 
-        # prevent backup data from being accidentally overwritten
-        # by create a temporary local copy and only open that one
-        if not isinstance(self.sid, snapshots.RootSnapshot):
-            full_path = self.parent._create_temporary_copy(full_path, sid)
+    #     # prevent backup data from being accidentally overwritten
+    #     # by create a temporary local copy and only open that one
+    #     if not isinstance(self.sid, snapshots.RootSnapshot):
+    #         full_path = self.parent._create_temporary_copy(full_path, sid)
 
-        QDesktopServices.openUrl(QUrl(full_path))
+    #     QDesktopServices.openUrl(QUrl(full_path))
 
     def btnDiffClicked(self):
-        sid1 = self.timeline.current_snapshot_id()
+        sid1 = None
+        if self.timeline.is_now_selected():
+            sid1 = snapshots.RootSnapshot(self.config)
+        else:
+            backup_descriptor = self.timeline.selected_backup_descriptor()
+            if backup_descriptor:
+                sid1 = snapshots.SID(backup_descriptor, self.config)
+
         sid2 = self.comboDiff.current_snapshot_id()
+
         if not sid1 or not sid2:
             return
 
@@ -501,13 +503,8 @@ class SnapshotsDialog(QDialog):
                     self.config.setExclude(exclude)
 
     def btnSelectAllClicked(self):
-        """
-        select all expect 'Now'
-        """
-        self.timeline.clearSelection()
-        for item in self.timeline.iter_snapshot_items():
-            if not isinstance(item.snapshot_id, snapshots.RootSnapshot):
-                item.setSelected(True)
+        """Select all backups but not 'Now'"""
+        self.timeline.select_all_backup_entries()
 
     def accept(self):
         sid = self.timeline.selected_backup_descriptor()

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import shlex
 
-from PyQt6.QtGui import QDesktopServices
+# from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtWidgets import (QCheckBox,
                              QDialog,
                              QDialogButtonBox,
@@ -28,9 +28,7 @@ from PyQt6.QtWidgets import (QCheckBox,
                              QPushButton,
                              QToolBar,
                              QVBoxLayout)
-from PyQt6.QtCore import (Qt,
-                          QThread,
-                          QUrl)
+from PyQt6.QtCore import Qt, QThread
 
 from timeline import TimeLine
 from bitwidgets import SnapshotCombo
@@ -263,7 +261,8 @@ class SnapshotsDialog(QDialog):
         self.timeLineChanged()
 
     def addSnapshot(self, sid):
-        # to timeline
+        """Add backup (sid) in the timeine widget"""
+        # pylint: disable-next=duplicate-code
         self.timeline.create_backup_entry(
             descriptor=sid.get_descriptor(),
             timestamp=sid.get_timestamp(),

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -200,10 +200,17 @@ class SnapshotsDialog(QDialog):
         self.btnSelectAll.triggered.connect(self.btnSelectAllClicked)
 
         # snapshots list
-        self.timeLine = TimeLine(self)
-        self.mainLayout.addWidget(self.timeLine)
-        self.timeLine.itemSelectionChanged.connect(self.timeLineChanged)
-        self.timeLine.itemActivated.connect(self.timeLineExecute)
+        self.timeline = TimeLine(self)
+
+        self.timeline.event_now_selected.register([
+            self._on_now_selected,
+        ])
+        self.timeline.event_backup_selected.register([
+            self._on_backup_selected,
+        ])
+
+        self.mainLayout.addWidget(self.timeline)
+        # self.timeLine.itemActivated.connect(self.timeLineExecute)
 
         # Diff
         layout = QHBoxLayout()
@@ -249,10 +256,22 @@ class SnapshotsDialog(QDialog):
         # update list and combobox
         self.UpdateSnapshotsAndComboEqualTo()
 
-    def addSnapshot(self, sid):
-        self.timeLine.addSnapshot(sid)
+    def _on_now_selected(self):
+        self.timeLineChanged()
 
-        # add to combo
+    def _on_backup_selected(self, _sid):
+        self.timeLineChanged()
+
+    def addSnapshot(self, sid):
+        # to timeline
+        self.timeline.create_backup_entry(
+            descriptor=sid.get_descriptor(),
+            timestamp=sid.get_timestamp(),
+            last_checked=sid.lastChecked,
+            label=sid.displayName
+        )
+
+        # to combo box
         self.comboDiff.add_snapshot_id(sid)
 
         if self.sid == sid:
@@ -260,7 +279,10 @@ class SnapshotsDialog(QDialog):
         self.comboDiff.check_selection()
 
     def updateSnapshots(self):
-        self.timeLine.clear()
+        # print('X'*100)
+        # print(f'{self.snapshots=}')
+        # print(f'{self.snapshotsList=}')
+        self.timeline.clear_and_reset()
         self.comboDiff.clear()
 
         equal_to_sid = self.comboEqualTo.current_snapshot_id()
@@ -272,14 +294,17 @@ class SnapshotsDialog(QDialog):
 
         snapshotsFiltered = self.snapshots.filter(
             base_sid=self.sid,
-            base_path=self.path,
+            base_path=self.path,  # !!!
             snapshotsList=self.snapshotsList,
             list_diff_only=self.cbOnlyDifferentSnapshots.isChecked(),
             flag_deep_check=self.cbDeepCheck.isChecked(),
             list_equal_to=equal_to
         )
+        WEITER HIER: filter liefert ein "/" zurück. bullshit
 
+        print(f'{snapshotsFiltered=}')
         for sid in snapshotsFiltered:
+            print(f'{sid=}')
             self.addSnapshot(sid)
 
         self.updateToolbar()
@@ -320,7 +345,7 @@ class SnapshotsDialog(QDialog):
         self.updateSnapshots()
 
     def updateToolbar(self):
-        sids = self.timeLine.get_all_selected_backup_descriptors()
+        sids = self.timeline.get_all_selected_backup_descriptors()
         sids = [
             snapshots.SID(date=descriptor, cfg=self.config)
             for descriptor in sids
@@ -347,14 +372,14 @@ class SnapshotsDialog(QDialog):
 
     def restoreThis(self):
         # See #1485 as related bug report
-        sid = self.timeLine.current_snapshot_id()
+        sid = self.timeline.current_snapshot_id()
         if not sid.isRoot:
             # pylint: disable-next=E1101
             restoredialog.restore(self, sid, self.path)
 
     def restoreThisTo(self):
         # See #1485 as related bug report
-        sid = self.timeLine.current_snapshot_id()
+        sid = self.timeline.current_snapshot_id()
         if not sid.isRoot:
             # pylint: disable-next=E1101
             restoredialog.restore(self, sid, self.path, None)
@@ -362,13 +387,13 @@ class SnapshotsDialog(QDialog):
     def timeLineChanged(self):
         self.updateToolbar()
 
-    def timeLineExecute(self, _item, _column):
+    def _deprecated_timeLineExecute(self, _item, _column):
         # Ctrl button pressed, indicates ongoing multiselection?
         modifiers = self.qapp.keyboardModifiers()
         if Qt.KeyboardModifier.ControlModifier in modifiers:
             return
 
-        sid = self.timeLine.current_snapshot_id()
+        sid = self.timeline.current_snapshot_id()
         if not sid:
             return
 
@@ -384,7 +409,7 @@ class SnapshotsDialog(QDialog):
         QDesktopServices.openUrl(QUrl(full_path))
 
     def btnDiffClicked(self):
-        sid1 = self.timeLine.current_snapshot_id()
+        sid1 = self.timeline.current_snapshot_id()
         sid2 = self.comboDiff.current_snapshot_id()
         if not sid1 or not sid2:
             return
@@ -434,7 +459,7 @@ class SnapshotsDialog(QDialog):
         self.updateSnapshots()
 
     def btnDeleteClicked(self):
-        items = self.timeLine.selectedItems()
+        items = self.timeline.selectedItems()
 
         if not items:
             return
@@ -479,15 +504,15 @@ class SnapshotsDialog(QDialog):
         """
         select all expect 'Now'
         """
-        self.timeLine.clearSelection()
-        for item in self.timeLine.iter_snapshot_items():
+        self.timeline.clearSelection()
+        for item in self.timeline.iter_snapshot_items():
             if not isinstance(item.snapshot_id, snapshots.RootSnapshot):
                 item.setSelected(True)
 
     def accept(self):
-        sid = self.timeLine.current_snapshot_id()
+        sid = self.timeline.selected_backup_descriptor()
         if sid:
-            self.sid = sid
+            self.sid = snapshots.SID(sid, self.config)
         super(SnapshotsDialog, self).accept()
 
 

--- a/qt/snapshotsdialog.py
+++ b/qt/snapshotsdialog.py
@@ -320,7 +320,11 @@ class SnapshotsDialog(QDialog):
         self.updateSnapshots()
 
     def updateToolbar(self):
-        sids = self.timeLine.selected_snapshot_ids()
+        sids = self.timeLine.get_all_selected_backup_descriptors()
+        sids = [
+            snapshots.SID(date=descriptor, cfg=self.config)
+            for descriptor in sids
+        ]
 
         if not sids:
             enable_restore = False

--- a/qt/test/test_lint.py
+++ b/qt/test/test_lint.py
@@ -90,6 +90,7 @@ full_test_files = [_base_dir / fp for fp in (
     'test/test_lint.py',
     'test/test_profile_operations.py',
     'test/test_statedata.py',
+    'test/test_timeline.py',
     'textdlg.py',
     'timeline.py',
     'usermessagedialog.py',

--- a/qt/test/test_timeline.py
+++ b/qt/test/test_timeline.py
@@ -82,7 +82,7 @@ class Periods(unittest.TestCase):
 
         self.assertEqual(_datetime_to_str(sut), expect)
 
-    def test_foo(self):
+    def test_last_week_overlap_last_month(self):
         """Without 'This month' and shorter 'Last month'
 
         This months, is covered by all previous periods in the list.
@@ -97,7 +97,21 @@ class Periods(unittest.TestCase):
             ('Yesterday', '2026-03-06 Fri 00:00', '2026-03-06 Fri 23:59'),
             ('This week', '2026-03-02 Mon 00:00', '2026-03-05 Thu 23:59'),
             ('Last week', '2026-02-23 Mon 00:00', '2026-03-01 Sun 23:59'),
-            # WEITER
+            ('Last month', '2026-02-01 Sun 00:00', '2026-02-22 Sun 23:59'),
+        ]
+
+        self.assertEqual(_datetime_to_str(sut), expect)
+
+    def test_this_week_overlap_yesterday(self):
+        """Without 'This week' because it touches 'Yesterday'.
+        """
+        today = date(2026, 3, 3)
+        sut = timeline._calculate_timeline_periods(today)
+
+        expect = [
+            ('Today', '2026-03-03 Tue 00:00', '2026-03-03 Tue 23:59'),
+            ('Yesterday', '2026-03-02 Mon 00:00', '2026-03-02 Mon 23:59'),
+            ('Last week', '2026-02-23 Mon 00:00', '2026-03-01 Sun 23:59'),
             ('Last month', '2026-02-01 Sun 00:00', '2026-02-22 Sun 23:59'),
         ]
 

--- a/qt/test/test_timeline.py
+++ b/qt/test/test_timeline.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: © 2026 Christian Buhtz <c.buhtz@posteo.jp>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+"""Tests about timeline widget."""
+# pylint: disable=wrong-import-position,wrong-import-order
+import unittest
+from datetime import datetime, date
+from qttools_path import register_backintime_path
+register_backintime_path('common')
+import timeline  # noqa: E402
+
+STRFTIME = '%Y-%m-%d %a %H:%M'
+
+
+def _datetime_to_str(result):
+    for idx, val in enumerate(result):
+        result[idx] = (
+            val[0],
+            val[1].strftime(STRFTIME),
+            val[2].strftime(STRFTIME)
+        )
+
+    return result
+
+
+class Periods(unittest.TestCase):
+    """StateData instance is a singleton."""
+
+    def test_simple_a(self):
+        """Simple situations without edge cases"""
+        today = date(2026, 3, 28)  # Saturday
+        sut = timeline._calculate_timeline_periods(today)
+
+        expect = [
+            ('Today', '2026-03-28 Sat 00:00', '2026-03-28 Sat 23:59'),
+            ('Yesterday', '2026-03-27 Fri 00:00', '2026-03-27 Fri 23:59'),
+            ('This week', '2026-03-23 Mon 00:00', '2026-03-26 Thu 23:59'),
+            ('Last week', '2026-03-16 Mon 00:00', '2026-03-22 Sun 23:59'),
+            ('This month', '2026-03-01 Sun 00:00', '2026-03-15 Sun 23:59'),
+            ('Last month', '2026-02-01 Sun 00:00', '2026-02-28 Sat 23:59'),
+        ]
+
+        self.assertEqual(
+            _datetime_to_str(sut),
+            expect
+        )
+
+    def test_simple_b(self):
+        today = date(2026, 3, 18)
+        sut = timeline._calculate_timeline_periods(today)
+
+        expect = [
+            ('Today', '2026-03-18 Wed 00:00', '2026-03-18 Wed 23:59'),
+            ('Yesterday', '2026-03-17 Tue 00:00', '2026-03-17 Tue 23:59'),
+            ('This week', '2026-03-16 Mon 00:00', '2026-03-16 Mon 23:59'),
+            ('Last week', '2026-03-09 Mon 00:00', '2026-03-15 Sun 23:59'),
+            ('This month', '2026-03-01 Sun 00:00', '2026-03-08 Sun 23:59'),
+            ('Last month', '2026-02-01 Sun 00:00', '2026-02-28 Sat 23:59'),
+        ]
+
+        self.assertEqual(
+            _datetime_to_str(sut),
+            expect
+        )
+
+    def test_simple_c(self):
+        today = date(2026, 3, 12)
+        sut = timeline._calculate_timeline_periods(today)
+
+        expect = [
+            ('Today', '2026-03-12 Thu 00:00', '2026-03-12 Thu 23:59'),
+            ('Yesterday', '2026-03-11 Wed 00:00', '2026-03-11 Wed 23:59'),
+            ('This week', '2026-03-09 Mon 00:00', '2026-03-10 Tue 23:59'),
+            ('Last week', '2026-03-02 Mon 00:00', '2026-03-08 Sun 23:59'),
+            ('This month', '2026-03-01 Sun 00:00', '2026-03-01 Sun 23:59'),
+            ('Last month', '2026-02-01 Sun 00:00', '2026-02-28 Sat 23:59'),
+        ]
+
+        self.assertEqual(_datetime_to_str(sut), expect)
+
+    def test_foo(self):
+        """Without 'This month' and shorter 'Last month'
+
+        This months, is covered by all previous periods in the list.
+        Last months is shorted because of Last week lapping into the last
+        months.
+        """
+        today = date(2026, 3, 7)
+        sut = timeline._calculate_timeline_periods(today)
+
+        expect = [
+            ('Today', '2026-03-07 Sat 00:00', '2026-03-07 Sat 23:59'),
+            ('Yesterday', '2026-03-06 Fri 00:00', '2026-03-06 Fri 23:59'),
+            ('This week', '2026-03-02 Mon 00:00', '2026-03-05 Thu 23:59'),
+            ('Last week', '2026-02-23 Mon 00:00', '2026-03-01 Sun 23:59'),
+            # WEITER
+            ('Last month', '2026-02-01 Sun 00:00', '2026-02-22 Sun 23:59'),
+        ]
+
+        self.assertEqual(_datetime_to_str(sut), expect)

--- a/qt/test/test_timeline.py
+++ b/qt/test/test_timeline.py
@@ -8,7 +8,7 @@
 """Tests about timeline widget."""
 # pylint: disable=wrong-import-position,wrong-import-order
 import unittest
-from datetime import datetime, date
+from datetime import date
 from qttools_path import register_backintime_path
 register_backintime_path('common')
 import timeline  # noqa: E402
@@ -29,6 +29,7 @@ def _datetime_to_str(result):
 
 class Periods(unittest.TestCase):
     """StateData instance is a singleton."""
+    # pylint: disable=protected-access,missing-function-docstring
 
     def test_simple_a(self):
         """Simple situations without edge cases"""

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -232,12 +232,22 @@ class TimeLine(QTreeWidget):
         """Snapshot IDs of all selected entries."""
         return [i.snapshot_id for i in self.selectedItems()]
 
-    def current_snapshot_id(self):
+    def is_now_selected(self) -> bool:
+        """If the 'Now' item, the first in the widget, is selected."""
+        model_index = self.currentIndex()
+        return model_index.row() == 0
+
+    def current_backup_descriptor(self) -> snapshots.SID:
         """Snapshot ID of current selected entry."""
+        if self.is_now_selected():
+            return None
+
         item = self.currentItem()
 
         return item.snapshot_id if item else None
 
+    def current_snapshot_id(self):
+        return self.current_backup_descriptor()
     def set_current_snapshot_id(self, sid):
         """Select entry related to the snapshot ID."""
         for item in self._iter_items():
@@ -269,32 +279,30 @@ class TimeLine(QTreeWidget):
             if isinstance(item, HeaderItem):
                 yield item
 
+WEITER : RESET, die items hier nach SID.date (echte zeitobjektei sortieren
+                                              dann könnte ich auch für Now
+                                              ein entsprechendes zeitobjektei
+                                              in der zukunft setzen und
+                                              bräuchte RootSnapshot nicht mehr
 
-class TimeLineItem(QTreeWidgetItem):
-    """Base class for TimeLine entry widgets.
+class _SortableItem(QTreeWidgetItem):
+    def __init__(self, backup_id: snapshots):
+        super().__init__()
 
-    Dev note (buhtz, 2025-03): I don't see a need for this. SnapshotItem and
-    HeaderItem can directly derive from QTreeWidgetItem.
-    """
+        self.setText(0, backup_descriptor.displayName)
+        self.setData(0, Qt.ItemDataRole.UserRole, backup_descriptor)
 
     def __lt__(self, other):
-        return self.snapshot_id < other.snapshot_id
-
-    @property
-    def snapshot_id(self):
-        """Id of the related snapshot."""
-        return self.data(0, Qt.ItemDataRole.UserRole)
+        return self.data(0, Qt.ItemDataRole.UserRole) \
+            < other.data(0, Qt.ItemDataRole.UserRole)
 
 
-class SnapshotItem(TimeLineItem):  # pylint: disable=too-few-public-methods
-    """Snapshot entry widget used in TimeLine."""
+class BackupEntry(QTreeWidgetItem):
+    """Backup entry widget used in TimeLine."""
+    def __init__(self, backup_id: str):
+        super().__init__(backup_id)
 
-    def __init__(self, sid):
-        super().__init__()
-        self.setText(0, sid.displayName)
-        self.setData(0, Qt.ItemDataRole.UserRole, sid)
-
-        self.is_now = sid.isRoot
+        self.is_now = backup_id.isRoot
 
         if self.is_now:
             self.setToolTip(
@@ -304,7 +312,16 @@ class SnapshotItem(TimeLineItem):  # pylint: disable=too-few-public-methods
         else:
             self.setToolTip(
                 0,
-                _('Last check {time}').format(time=sid.lastChecked))
+                _('Last check {time}').format(time=backup_id.lastChecked))
+
+    @property
+    def backup_descriptor(self):
+        """Id of the related snapshot."""
+        return self.data(0, Qt.ItemDataRole.UserRole)
+
+
+
+class SnapshotItem(TimeLineItem):  # pylint: disable=too-few-public-methods
 
 
 class HeaderItem(TimeLineItem):  # pylint: disable=too-few-public-methods

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -102,9 +102,8 @@ class TimeLine(QTreeWidget):
 
     The widget is placed on the right side of the main window.
     """
-    # update_files_view = pyqtSignal(int)
 
-    event_selection_changed = Event()
+    # event_selection_changed = Event()
     event_now_selected = Event()
     event_backup_selected = Event()
 
@@ -155,11 +154,6 @@ class TimeLine(QTreeWidget):
         """Remove all entries, recalculate header data and add 'Now' entry"""
 
         with qttools.block_paint_updates(self):
-
-            # # dirty signal hack
-            # with self.event_selection_changed.keep_silent():
-            #     with self.event_now_item_selected.keep_silent():
-            #         with self.event_backup_item_selected.keep_silent():
             super().clear()
             self._header_data = []
             self._default_header_data = _calculate_timeline_periods()
@@ -177,6 +171,9 @@ class TimeLine(QTreeWidget):
 
         Also add a header if not already present.
         """
+        print(f'\n{descriptor=}')
+        import traceback
+        traceback.print_stack()
         item = BackupEntry(
             descriptor=descriptor,
             timestamp=timestamp,
@@ -186,9 +183,6 @@ class TimeLine(QTreeWidget):
 
         self.addTopLevelItem(item)
         self._create_header_if_necessary(timestamp)
-
-        # Select the snapshot that was selected before
-        # use FileView.preserve_selection() TODO
 
     def _header_in_use(self, backup_timestamp: datetime) -> bool:
         """Check if the backup timestamp fit into an already existing
@@ -315,7 +309,7 @@ class TimeLine(QTreeWidget):
 
     def _set_current_item(self, item, *args, **kwargs):
         self.setCurrentItem(item, *args, **kwargs)
-        self.event_selection_changed.notify()
+        # self.event_selection_changed.notify()
 
     def _iter_items(self):
         for index in range(self.topLevelItemCount()):
@@ -344,7 +338,9 @@ class _TimeLineItemBase(QTreeWidgetItem):
         super().__init__()
 
         if tooltip:
-            self.setToolTip(0, tooltip)
+            # DEBUG
+            self.setToolTip(0, f'{type(self)} {tooltip}')
+            # self.setToolTip(0, tooltip)
 
         self.setText(0, label)
         self.setData(0, Qt.ItemDataRole.UserRole, timestamp)

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -15,8 +15,10 @@
 """
 from datetime import (datetime, date, timedelta)
 from calendar import monthrange
+from contextlib import contextmanager
+from functools import partial
 from PyQt6.QtGui import QFont, QPalette
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (QAbstractItemView,
                              QApplication,
                              QTreeWidget,
@@ -242,12 +244,31 @@ class TimeLine(QTreeWidget):
 
         return True
 
-    # pylint: disable-next=invalid-name
-    def checkSelection(self):  # noqa: N802
-        """Slot handling selection events."""
-        if self.currentItem() is None:
-            # Select the 'Now' item
-            self._set_current_item(self.topLevelItem(0))
+    @contextmanager
+    def preserve_selection(self):
+        """Context manager preserving the selection of the current selected
+        item. If no selection exists the 'Now' item will be selected.
+        """
+        previous_selection = self.selected_backup_descriptor()
+
+        try:
+            yield
+
+        finally:
+            if previous_selection:
+                # Select the backup
+                callback_func = partial(
+                    self.select_by_descriptor, previous_selection
+                )
+            else:
+                # "Now" if previously no backup was selected
+                callback_func = self.select_now
+
+            QTimer.singleShot(0, callback_func)
+
+    def select_now(self):
+        """Select the first item, which is the 'Now' entry"""
+        self._set_current_item(self.topLevelItem(0))
 
     def get_all_selected_backup_descriptors(self) -> list[str]:
         """A list of all selected backup descriptors"""

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -23,7 +23,7 @@ from PyQt6.QtWidgets import (QAbstractItemView,
                              QApplication,
                              QTreeWidget,
                              QTreeWidgetItem)
-import logger  # workaround. shouldn't be neccessary
+import logger  # workaround. shouldn't be necessary
 import qttools
 from event import Event
 from qttools_path import register_backintime_path
@@ -50,10 +50,12 @@ def _calculate_timeline_periods(today: date = date.today()
                                 ) -> list[tuple[str, datetime, datetime]]:
     """Calculate timestamps for the sub-headers.
 
-    Returns:
-        A list of tuples with label, start and end datetime of each periode.
-    """
+    The headers are Today, Yesterday, This Week, Last Week, This Month and
+    Last Month.
 
+    Returns:
+        A list of tuples with label, start and end datetime of each period.
+    """
     result = []
 
     # Today
@@ -139,10 +141,9 @@ class TimeLine(QTreeWidget):
         self.itemSelectionChanged.connect(self._on_item_selection_changed)
 
     def _on_item_selection_changed(self):
-        # Maybe remove
-        # self.event_selection_changed.notify()
-        # print('_on_item_selection_changed()')
-
+        """Selection event handler distinguishing between 'Now' and backup
+        entries.
+        """
         if self.is_now_selected():
             self.event_now_selected.notify()
             return
@@ -283,7 +284,7 @@ class TimeLine(QTreeWidget):
         """Return the backup descriptor of the current selected item.
 
         Return:
-            The descriptor (formaly known as 'sid') as a string.
+            The descriptor (formally known as 'sid') as a string.
         """
         if self.is_now_selected():
             return None
@@ -295,7 +296,7 @@ class TimeLine(QTreeWidget):
     def selected_backup_label(self) -> str:
         """Return the label used of the current selected item.
 
-        That is the backup descriptor plus a name string if definied
+        That is the backup descriptor plus a name string if defined
         by the user.
         """
         if self.is_now_selected():

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -64,7 +64,9 @@ def _calculate_timeline_periods(now: date = date.today()
     # This week, but not yesterday or today
     this_week_min = start_of_day(now - timedelta(now.weekday()))
     this_week_max = end_of_day(yesterday_min - timedelta(days=1))
-    result.append((_('This week'), this_week_min, this_week_max))
+    # Add only, if not overlapping with Yesterday
+    if this_week_max > this_week_min:
+        result.append((_('This week'), this_week_min, this_week_max))
 
     # Last week
     last_week_min = start_of_day(now - timedelta(now.weekday() + 7))
@@ -80,6 +82,8 @@ def _calculate_timeline_periods(now: date = date.today()
     # Last months
     last_month_max = end_of_day(now.replace(day=1) - timedelta(days=1))
     last_month_min = start_of_day(last_month_max.replace(day=1))
+    if last_month_max.date() >= last_week_min.date():
+        last_month_max = end_of_day(last_week_min.date() - timedelta(days=1))
     result.append((_('Last month'), last_month_min, last_month_max))
 
     return result
@@ -113,11 +117,16 @@ class TimeLine(QTreeWidget):
         self.parent = parent
         self.snapshots = parent.snapshots
 
+        self.now = None
+
+        # list of tuples with (text, startDate, endDate)
+        self._header_data = None
+
         # That timestmap is used to decide if a backup needs an extra
         # header item. It is previous to the last month or older.
         self._specific_month_boundary = None
 
-        self._calculate_header_data()
+        self._reset_default_header_data()
 
         self.itemSelectionChanged.connect(self._on_item_selection_changed)
 
@@ -132,6 +141,11 @@ class TimeLine(QTreeWidget):
 
         self.event_backup_item_selected.notify(self.current_backup_descriptor)
 
+    def _reset_default_header_data(self):
+        self.now = date.today()
+        self._header_data = _calculate_timeline_periods(self.now)
+        self._specific_month_boundary = self._header_data[-1][1]
+
     def clear_and_rebuild_header(self):
         # blocker = QSignalBlocker(self)
         # import traceback
@@ -143,7 +157,7 @@ class TimeLine(QTreeWidget):
             # with self.event_selection_changed.keep_silent():
             #     with self.event_now_item_selected.keep_silent():
             #         with self.event_backup_item_selected.keep_silent():
-            self._calculate_header_data()
+            self._reset_default_header_data()
             super().clear()
 
             # "Now"
@@ -154,66 +168,6 @@ class TimeLine(QTreeWidget):
                 # DEBUG
                 item.setToolTip(0, f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}')
                 self.addTopLevelItem(item)
-
-    def _add_header_data(self, label: str, start: datetime, end: datetime):
-        if start >= end:
-            return
-
-        self._header_data.append((label, start, end))
-
-    def _calculate_header_data(self):
-        """Calculate timestamps for the sub-headers.
-        """
-        self.now = date.today()
-        self._specific_month_boundary = None
-
-        # list of tuples with (text, startDate, endDate)
-        self._header_data = []
-
-        # Today
-        today_min = self.start_of_day(self.now)
-        today_max = self.end_of_day(self.now)
-        self._add_header_data(_('Today'), today_min, today_max)
-
-        # Yesterday
-        yesterday_min = self.start_of_day(self.now - timedelta(days=1))
-        yesterday_max = self.end_of_day(today_min - timedelta(hours=1))
-        self._add_header_data(_('Yesterday'), yesterday_min, yesterday_max)
-
-        # This week
-        this_week_min = self.start_of_day(self.now - timedelta(self.now.weekday()))
-        this_week_max = self.end_of_day(yesterday_min - timedelta(hours=1))
-        self._add_header_data(_('This week'), this_week_min, this_week_max)
-
-        # Last week
-        last_week_min = self.start_of_day(self.now - timedelta(self.now.weekday() + 7))
-        last_week_max = self.end_of_day(self._header_data[-1][1] - timedelta(hours=1))
-        self._add_header_data(_('Last week'), last_week_min, last_week_max)
-
-        # Rest of current month, but only if Yesterday, This Week and
-        # Last Week do not touch the last month.
-        this_month_min = self.start_of_day(self.now.replace(day=1))
-        this_month_max = self.end_of_day(this_week_min - timedelta(hours=1))
-        self._add_header_data(
-            _('This month'),  # this_month_min.strftime('%B').capitalize(),
-            this_month_min,
-            this_month_max
-        )
-
-        # Rest of last month (before last week)
-        last_month_max = self.end_of_day(last_week_min) - timedelta(microseconds=1)
-        last_month_min = self.start_of_day(last_month_max.date().replace(day=1))
-        self._add_header_data(
-            _('Last month'),  # last_month_min.strftime('%B').capitalize(),
-            last_month_min,
-            last_month_max
-        )
-
-        # DEBUG
-        # for a, b, c in self._header_data:
-        #     print(a, b, c)
-
-        self._specific_month_boundary = last_month_min
 
     @pyqtSlot(snapshots.SID)
     # pylint: disable-next=invalid-name

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -41,7 +41,7 @@ def start_of_day(day: date) -> datetime:
 def end_of_day(day: date) -> datetime:
     return datetime.combine(day, datetime.max.time())
 
-def _calculate_timeline_periods(now: date = date.today()
+def _calculate_timeline_periods(today: date = date.today()
                                 ) -> list[tuple[str, datetime, datetime]]:
     """Calculate timestamps for the sub-headers.
 
@@ -52,17 +52,17 @@ def _calculate_timeline_periods(now: date = date.today()
     result = []
 
     # Today
-    today_min = start_of_day(now)
-    today_max = end_of_day(now)
+    today_min = start_of_day(today)
+    today_max = end_of_day(today)
     result.append((_('Today'), today_min, today_max))
 
     # Yesterday
-    yesterday_min = start_of_day(now - timedelta(days=1))
+    yesterday_min = start_of_day(today - timedelta(days=1))
     yesterday_max = end_of_day(today_min - timedelta(hours=1))
     result.append((_('Yesterday'), yesterday_min, yesterday_max))
 
     # This week, but not yesterday or today
-    this_week_min = start_of_day(now - timedelta(now.weekday()))
+    this_week_min = start_of_day(today - timedelta(now.weekday()))
     this_week_max = end_of_day(yesterday_min - timedelta(days=1))
     # Add only, if not overlapping with Yesterday
     if this_week_max > this_week_min:
@@ -75,12 +75,12 @@ def _calculate_timeline_periods(now: date = date.today()
 
     # This month
     if now.month == last_week_min.month and now.month == this_week_min.month:
-        this_month_min = start_of_day(now.replace(day=1))
+        this_month_min = start_of_day(today.replace(day=1))
         this_month_max = end_of_day(last_week_min - timedelta(days=1))
         result.append((_('This month'), this_month_min, this_month_max))
 
     # Last months
-    last_month_max = end_of_day(now.replace(day=1) - timedelta(days=1))
+    last_month_max = end_of_day(today.replace(day=1) - timedelta(days=1))
     last_month_min = start_of_day(last_month_max.replace(day=1))
     if last_month_max.date() >= last_week_min.date():
         last_month_max = end_of_day(last_week_min.date() - timedelta(days=1))
@@ -117,16 +117,18 @@ class TimeLine(QTreeWidget):
         self.parent = parent
         self.snapshots = parent.snapshots
 
-        self.now = None
-
-        # list of tuples with (text, startDate, endDate)
+        # Used headers. A of tuples with (label, start, end)
         self._header_data = None
 
-        # That timestmap is used to decide if a backup needs an extra
-        # header item. It is previous to the last month or older.
+        # Timestamp boundaries (from-to) used for the header items:
+        # Today, Yesterday, This Week, Last Week, This Months, Last Months
+        self._default_header_data = None
+
+        # Helper variable. Timestamps older than this need and extra header,
+        # other than a default header.
         self._specific_month_boundary = None
 
-        self._reset_default_header_data()
+        self.clear_and_reset()
 
         self.itemSelectionChanged.connect(self._on_item_selection_changed)
 
@@ -141,15 +143,7 @@ class TimeLine(QTreeWidget):
 
         self.event_backup_item_selected.notify(self.current_backup_descriptor)
 
-    def _reset_default_header_data(self):
-        self.now = date.today()
-        self._header_data = _calculate_timeline_periods(self.now)
-        self._specific_month_boundary = self._header_data[-1][1]
-
-        print('')
-        print(self._header_data)
-
-    def clear_and_rebuild_header(self):
+    def clear_and_reset(self):
         # blocker = QSignalBlocker(self)
         # import traceback
         # traceback.print_stack(limit=5)
@@ -160,17 +154,13 @@ class TimeLine(QTreeWidget):
             # with self.event_selection_changed.keep_silent():
             #     with self.event_now_item_selected.keep_silent():
             #         with self.event_backup_item_selected.keep_silent():
-            self._reset_default_header_data()
             super().clear()
+            self._header_data = []
+            self._default_header_data = self._calculate_timtline_periods()
+            self._specific_month_boundary = self._default_header_data[-1][1]
 
             # "Now"
             self.addTopLevelItem(NowEntry())
-
-            for label, start, end in self._header_data:
-                item = HeaderEntry(label=label, timestamp=end)
-                # DEBUG
-                item.setToolTip(0, f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}')
-                self.addTopLevelItem(item)
 
     @pyqtSlot(snapshots.SID)
     # pylint: disable-next=invalid-name
@@ -194,13 +184,10 @@ class TimeLine(QTreeWidget):
 
         return item
 
-    def _header_exists(self, backup_timestamp: datetime) -> bool:
-        # Not necessary. The timestamps is before the boundary of existing
-        # default headers.
-        if backup_timestamp >= self._specific_month_boundary:
-            return True
+    def _header_in_use(self, backup_timestamp: datetime) -> bool:
+        """Check if the backup timestamp fit into an already existing
+        header item."""
 
-        # maybe an extra/older months exists?
         for _text, start, end in self._header_data:
             if start <= backup_timestamp <= end:
                 return True
@@ -210,18 +197,30 @@ class TimeLine(QTreeWidget):
     def _create_header_if_necessary(self, backup_timestamp: datetime):
         """Create an header entry for the backup timestamp if necessary"""
 
-        if self._header_exists(backup_timestamp):
+        # Already used header fit this timestamp?
+        if self._header_in_use(backup_timestamp):
             return
 
-        # Any previous months
-        year = backup_timestamp.year
-        month = backup_timestamp.month
+        # Use a default header?
+        if backup_timestamp >= self._sepcific_month_boundary:
+            for label, start, end in self._default_header_data:
+                if start <= backup_timestamp <= end:
+                    self._create_header(label, start, end)
+                    return
+
+            logger.critical(
+                'Unexpected situation. Found no default header for '
+                f'{backup_timestamp=} in {self._default_header_data=}'
+            )
+
+
+        # Create an extra months header
 
         # Calculate start and end of backup months
-        first_day = date(year, month, 1)
-        last_day = date(year, month, monthrange(year, month)[1])
+        start = backup_timestamp.date().replace(day=1)
+        end = first_day.replace(day=monthrange(first_day.year, first_day.month)[1])
 
-        label = first_day.strftime('%B' if year == self.now.year else '%B, %Y')
+        label = start.strftime('%B' if start.year == date.year else '%B, %Y')
         label = label.capitalize()
 
         first_day = start_of_day(first_day)
@@ -232,35 +231,32 @@ class TimeLine(QTreeWidget):
         item = HeaderEntry(label=label, timestamp=last_day)
         self.addTopLevelItem(item)
 
-    def _remove_consecutive_header_entries(self):
-        """Remove header items without backup entries."""
-        previous_was_header = False
-        to_remove = []
+    # def _remove_consecutive_header_entries(self):
+    #     """Remove header items without backup entries."""
+    #     previous_was_header = False
+    #     to_remove = []
 
-        for idx in range(self.topLevelItemCount()):
-            item = self.topLevelItem(idx)
+    #     for idx in range(self.topLevelItemCount()):
+    #         item = self.topLevelItem(idx)
 
-            if not isinstance(item, HeaderEntry):
-                previous_was_header = False
-                continue
+    #         if not isinstance(item, HeaderEntry):
+    #             previous_was_header = False
+    #             continue
 
-            if previous_was_header:
-                to_remove.append(idx)
+    #         if previous_was_header:
+    #             to_remove.append(idx)
 
-            previous_was_header = True
+    #         previous_was_header = True
 
-        # Remove from behind
-        for idx in reversed(to_remove):
-            self.takeTopLevelItem(idx)
+    #     # Remove from behind
+    #     for idx in reversed(to_remove):
+    #         self.takeTopLevelItem(idx)
 
-    def _create_header_entry(self, text, end_date):
-        # Don't create if it still exists.
-        for item in self._iter_header_items():
-            if item.snapshot_id.date == end_date:
-                return False
-
-        item = HeaderEntry(text, snapshots.SID(end_date, self.parent.config))
-        self.addTopLevelItem(item)
+    def _create_header_entry(self, label, start_date, end_date):
+        self.addTopLevelItem(
+            HeaderEntry(label, snapshots.SID(end_date, self.parent.config))
+        )
+        self._header_data.append((label, start_date, end_date))
 
         return True
 
@@ -402,7 +398,9 @@ class HeaderEntry(_TimeLineItemBase):  # pylint: disable=too-few-public-methods
         """
         super().__init__(
             timestamp=timestamp,
-            tooltip=None,
+            # DEBUG
+            tooltip=f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}',
+            # tooltip=None,
             label=label
         )
 

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -101,8 +101,8 @@ class TimeLine(QTreeWidget):
     # update_files_view = pyqtSignal(int)
 
     event_selection_changed = Event()
-    event_now_item_selected = Event()
-    event_backup_item_selected = Event()
+    event_now_selected = Event()
+    event_backup_selected = Event()
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -142,10 +142,11 @@ class TimeLine(QTreeWidget):
         # print('_on_item_selection_changed()')
 
         if self.is_now_selected():
-            self.event_now_item_selected.notify()
+            self.event_now_selected.notify()
             return
 
-        self.event_backup_item_selected.notify(self.selected_backup_descriptor)
+        self.event_backup_selected.notify(
+            self.selected_backup_descriptor)
 
     def clear_and_reset(self):
         """Remove all entries, recalculate header data and add 'Now' entry"""

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -305,6 +305,7 @@ class TimeLine(QTreeWidget):
                 break
 
     def select_all_backup_entries(self):
+        """Highlight all backup entries."""
         self.clearSelection()
         for item in self.iter_backup_items():
             item.setSelected(True)

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -35,6 +35,12 @@ except NameError:
     _ = lambda s: s
 
 
+def start_of_day(day: date) -> datetime:
+    return datetime.combine(day, datetime.min.time())
+
+def end_of_day(day: date) -> datetime:
+    return datetime.combine(day, datetime.max.time())
+
 def _calculate_timeline_periods(now: date = date.today()
                                 ) -> list[tuple[str, datetime, datetime]]:
     """Calculate timestamps for the sub-headers.
@@ -42,12 +48,6 @@ def _calculate_timeline_periods(now: date = date.today()
     Returns:
         A list of tuples with label, start and end datetime of each periode.
     """
-
-    def start_of_day(day: date) -> datetime:
-        return datetime.combine(day, datetime.min.time())
-
-    def end_of_day(day: date) -> datetime:
-        return datetime.combine(day, datetime.max.time())
 
     result = []
 
@@ -146,6 +146,9 @@ class TimeLine(QTreeWidget):
         self._header_data = _calculate_timeline_periods(self.now)
         self._specific_month_boundary = self._header_data[-1][1]
 
+        print('')
+        print(self._header_data)
+
     def clear_and_rebuild_header(self):
         # blocker = QSignalBlocker(self)
         # import traceback
@@ -221,10 +224,10 @@ class TimeLine(QTreeWidget):
         label = first_day.strftime('%B' if year == self.now.year else '%B, %Y')
         label = label.capitalize()
 
-        first_day = self.start_of_day(first_day)
-        last_day = self.end_of_day(last_day)
+        first_day = start_of_day(first_day)
+        last_day = end_of_day(last_day)
 
-        self._add_header_data(label, first_day, last_day)
+        self._header_data.append((label, first_day, last_day))
 
         item = HeaderEntry(label=label, timestamp=last_day)
         self.addTopLevelItem(item)

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -46,22 +46,29 @@ class TimeLine(QTreeWidget):
         self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
         self.setSelectionMode(
             QAbstractItemView.SelectionMode.ExtendedSelection)
-        self.setHeaderLabels([_('Backups'), 'foo'])
+
+        self.setHeaderLabels([_('Backups')])
+
         self.setSortingEnabled(True)
-        self.sortByColumn(1, Qt.SortOrder.DescendingOrder)
-        self.hideColumn(1)
+        self.setSortRole(Qt.ItemDataRole.UserRole)
+        self.sortByColumn(0, Qt.SortOrder.DescendingOrder)
+
         self.header().setSectionsClickable(False)
 
         self.parent = parent
         self.snapshots = parent.snapshots
-        self._root_item = None
-        self._reset_header_data()
+
+        # That timestmap is used to decide if a backup needs an extra
+        # header item. It is previous to the last month or older.
+        self._specific_month_boundary = None
+
+        self._calculate_header_data()
 
         self.itemSelectionChanged.connect(self._on_item_selection_changed)
 
-    def get_now_sid(self):
-        """Bullshit to refactore. 'Now' shouldn't have a backu id."""
-        return self._root_item.snapshot_id
+    # def get_now_sid(self):
+    #     """Bullshit to refactore. 'Now' shouldn't have a backu id."""
+    #     return self._root_item.snapshot_id
 
     def _on_item_selection_changed(self):
         # Maybe remove
@@ -83,92 +90,95 @@ class TimeLine(QTreeWidget):
         with self.event_selection_changed.keep_silent():
             with self.event_now_item_selected.keep_silent():
                 with self.event_backup_item_selected.keep_silent():
-                    self._reset_header_data()
+                    self._calculate_header_data()
                     result = super().clear()
 
         return result
 
-    def _reset_header_data(self):
+    def _add_header_data(self, label: str, start: datetime, end: datetime):
+        if start < end:
+            self._header_data.append((label, start, end))
+
+    def _calculate_header_data(self):
+        """Calculate timestamps for the sub-headers.
+        """
+        def start_of_day(day: date) -> datetime:
+            return datetime.combine(day, datetime.min.time())
+
+        def end_of_day(day: date) -> datetime:
+            return datetime.combine(day, datetime.max.time())
+
         self.now = date.today()
 
         # list of tuples with (text, startDate, endDate)
         self._header_data = []
 
         # Today
-        today_min = datetime.combine(self.now, datetime.min.time())
-        today_max = datetime.combine(self.now, datetime.max.time())
-        self._header_data.append((_('Today'), today_min, today_max))
+        today_min = start_of_day(self.now)
+        today_max = end_of_day(self.now)
+        self._add_header_data(_('Today'), today_min, today_max)
 
         # Yesterday
-        yesterday_min = datetime.combine(
-            self.now - timedelta(days=1), datetime.min.time())
-        yesterday_max = datetime.combine(
-            today_min - timedelta(hours=1), datetime.max.time())
-        self._header_data.append(
-            (_('Yesterday'), yesterday_min, yesterday_max))
+        yesterday_min = start_of_day(self.now - timedelta(days=1))
+        yesterday_max = end_of_day(today_min - timedelta(hours=1))
+        self._add_header_data(_('Yesterday'), yesterday_min, yesterday_max)
 
         # This week
-        this_week_min = datetime.combine(
-            self.now - timedelta(self.now.weekday()), datetime.min.time())
-        this_week_max = datetime.combine(
-            yesterday_min - timedelta(hours=1), datetime.max.time())
-
-        if this_week_min < this_week_max:
-            self._header_data.append(
-                (_('This week'), this_week_min, this_week_max))
+        this_week_min = start_of_day(self.now - timedelta(self.now.weekday()))
+        this_week_max = end_of_day(yesterday_min - timedelta(hours=1))
+        self._add_header_data(_('This week'), this_week_min, this_week_max)
 
         # Last week
-        last_week_min = datetime.combine(
-            self.now - timedelta(self.now.weekday() + 7), datetime.min.time())
-        last_week_max = datetime.combine(
-            self._header_data[-1][1] - timedelta(hours=1), datetime.max.time())
-        self._header_data.append(
-            (_('Last week'), last_week_min, last_week_max))
+        last_week_min = start_of_day(self.now - timedelta(self.now.weekday() + 7))
+        last_week_max = end_of_day(self._header_data[-1][1] - timedelta(hours=1))
+        self._add_header_data(_('Last week'), last_week_min, last_week_max)
 
         # Rest of current month. Otherwise this months header would be
         # above today.
-        this_month_min = datetime.combine(
-            self.now - timedelta(self.now.day - 1), datetime.min.time())
-        this_month_max = datetime.combine(
-            last_week_min - timedelta(hours=1), datetime.max.time())
-        if this_month_min < this_month_max:
-            self._header_data.append((
-                this_month_min.strftime('%B').capitalize(),
-                this_month_min,
-                this_month_max))
+        this_month_min = start_of_day(self.now - timedelta(self.now.day - 1))
+        this_month_max = end_of_day(last_week_min - timedelta(hours=1))
+        self._add_header_data(
+            this_month_min.strftime('%B').capitalize(),
+            this_month_min,
+            this_month_max
+        )
 
         # Rest of last month
-        last_month_max = datetime.combine(
-            self._header_data[-1][1] - timedelta(hours=1), datetime.max.time())
-        last_month_min = datetime.combine(
-            date(last_month_max.year, last_month_max.month, 1),
-            datetime.min.time()
-        )
-        self._header_data.append((
+        last_month_min = start_of_day(date(last_month_max.year, last_month_max.month, 1))
+        last_month_max = end_of_day(self._header_data[-1][1] - timedelta(hours=1))
+        self._add_header_data(
             last_month_min.strftime('%B').capitalize(),
             last_month_min,
-            last_month_max))
+            last_month_max
+        )
 
-    def add_root(self, sid):
-        """Dev note: What is 'root' in this context?
+        self._specific_month_boundary = last_month_min
 
-        Args:
-            sid: Snapshot ID
+    # def add_root(self):
+    #     """Dev note: What is 'root' in this context?
 
-        Returns:
-            The root item itself.
-        """
-        # dirty signal hack
-        with qttools.block_signals(self):
-            self._root_item = self.addSnapshot(sid)
+    #     Args:
+    #         sid: Snapshot ID
 
-        return self._root_item
+    #     Returns:
+    #         The root item itself.
+    #     """
+    #     # dirty signal hack
+    #     with qttools.block_signals(self):
+    #         self._root_item = self.addSnapshot(sid)
+
+    #     return self._root_item
 
     @pyqtSlot(snapshots.SID)
     # pylint: disable-next=invalid-name
     def addSnapshot(self, sid):  # noqa: N802
         """Slot to handle selection of snapshots."""
-        item = SnapshotItem(sid)
+        item = BackupEntry(
+            backup_descriptor=sid.get_descriptor(),
+            backup_timestamp=sid.get_timestamp(),
+            last_checked=sid.lastChecked,
+            label=sid.displayName,
+        )
 
         self.addTopLevelItem(item)
 
@@ -176,35 +186,66 @@ class TimeLine(QTreeWidget):
         if sid == self.parent.sid:
             self._set_current_item(item)
 
-        if not sid.isRoot:
-            self.add_header(sid)
+        self._create_header_if_necessary(sid.get_timestmap())
 
         return item
 
-    def add_header(self, sid):
-        """Add an entry as a header item."""
+    def _header_exists(self, backup_timestamp: datetime) -> bool:
+        # Not necessary. The timestamps is before the boundary of existing
+        # default headers.
+        if backup_timestamp >= self._specific_month_boundary:
+            return True
 
-        for text, start_date, end_date in self._header_data:
-            if start_date <= sid.date <= end_date:
-                self._create_header_item(text, end_date)
-                return
+        # maybe an extra/older months exists?
+        for _text, start, end in self._header_data:
+            if start <= backup_timestamp <= end:
+                return True
+
+        return False
+
+    def _create_header_if_necessary(self, backup_timestamp: datetime):
+        """Create an header entry for the backup timestamp if necessary"""
+
+        if self._header_exists(backup_timestamp):
+            return
 
         # Any previous months
-        year = sid.date.year
-        month = sid.date.month
+        year = backup_timestamp.year
+        month = backup_timestamp.month
 
-        if year == self.now.year:
-            text = date(year, month, 1).strftime('%B').capitalize()
-        else:
-            text = date(year, month, 1).strftime('%B, %Y').capitalize()
+        # Calculate start and end of backup months
+        first_day = date(year, month, 1)
+        last_day = date(year, month, monthrange(year, month)[1])
 
-        start_date = datetime.combine(
-            date(year, month, 1), datetime.min.time())
-        end_date = datetime.combine(
-            date(year, month, monthrange(year, month)[1]), datetime.max.time())
+        label = first_day.strftime('%B' if year == self.now.year else '%B, %Y')
+        label = label.capitalize()
 
+        self._add_header_data(label, first_day, last_day)
+
+        WEITEW
         if self._create_header_item(text, end_date):
             self._header_data.append((text, start_date, end_date))
+
+    def _remove_consecutive_header_entries(self):
+        """Remove header items without backup entries."""
+        previous_was_header = False
+        to_remove = []
+
+        for idx in range(self.topLevelItemCount()):
+            item = self.topLevelItem(idx)
+
+            if not isinstance(item, HeaderEntry):
+                previous_was_header = False
+                continue
+
+            if previous_was_header:
+                to_remove.append(idx)
+
+            previous_was_header = True
+
+        # Remove from behind
+        for idx in reversed(to_remove):
+            self.takeTopLevelItem(idx)
 
     def _create_header_item(self, text, end_date):
         # Don't create if it still exists.
@@ -248,6 +289,7 @@ class TimeLine(QTreeWidget):
 
     def current_snapshot_id(self):
         return self.current_backup_descriptor()
+
     def set_current_snapshot_id(self, sid):
         """Select entry related to the snapshot ID."""
         for item in self._iter_items():
@@ -271,69 +313,86 @@ class TimeLine(QTreeWidget):
     def iter_snapshot_items(self):
         """Iterate over all items."""
         for item in self._iter_items():
-            if isinstance(item, SnapshotItem):
+            if isinstance(item, BackupEntry):
                 yield item
 
     def _iter_header_items(self):
         for item in self._iter_items():
-            if isinstance(item, HeaderItem):
+            if isinstance(item, HeaderEntry):
                 yield item
 
-WEITER : RESET, die items hier nach SID.date (echte zeitobjektei sortieren
-                                              dann könnte ich auch für Now
-                                              ein entsprechendes zeitobjektei
-                                              in der zukunft setzen und
-                                              bräuchte RootSnapshot nicht mehr
 
-class _SortableItem(QTreeWidgetItem):
-    def __init__(self, backup_id: snapshots):
+class _TimeLineItemBase(QTreeWidgetItem):
+    """Backup entry widget used in TimeLine."""
+
+    def __init__(self,
+                 timestamp: datetime,
+                 tooltip: str,
+                 label: str):
         super().__init__()
 
-        self.setText(0, backup_descriptor.displayName)
-        self.setData(0, Qt.ItemDataRole.UserRole, backup_descriptor)
+        if tooltip:
+            self.setToolTip(0, tooltip)
+
+        self.setText(0, label)
+        self.setData(0, Qt.ItemDataRole.UserRole, timestamp)
 
     def __lt__(self, other):
         return self.data(0, Qt.ItemDataRole.UserRole) \
             < other.data(0, Qt.ItemDataRole.UserRole)
 
 
-class BackupEntry(QTreeWidgetItem):
+class BackupEntry(_TimeLineItemBase):
     """Backup entry widget used in TimeLine."""
-    def __init__(self, backup_id: str):
-        super().__init__(backup_id)
 
-        self.is_now = backup_id.isRoot
+    def __init__(self,
+                 backup_descriptor: str,
+                 backup_timestamp: datetime,
+                 last_checked: str,
+                 label: str):
 
-        if self.is_now:
-            self.setToolTip(
-                0,
-                _('This is NOT a backup but a live view '
-                  'of the local files.'))
-        else:
-            self.setToolTip(
-                0,
-                _('Last check {time}').format(time=backup_id.lastChecked))
+        tooltip = _('Last check {time}').format(time=last_checked)
+
+        super().__init__(
+            timestmap=backup_timestamp,
+            tooltip=tooltip,
+            label=label
+        )
+
+        self._backup_descriptor = backup_descriptor
 
     @property
-    def backup_descriptor(self):
-        """Id of the related snapshot."""
-        return self.data(0, Qt.ItemDataRole.UserRole)
+    def backup_descriptor(self) -> str:
+        """Descriptor (sid) of the related backup."""
+        return self._backup_descriptor
 
 
+class NowEntry(_TimeLineItemBase):
+    """Now entry widget used in TimeLine."""
 
-class SnapshotItem(TimeLineItem):  # pylint: disable=too-few-public-methods
+    def __init__(self):
+        super().__init__(
+            timestamp=datetime.max,
+            tooltip=_(
+                'This is NOT a backup but a live view of the local files.'),
+            label=_('Now')
+        )
 
 
-class HeaderItem(TimeLineItem):  # pylint: disable=too-few-public-methods
+class HeaderEntry(_TimeLineItemBase):  # pylint: disable=too-few-public-methods
     """Header entry widget used in TimeLine."""
 
-    def __init__(self, name, sid):
+    def __init__(self, label: str, timestamp: datetime):
         """
         Dev note (buhtz, 2024-01-14): Parts of that code are redundant with
         app.py::MainWindow.addPlace().
         """
-        super().__init__()
-        self.setText(0, name)
+        super().__init__(
+            timestamp=timestamp,
+            tooltip=None,
+            label=label
+        )
+
         font = self.font(0)
         font.setWeight(QFont.Weight.Bold)
         self.setFont(0, font)
@@ -345,5 +404,3 @@ class HeaderItem(TimeLineItem):  # pylint: disable=too-few-public-methods
             0, palette.color(QPalette.ColorRole.AlternateBase))
 
         self.setFlags(Qt.ItemFlag.NoItemFlags)
-
-        self.setData(0, Qt.ItemDataRole.UserRole, sid)

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -17,13 +17,13 @@ from datetime import (datetime, date, timedelta)
 from calendar import monthrange
 from PyQt6.QtGui import QFont, QPalette
 from PyQt6.QtCore import (Qt,
-                          pyqtSlot)
+                          pyqtSlot,
+                          QSignalBlocker)
 from PyQt6.QtWidgets import (QAbstractItemView,
                              QApplication,
                              QTreeWidget,
                              QTreeWidgetItem)
 import snapshots
-import qttools
 from event import Event
 from qttools_path import register_backintime_path
 register_backintime_path('common')
@@ -50,7 +50,6 @@ class TimeLine(QTreeWidget):
         self.setHeaderLabels([_('Backups')])
 
         self.setSortingEnabled(True)
-        self.setSortRole(Qt.ItemDataRole.UserRole)
         self.sortByColumn(0, Qt.SortOrder.DescendingOrder)
 
         self.header().setSectionsClickable(False)
@@ -66,113 +65,111 @@ class TimeLine(QTreeWidget):
 
         self.itemSelectionChanged.connect(self._on_item_selection_changed)
 
-    # def get_now_sid(self):
-    #     """Bullshit to refactore. 'Now' shouldn't have a backu id."""
-    #     return self._root_item.snapshot_id
-
     def _on_item_selection_changed(self):
         # Maybe remove
         # self.event_selection_changed.notify()
+        # print('_on_item_selection_changed()')
 
-        sid = self.current_snapshot_id()
-
-        if not sid:
+        if self.is_now_selected():
+            self.event_now_item_selected.notify()
             return
 
-        if sid.isRoot:
-            self.event_now_item_selected.notify()
-        else:
-            self.event_backup_item_selected.notify(sid)
+        self.event_backup_item_selected.notify(self.current_backup_descriptor)
 
-    def clear(self):
-        """Clear all entries from the widget."""
+    def clear_and_rebuild_header(self):
+        # blocker = QSignalBlocker(self)
+        # import traceback
+        # traceback.print_stack(limit=5)
+
         # dirty signal hack
         with self.event_selection_changed.keep_silent():
             with self.event_now_item_selected.keep_silent():
                 with self.event_backup_item_selected.keep_silent():
                     self._calculate_header_data()
-                    result = super().clear()
+                    super().clear()
 
-        return result
+        # "Now"
+        self.addTopLevelItem(NowEntry())
+
+        for label, start, end in self._header_data:
+            item = HeaderEntry(label=label, timestamp=end)
+            # DEBUG
+            item.setToolTip(0, f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}')
+            self.addTopLevelItem(item)
 
     def _add_header_data(self, label: str, start: datetime, end: datetime):
-        if start < end:
-            self._header_data.append((label, start, end))
+        if start >= end:
+            return
+
+        self._header_data.append((label, start, end))
+
+    @staticmethod
+    def start_of_day(day: date) -> datetime:
+        return datetime.combine(day, datetime.min.time())
+
+    @staticmethod
+    def end_of_day(day: date) -> datetime:
+        return datetime.combine(day, datetime.max.time())
 
     def _calculate_header_data(self):
         """Calculate timestamps for the sub-headers.
         """
-        def start_of_day(day: date) -> datetime:
-            return datetime.combine(day, datetime.min.time())
-
-        def end_of_day(day: date) -> datetime:
-            return datetime.combine(day, datetime.max.time())
-
         self.now = date.today()
+        self._specific_month_boundary = None
 
         # list of tuples with (text, startDate, endDate)
         self._header_data = []
 
         # Today
-        today_min = start_of_day(self.now)
-        today_max = end_of_day(self.now)
+        today_min = self.start_of_day(self.now)
+        today_max = self.end_of_day(self.now)
         self._add_header_data(_('Today'), today_min, today_max)
 
         # Yesterday
-        yesterday_min = start_of_day(self.now - timedelta(days=1))
-        yesterday_max = end_of_day(today_min - timedelta(hours=1))
+        yesterday_min = self.start_of_day(self.now - timedelta(days=1))
+        yesterday_max = self.end_of_day(today_min - timedelta(hours=1))
         self._add_header_data(_('Yesterday'), yesterday_min, yesterday_max)
 
         # This week
-        this_week_min = start_of_day(self.now - timedelta(self.now.weekday()))
-        this_week_max = end_of_day(yesterday_min - timedelta(hours=1))
+        this_week_min = self.start_of_day(self.now - timedelta(self.now.weekday()))
+        this_week_max = self.end_of_day(yesterday_min - timedelta(hours=1))
         self._add_header_data(_('This week'), this_week_min, this_week_max)
 
         # Last week
-        last_week_min = start_of_day(self.now - timedelta(self.now.weekday() + 7))
-        last_week_max = end_of_day(self._header_data[-1][1] - timedelta(hours=1))
+        last_week_min = self.start_of_day(self.now - timedelta(self.now.weekday() + 7))
+        last_week_max = self.end_of_day(self._header_data[-1][1] - timedelta(hours=1))
         self._add_header_data(_('Last week'), last_week_min, last_week_max)
 
-        # Rest of current month. Otherwise this months header would be
-        # above today.
-        this_month_min = start_of_day(self.now - timedelta(self.now.day - 1))
-        this_month_max = end_of_day(last_week_min - timedelta(hours=1))
+        # Rest of current month, but only if Yesterday, This Week and
+        # Last Week do not touch the last month.
+        this_month_min = self.start_of_day(self.now.replace(day=1))
+        this_month_max = self.end_of_day(this_week_min - timedelta(hours=1))
         self._add_header_data(
-            this_month_min.strftime('%B').capitalize(),
+            _('This month'),  # this_month_min.strftime('%B').capitalize(),
             this_month_min,
             this_month_max
         )
 
-        # Rest of last month
-        last_month_min = start_of_day(date(last_month_max.year, last_month_max.month, 1))
-        last_month_max = end_of_day(self._header_data[-1][1] - timedelta(hours=1))
+        # Rest of last month (before last week)
+        last_month_max = self.end_of_day(last_week_min) - timedelta(microseconds=1)
+        last_month_min = self.start_of_day(last_month_max.date().replace(day=1))
         self._add_header_data(
-            last_month_min.strftime('%B').capitalize(),
+            _('Last month'),  # last_month_min.strftime('%B').capitalize(),
             last_month_min,
             last_month_max
         )
 
+        # DEBUG
+        # for a, b, c in self._header_data:
+        #     print(a, b, c)
+
         self._specific_month_boundary = last_month_min
-
-    # def add_root(self):
-    #     """Dev note: What is 'root' in this context?
-
-    #     Args:
-    #         sid: Snapshot ID
-
-    #     Returns:
-    #         The root item itself.
-    #     """
-    #     # dirty signal hack
-    #     with qttools.block_signals(self):
-    #         self._root_item = self.addSnapshot(sid)
-
-    #     return self._root_item
 
     @pyqtSlot(snapshots.SID)
     # pylint: disable-next=invalid-name
     def addSnapshot(self, sid):  # noqa: N802
         """Slot to handle selection of snapshots."""
+        # print(f'addSnapshot() :: {sid=}')
         item = BackupEntry(
             backup_descriptor=sid.get_descriptor(),
             backup_timestamp=sid.get_timestamp(),
@@ -186,7 +183,7 @@ class TimeLine(QTreeWidget):
         if sid == self.parent.sid:
             self._set_current_item(item)
 
-        self._create_header_if_necessary(sid.get_timestmap())
+        self._create_header_if_necessary(sid.get_timestamp())
 
         return item
 
@@ -220,11 +217,13 @@ class TimeLine(QTreeWidget):
         label = first_day.strftime('%B' if year == self.now.year else '%B, %Y')
         label = label.capitalize()
 
+        first_day = self.start_of_day(first_day)
+        last_day = self.end_of_day(last_day)
+
         self._add_header_data(label, first_day, last_day)
 
-        WEITEW
-        if self._create_header_item(text, end_date):
-            self._header_data.append((text, start_date, end_date))
+        item = HeaderEntry(label=label, timestamp=last_day)
+        self.addTopLevelItem(item)
 
     def _remove_consecutive_header_entries(self):
         """Remove header items without backup entries."""
@@ -247,18 +246,17 @@ class TimeLine(QTreeWidget):
         for idx in reversed(to_remove):
             self.takeTopLevelItem(idx)
 
-    def _create_header_item(self, text, end_date):
+    def _create_header_entry(self, text, end_date):
         # Don't create if it still exists.
         for item in self._iter_header_items():
             if item.snapshot_id.date == end_date:
                 return False
 
-        item = HeaderItem(text, snapshots.SID(end_date, self.parent.config))
+        item = HeaderEntry(text, snapshots.SID(end_date, self.parent.config))
         self.addTopLevelItem(item)
 
         return True
 
-    # @pyqtSlot()
     # pylint: disable-next=invalid-name
     def checkSelection(self):  # noqa: N802
         """Slot handling selection events."""
@@ -266,8 +264,7 @@ class TimeLine(QTreeWidget):
             self.select_root_item()
 
     def select_root_item(self):
-        """Dev note: Don't know what 'root' means in this context."""
-        self._set_current_item(self._root_item)
+        self._set_current_item(self.topLevelItem(0))
 
     def selected_snapshot_ids(self):
         """Snapshot IDs of all selected entries."""
@@ -278,14 +275,21 @@ class TimeLine(QTreeWidget):
         model_index = self.currentIndex()
         return model_index.row() == 0
 
-    def current_backup_descriptor(self) -> snapshots.SID:
-        """Snapshot ID of current selected entry."""
+    def current_backup_descriptor(self) -> str:
         if self.is_now_selected():
             return None
 
         item = self.currentItem()
 
-        return item.snapshot_id if item else None
+        return item.backup_descriptor if item else None
+
+    def current_backup_label(self) -> str:
+        if self.is_now_selected():
+            return None
+
+        item = self.currentItem()
+
+        return item.backup_label if item else None
 
     def current_snapshot_id(self):
         return self.current_backup_descriptor()
@@ -301,10 +305,11 @@ class TimeLine(QTreeWidget):
     def _set_current_item(self, item, *args, **kwargs):
         self.setCurrentItem(item, *args, **kwargs)
 
-        if self.parent.sid != item.snapshot_id:
-            self.parent.sid = item.snapshot_id
+        # if self.parent.sid != item.snapshot_id:
+        #     self.parent.sid = item.snapshot_id
             # self.update_files_view.emit(2)
-            self.event_selection_changed.notify()
+        #    self.event_selection_changed.notify()
+        self.event_selection_changed.notify()
 
     def _iter_items(self):
         for index in range(self.topLevelItemCount()):
@@ -354,12 +359,13 @@ class BackupEntry(_TimeLineItemBase):
         tooltip = _('Last check {time}').format(time=last_checked)
 
         super().__init__(
-            timestmap=backup_timestamp,
+            timestamp=backup_timestamp,
             tooltip=tooltip,
             label=label
         )
 
         self._backup_descriptor = backup_descriptor
+        self._backup_label = label
 
     @property
     def backup_descriptor(self) -> str:

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -171,9 +171,6 @@ class TimeLine(QTreeWidget):
 
         Also add a header if not already present.
         """
-        print(f'\n{descriptor=}')
-        import traceback
-        traceback.print_stack()
         item = BackupEntry(
             descriptor=descriptor,
             timestamp=timestamp,
@@ -306,6 +303,11 @@ class TimeLine(QTreeWidget):
             if item.descriptor == backup_descriptor:
                 self._set_current_item(item)
                 break
+
+    def select_all_backup_entries(self):
+        self.clearSelection()
+        for item in self.iter_backup_items():
+            item.setSelected(True)
 
     def _set_current_item(self, item, *args, **kwargs):
         self.setCurrentItem(item, *args, **kwargs)

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -21,8 +21,8 @@ from PyQt6.QtWidgets import (QAbstractItemView,
                              QApplication,
                              QTreeWidget,
                              QTreeWidgetItem)
-import qttools
 import logger  # workaround. shouldn't be neccessary
+import qttools
 from event import Event
 from qttools_path import register_backintime_path
 register_backintime_path('common')
@@ -30,14 +30,17 @@ register_backintime_path('common')
 try:
     _('Warning')
 except NameError:
-    _ = lambda s: s  # noqa: E731
+    def _(txt):
+        return txt
 
 
 def start_of_day(day: date) -> datetime:
+    """Add 00:00 to a date object"""
     return datetime.combine(day, datetime.min.time())
 
 
 def end_of_day(day: date) -> datetime:
+    """Add 23:59 to a date object"""
     return datetime.combine(day, datetime.max.time())
 
 
@@ -145,9 +148,7 @@ class TimeLine(QTreeWidget):
         self.event_backup_item_selected.notify(self.selected_backup_descriptor)
 
     def clear_and_reset(self):
-        # blocker = QSignalBlocker(self)
-        # import traceback
-        # traceback.print_stack(limit=5)
+        """Remove all entries, recalculate header data and add 'Now' entry"""
 
         with qttools.block_paint_updates(self):
 
@@ -168,6 +169,10 @@ class TimeLine(QTreeWidget):
                             timestamp: datetime,
                             last_checked: str,
                             label: str):
+        """Create and add an item representing backup.
+
+        Also add a header if not already present.
+        """
         item = BackupEntry(
             descriptor=descriptor,
             timestamp=timestamp,
@@ -216,7 +221,9 @@ class TimeLine(QTreeWidget):
         start = backup_timestamp.date().replace(day=1)
         end = start.replace(day=monthrange(start.year, start.month)[1])
 
-        label = start.strftime('%B' if start.year == date.year else '%B, %Y')
+        label = start.strftime(
+            '%B' if start.year == date.today().year else '%B, %Y'
+        )
         label = label.capitalize()
 
         self._create_header_entry(label, start_of_day(start), end_of_day(end))
@@ -238,14 +245,12 @@ class TimeLine(QTreeWidget):
     def checkSelection(self):  # noqa: N802
         """Slot handling selection events."""
         if self.currentItem() is None:
-            self.select_root_item()
+            # Select the 'Now' item
+            self._set_current_item(self.topLevelItem(0))
 
-    def select_root_item(self):
-        self._set_current_item(self.topLevelItem(0))
-
-    def selected_snapshot_ids(self):
-        """Snapshot IDs of all selected entries."""
-        return [i.snapshot_id for i in self.selectedItems()]
+    def get_all_selected_backup_descriptors(self) -> list[str]:
+        """A list of all selected backup descriptors"""
+        return [item.descriptor for item in self.selectedItems()]
 
     def is_now_selected(self) -> bool:
         """If the 'Now' item, the first in the widget, is selected."""
@@ -253,6 +258,11 @@ class TimeLine(QTreeWidget):
         return model_index.row() == 0
 
     def selected_backup_descriptor(self) -> str:
+        """Return the backup descriptor of the current selected item.
+
+        Return:
+            The descriptor (formaly known as 'sid') as a string.
+        """
         if self.is_now_selected():
             return None
 
@@ -261,6 +271,11 @@ class TimeLine(QTreeWidget):
         return item.descriptor if item else None
 
     def selected_backup_label(self) -> str:
+        """Return the label used of the current selected item.
+
+        That is the backup descriptor plus a name string if definied
+        by the user.
+        """
         if self.is_now_selected():
             return None
 
@@ -295,6 +310,7 @@ class TimeLine(QTreeWidget):
                 yield item
 
 
+# pylint: disable-next=too-few-public-methods
 class _TimeLineItemBase(QTreeWidgetItem):
     """Backup entry widget used in TimeLine."""
 
@@ -341,9 +357,11 @@ class BackupEntry(_TimeLineItemBase):
 
     @property
     def label(self) -> str:
+        """Text label of the entry."""
         return self.text(0)
 
 
+# pylint: disable-next=too-few-public-methods
 class NowEntry(_TimeLineItemBase):
     """Now entry widget used in TimeLine."""
 

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -163,27 +163,23 @@ class TimeLine(QTreeWidget):
             # "Now"
             self.addTopLevelItem(NowEntry())
 
-    @pyqtSlot(snapshots.SID)
-    # pylint: disable-next=invalid-name
-    def addSnapshot(self, sid):  # noqa: N802
-        """Slot to handle selection of snapshots."""
-        # print(f'addSnapshot() :: {sid=}')
+    def create_backup_entry(self,
+                            descriptor: str,
+                            timestamp: datetime,
+                            last_checked: str,
+                            label: str):
         item = BackupEntry(
-            backup_descriptor=sid.get_descriptor(),
-            backup_timestamp=sid.get_timestamp(),
-            last_checked=sid.lastChecked,
-            label=sid.displayName,
+            backup_descriptor=descriptor,
+            backup_timestamp=timestamp,
+            last_checked=last_checked,
+            label=label
         )
 
         self.addTopLevelItem(item)
+        self._create_header_if_necessary(timestamp)
 
         # Select the snapshot that was selected before
-        if sid == self.parent.sid:
-            self._set_current_item(item)
-
-        self._create_header_if_necessary(sid.get_timestamp())
-
-        return item
+        # use FileView.preserve_selection() TODO
 
     def _header_in_use(self, backup_timestamp: datetime) -> bool:
         """Check if the backup timestamp fit into an already existing

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -62,19 +62,20 @@ def _calculate_timeline_periods(today: date = date.today()
     result.append((_('Yesterday'), yesterday_min, yesterday_max))
 
     # This week, but not yesterday or today
-    this_week_min = start_of_day(today - timedelta(now.weekday()))
+    this_week_min = start_of_day(today - timedelta(today.weekday()))
     this_week_max = end_of_day(yesterday_min - timedelta(days=1))
     # Add only, if not overlapping with Yesterday
     if this_week_max > this_week_min:
         result.append((_('This week'), this_week_min, this_week_max))
 
     # Last week
-    last_week_min = start_of_day(now - timedelta(now.weekday() + 7))
+    last_week_min = start_of_day(today - timedelta(today.weekday() + 7))
     last_week_max = end_of_day(last_week_min + timedelta(days=6))
     result.append((_('Last week'), last_week_min, last_week_max))
 
     # This month
-    if now.month == last_week_min.month and now.month == this_week_min.month:
+    if (today.month == last_week_min.month
+            and today.month == this_week_min.month):
         this_month_min = start_of_day(today.replace(day=1))
         this_month_max = end_of_day(last_week_min - timedelta(days=1))
         result.append((_('This month'), this_month_min, this_month_max))
@@ -156,7 +157,7 @@ class TimeLine(QTreeWidget):
             #         with self.event_backup_item_selected.keep_silent():
             super().clear()
             self._header_data = []
-            self._default_header_data = self._calculate_timtline_periods()
+            self._default_header_data = _calculate_timeline_periods()
             self._specific_month_boundary = self._default_header_data[-1][1]
 
             # "Now"
@@ -202,10 +203,10 @@ class TimeLine(QTreeWidget):
             return
 
         # Use a default header?
-        if backup_timestamp >= self._sepcific_month_boundary:
+        if backup_timestamp >= self._specific_month_boundary:
             for label, start, end in self._default_header_data:
                 if start <= backup_timestamp <= end:
-                    self._create_header(label, start, end)
+                    self._create_header_entry(label, start, end)
                     return
 
             logger.critical(
@@ -218,18 +219,13 @@ class TimeLine(QTreeWidget):
 
         # Calculate start and end of backup months
         start = backup_timestamp.date().replace(day=1)
-        end = first_day.replace(day=monthrange(first_day.year, first_day.month)[1])
+        end = start.replace(day=monthrange(start.year, start.month)[1])
 
         label = start.strftime('%B' if start.year == date.year else '%B, %Y')
         label = label.capitalize()
 
-        first_day = start_of_day(first_day)
-        last_day = end_of_day(last_day)
+        self._create_header_entry(label, start_of_day(start), end_of_day(end))
 
-        self._header_data.append((label, first_day, last_day))
-
-        item = HeaderEntry(label=label, timestamp=last_day)
-        self.addTopLevelItem(item)
 
     # def _remove_consecutive_header_entries(self):
     #     """Remove header items without backup entries."""
@@ -252,11 +248,16 @@ class TimeLine(QTreeWidget):
     #     for idx in reversed(to_remove):
     #         self.takeTopLevelItem(idx)
 
-    def _create_header_entry(self, label, start_date, end_date):
-        self.addTopLevelItem(
-            HeaderEntry(label, snapshots.SID(end_date, self.parent.config))
+    def _create_header_entry(self, label, start, end):
+        item = HeaderEntry(label, end)
+        self.addTopLevelItem(item)
+        self._header_data.append((label, start, end))
+
+        # DEBUG
+        item.setToolTip(
+            0,
+            f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}'
         )
-        self._header_data.append((label, start_date, end_date))
 
         return True
 
@@ -398,9 +399,7 @@ class HeaderEntry(_TimeLineItemBase):  # pylint: disable=too-few-public-methods
         """
         super().__init__(
             timestamp=timestamp,
-            # DEBUG
-            tooltip=f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}',
-            # tooltip=None,
+            tooltip=None,
             label=label
         )
 

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -24,9 +24,65 @@ from PyQt6.QtWidgets import (QAbstractItemView,
                              QTreeWidget,
                              QTreeWidgetItem)
 import snapshots
+import qttools
 from event import Event
 from qttools_path import register_backintime_path
 register_backintime_path('common')
+
+try:
+    _('Warning')
+except NameError:
+    _ = lambda s: s
+
+
+def _calculate_timeline_periods(now: date = date.today()
+                                ) -> list[tuple[str, datetime, datetime]]:
+    """Calculate timestamps for the sub-headers.
+
+    Returns:
+        A list of tuples with label, start and end datetime of each periode.
+    """
+
+    def start_of_day(day: date) -> datetime:
+        return datetime.combine(day, datetime.min.time())
+
+    def end_of_day(day: date) -> datetime:
+        return datetime.combine(day, datetime.max.time())
+
+    result = []
+
+    # Today
+    today_min = start_of_day(now)
+    today_max = end_of_day(now)
+    result.append((_('Today'), today_min, today_max))
+
+    # Yesterday
+    yesterday_min = start_of_day(now - timedelta(days=1))
+    yesterday_max = end_of_day(today_min - timedelta(hours=1))
+    result.append((_('Yesterday'), yesterday_min, yesterday_max))
+
+    # This week, but not yesterday or today
+    this_week_min = start_of_day(now - timedelta(now.weekday()))
+    this_week_max = end_of_day(yesterday_min - timedelta(days=1))
+    result.append((_('This week'), this_week_min, this_week_max))
+
+    # Last week
+    last_week_min = start_of_day(now - timedelta(now.weekday() + 7))
+    last_week_max = end_of_day(last_week_min + timedelta(days=6))
+    result.append((_('Last week'), last_week_min, last_week_max))
+
+    # This month
+    if now.month == last_week_min.month and now.month == this_week_min.month:
+        this_month_min = start_of_day(now.replace(day=1))
+        this_month_max = end_of_day(last_week_min - timedelta(days=1))
+        result.append((_('This month'), this_month_min, this_month_max))
+
+    # Last months
+    last_month_max = end_of_day(now.replace(day=1) - timedelta(days=1))
+    last_month_min = start_of_day(last_month_max.replace(day=1))
+    result.append((_('Last month'), last_month_min, last_month_max))
+
+    return result
 
 
 class TimeLine(QTreeWidget):
@@ -81,35 +137,29 @@ class TimeLine(QTreeWidget):
         # import traceback
         # traceback.print_stack(limit=5)
 
-        # dirty signal hack
-        with self.event_selection_changed.keep_silent():
-            with self.event_now_item_selected.keep_silent():
-                with self.event_backup_item_selected.keep_silent():
-                    self._calculate_header_data()
-                    super().clear()
+        with qttools.block_paint_updates(self):
 
-        # "Now"
-        self.addTopLevelItem(NowEntry())
+            # # dirty signal hack
+            # with self.event_selection_changed.keep_silent():
+            #     with self.event_now_item_selected.keep_silent():
+            #         with self.event_backup_item_selected.keep_silent():
+            self._calculate_header_data()
+            super().clear()
 
-        for label, start, end in self._header_data:
-            item = HeaderEntry(label=label, timestamp=end)
-            # DEBUG
-            item.setToolTip(0, f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}')
-            self.addTopLevelItem(item)
+            # "Now"
+            self.addTopLevelItem(NowEntry())
+
+            for label, start, end in self._header_data:
+                item = HeaderEntry(label=label, timestamp=end)
+                # DEBUG
+                item.setToolTip(0, f'DEBUG - {start.strftime("%c")} to {end.strftime("%c")}')
+                self.addTopLevelItem(item)
 
     def _add_header_data(self, label: str, start: datetime, end: datetime):
         if start >= end:
             return
 
         self._header_data.append((label, start, end))
-
-    @staticmethod
-    def start_of_day(day: date) -> datetime:
-        return datetime.combine(day, datetime.min.time())
-
-    @staticmethod
-    def end_of_day(day: date) -> datetime:
-        return datetime.combine(day, datetime.max.time())
 
     def _calculate_header_data(self):
         """Calculate timestamps for the sub-headers.

--- a/qt/timeline.py
+++ b/qt/timeline.py
@@ -16,15 +16,13 @@
 from datetime import (datetime, date, timedelta)
 from calendar import monthrange
 from PyQt6.QtGui import QFont, QPalette
-from PyQt6.QtCore import (Qt,
-                          pyqtSlot,
-                          QSignalBlocker)
+from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (QAbstractItemView,
                              QApplication,
                              QTreeWidget,
                              QTreeWidgetItem)
-import snapshots
 import qttools
+import logger  # workaround. shouldn't be neccessary
 from event import Event
 from qttools_path import register_backintime_path
 register_backintime_path('common')
@@ -32,14 +30,16 @@ register_backintime_path('common')
 try:
     _('Warning')
 except NameError:
-    _ = lambda s: s
+    _ = lambda s: s  # noqa: E731
 
 
 def start_of_day(day: date) -> datetime:
     return datetime.combine(day, datetime.min.time())
 
+
 def end_of_day(day: date) -> datetime:
     return datetime.combine(day, datetime.max.time())
+
 
 def _calculate_timeline_periods(today: date = date.today()
                                 ) -> list[tuple[str, datetime, datetime]]:
@@ -142,7 +142,7 @@ class TimeLine(QTreeWidget):
             self.event_now_item_selected.notify()
             return
 
-        self.event_backup_item_selected.notify(self.current_backup_descriptor)
+        self.event_backup_item_selected.notify(self.selected_backup_descriptor)
 
     def clear_and_reset(self):
         # blocker = QSignalBlocker(self)
@@ -169,8 +169,8 @@ class TimeLine(QTreeWidget):
                             last_checked: str,
                             label: str):
         item = BackupEntry(
-            backup_descriptor=descriptor,
-            backup_timestamp=timestamp,
+            descriptor=descriptor,
+            timestamp=timestamp,
             last_checked=last_checked,
             label=label
         )
@@ -210,7 +210,6 @@ class TimeLine(QTreeWidget):
                 f'{backup_timestamp=} in {self._default_header_data=}'
             )
 
-
         # Create an extra months header
 
         # Calculate start and end of backup months
@@ -221,28 +220,6 @@ class TimeLine(QTreeWidget):
         label = label.capitalize()
 
         self._create_header_entry(label, start_of_day(start), end_of_day(end))
-
-
-    # def _remove_consecutive_header_entries(self):
-    #     """Remove header items without backup entries."""
-    #     previous_was_header = False
-    #     to_remove = []
-
-    #     for idx in range(self.topLevelItemCount()):
-    #         item = self.topLevelItem(idx)
-
-    #         if not isinstance(item, HeaderEntry):
-    #             previous_was_header = False
-    #             continue
-
-    #         if previous_was_header:
-    #             to_remove.append(idx)
-
-    #         previous_was_header = True
-
-    #     # Remove from behind
-    #     for idx in reversed(to_remove):
-    #         self.takeTopLevelItem(idx)
 
     def _create_header_entry(self, label, start, end):
         item = HeaderEntry(label, end)
@@ -275,47 +252,38 @@ class TimeLine(QTreeWidget):
         model_index = self.currentIndex()
         return model_index.row() == 0
 
-    def current_backup_descriptor(self) -> str:
+    def selected_backup_descriptor(self) -> str:
         if self.is_now_selected():
             return None
 
         item = self.currentItem()
 
-        return item.backup_descriptor if item else None
+        return item.descriptor if item else None
 
-    def current_backup_label(self) -> str:
+    def selected_backup_label(self) -> str:
         if self.is_now_selected():
             return None
 
         item = self.currentItem()
 
-        return item.backup_label if item else None
+        return item.label if item else None
 
-    def current_snapshot_id(self):
-        return self.current_backup_descriptor()
-
-    def set_current_snapshot_id(self, sid):
-        """Select entry related to the snapshot ID."""
-        for item in self._iter_items():
-
-            if item.snapshot_id == sid:
+    def select_by_descriptor(self, backup_descriptor: str):
+        """Select backup entry related to the descriptor."""
+        for item in self.iter_backup_items():
+            if item.descriptor == backup_descriptor:
                 self._set_current_item(item)
                 break
 
     def _set_current_item(self, item, *args, **kwargs):
         self.setCurrentItem(item, *args, **kwargs)
-
-        # if self.parent.sid != item.snapshot_id:
-        #     self.parent.sid = item.snapshot_id
-            # self.update_files_view.emit(2)
-        #    self.event_selection_changed.notify()
         self.event_selection_changed.notify()
 
     def _iter_items(self):
         for index in range(self.topLevelItemCount()):
             yield self.topLevelItem(index)
 
-    def iter_snapshot_items(self):
+    def iter_backup_items(self):
         """Iterate over all items."""
         for item in self._iter_items():
             if isinstance(item, BackupEntry):
@@ -351,26 +319,29 @@ class BackupEntry(_TimeLineItemBase):
     """Backup entry widget used in TimeLine."""
 
     def __init__(self,
-                 backup_descriptor: str,
-                 backup_timestamp: datetime,
+                 descriptor: str,
+                 timestamp: datetime,
                  last_checked: str,
                  label: str):
 
         tooltip = _('Last check {time}').format(time=last_checked)
 
         super().__init__(
-            timestamp=backup_timestamp,
+            timestamp=timestamp,
             tooltip=tooltip,
             label=label
         )
 
-        self._backup_descriptor = backup_descriptor
-        self._backup_label = label
+        self._descriptor = descriptor
 
     @property
-    def backup_descriptor(self) -> str:
+    def descriptor(self) -> str:
         """Descriptor (sid) of the related backup."""
-        return self._backup_descriptor
+        return self._descriptor
+
+    @property
+    def label(self) -> str:
+        return self.text(0)
 
 
 class NowEntry(_TimeLineItemBase):


### PR DESCRIPTION
More decopeling code around MainWindow and its widgets. This time focus was the timeline widgt. But several other widgets, the main window and the snapshots dialog are also affected.

- Removed `MainWindow.sid`
- Fill the timeline is done via Python native threads instead of `QThread`
- Minimized the use of snapshots.RootSnapshot. But currently not able to remove it totally.