### PR TITLE
feat(core): add GUI support for explicit attribute preservation and…

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -1265,6 +1265,39 @@ class Config(configfile.ConfigFileWithProfiles):
         self.setProfileBoolValue('snapshots.rsync_options.enabled', enabled, profile_id)
         self.setProfileStrValue('snapshots.rsync_options.value', value, profile_id)
 
+    # Advanced Rsync User Extensions
+    def preserveCrtimes(self, profile_id=None):
+        return self.profileBoolValue('snapshots.preserve_crtimes', False, profile_id)
+
+    def setPreserveCrtimes(self, value, profile_id=None):
+        self.setProfileBoolValue('snapshots.preserve_crtimes', value, profile_id)
+
+    def preserveOwner(self, profile_id=None):
+        return self.profileBoolValue('snapshots.preserve_owner', False, profile_id)
+
+    def setPreserveOwner(self, value, profile_id=None):
+        self.setProfileBoolValue('snapshots.preserve_owner', value, profile_id)
+
+    def preserveGroup(self, profile_id=None):
+        return self.profileBoolValue('snapshots.preserve_group', False, profile_id)
+
+    def setPreserveGroup(self, value, profile_id=None):
+        self.setProfileBoolValue('snapshots.preserve_group', value, profile_id)
+
+
+
+    def sparse(self, profile_id=None):
+        return self.profileBoolValue('snapshots.sparse', False, profile_id)
+
+    def setSparse(self, value, profile_id=None):
+        self.setProfileBoolValue('snapshots.sparse', value, profile_id)
+
+    def numericIds(self, profile_id=None):
+        return self.profileBoolValue('snapshots.numeric_ids', False, profile_id)
+
+    def setNumericIds(self, value, profile_id=None):
+        self.setProfileBoolValue('snapshots.numeric_ids', value, profile_id)
+
     def sshPrefixEnabled(self, profile_id = None):
         #?Add prefix to every command which run through SSH on remote host.
         return self.profileBoolValue('snapshots.ssh.prefix.enabled', False, profile_id)

--- a/common/tools.py
+++ b/common/tools.py
@@ -1343,6 +1343,24 @@ def rsyncPrefix(config,
     if config.bwlimitEnabled():
         cmd.append('--bwlimit=%d' % config.bwlimit())
 
+    if config.preserveCrtimes() and "crtimes" in caps:
+        cmd.append('--crtimes')
+
+    if config.dryRun():
+        cmd.append('--dry-run')
+
+    if config.preserveOwner():
+        cmd.append('--owner')
+
+    if config.preserveGroup():
+        cmd.append('--group')
+
+    if config.sparse():
+        cmd.append('--sparse')
+
+    if config.numericIds():
+        cmd.append('--numeric-ids')
+
     if config.rsyncOptionsEnabled():
         cmd.extend(shlex.split(config.rsyncOptions()))
 

--- a/qt/manageprofiles/tab_expert_options.py
+++ b/qt/manageprofiles/tab_expert_options.py
@@ -241,6 +241,37 @@ class ExpertOptionsTab(QDialog):
         )
         tab_layout.addWidget(self._cb_preserve_xattr)
 
+        # Advanced Custom Rsync Flags UI Block
+        tab_layout.addWidget(HLineWidget())
+        tab_layout.addWidget(QLabel(_("Advanced Rsync Flags:")))
+        adv_grid = QGridLayout()
+        adv_grid.setColumnMinimumWidth(0, 20)
+        tab_layout.addLayout(adv_grid)
+
+        self._cb_preserve_crtimes = QCheckBox(_('Preserve Creation Time (crtimes)'), self)
+        qttools.set_wrapped_tooltip(self._cb_preserve_crtimes, _("Uses 'rsync --crtimes'. Preserves the creation time of files (if supported by system/rsync)."))
+        adv_grid.addWidget(self._cb_preserve_crtimes, 0, 1)
+
+
+
+        self._cb_preserve_owner = QCheckBox(_('Preserve Owner'), self)
+        qttools.set_wrapped_tooltip(self._cb_preserve_owner, _("Uses 'rsync --owner'. Maintain user ownership. Usually requires root."))
+        adv_grid.addWidget(self._cb_preserve_owner, 2, 1)
+
+        self._cb_preserve_group = QCheckBox(_('Preserve Group'), self)
+        qttools.set_wrapped_tooltip(self._cb_preserve_group, _("Uses 'rsync --group'. Maintain group ownership. Usually requires root."))
+        adv_grid.addWidget(self._cb_preserve_group, 3, 1)
+
+        self._cb_sparse = QCheckBox(_('Sparse Files'), self)
+        qttools.set_wrapped_tooltip(self._cb_sparse, _("Uses 'rsync --sparse'. Handle sparse files efficiently to save space."))
+        adv_grid.addWidget(self._cb_sparse, 4, 1)
+
+        self._cb_numeric_ids = QCheckBox(_('Numeric IDs'), self)
+        qttools.set_wrapped_tooltip(self._cb_numeric_ids, _("Uses 'rsync --numeric-ids'. Don't map uid/gid values by user/group name."))
+        adv_grid.addWidget(self._cb_numeric_ids, 5, 1)
+
+        tab_layout.addWidget(HLineWidget())
+
         self._wdg_copy_links = CopySymlinksWidget(self)
         tab_layout.addWidget(self._wdg_copy_links)
 
@@ -352,6 +383,12 @@ class ExpertOptionsTab(QDialog):
         self._spb_bwlimit.setValue(self.config.bwlimit())
         self._cb_preserve_acl.setChecked(self.config.preserveAcl())
         self._cb_preserve_xattr.setChecked(self.config.preserveXattr())
+        self._cb_preserve_crtimes.setChecked(self.config.preserveCrtimes())
+
+        self._cb_preserve_owner.setChecked(self.config.preserveOwner())
+        self._cb_preserve_group.setChecked(self.config.preserveGroup())
+        self._cb_sparse.setChecked(self.config.sparse())
+        self._cb_numeric_ids.setChecked(self.config.numericIds())
 
         all_links = self.config.copyLinks()
         only_external = self.config.copyUnsafeLinks()
@@ -383,6 +420,12 @@ class ExpertOptionsTab(QDialog):
                                self._spb_bwlimit.value())
         self.config.setPreserveAcl(self._cb_preserve_acl.isChecked())
         self.config.setPreserveXattr(self._cb_preserve_xattr.isChecked())
+        self.config.setPreserveCrtimes(self._cb_preserve_crtimes.isChecked())
+
+        self.config.setPreserveOwner(self._cb_preserve_owner.isChecked())
+        self.config.setPreserveGroup(self._cb_preserve_group.isChecked())
+        self.config.setSparse(self._cb_sparse.isChecked())
+        self.config.setNumericIds(self._cb_numeric_ids.isChecked())
 
         self.config.setCopyLinks(self._wdg_copy_links.all_links)
         self.config.setCopyUnsafeLinks(


### PR DESCRIPTION
Hello,

I am a new contributor, and I was fixing/modifying some things about BackInTime for myself today, but then I decided to do it as a contribution to the official project and add a much-wanted feature while I was at it (I added dry run).  I have tested everything, and it works 100%.  Screenshots shouldn't be necessary for these additions/fixes since nothing about the GUI itself has changed.  I hope this helps others to continue to use BackIntime for many years to come!

feat(core): add GUI support for explicit attribute preservation and specialized rsync flags

- Added dedicated toggles under 'Expert Options' for specialized rsync flags: Preserve Creation Time (`--crtimes`), Preserve Owner (`--owner`), Preserve Group (`--group`), Sparse Files (`--sparse`), and Numeric IDs (`--numeric-ids`).
- Directly mapped UI components to config logic and `rsyncPrefix` generation in `tools.py` for maximum backup configurability.