### PR TITLE
fix(gui): inherit wayland display and desktop styling for root GUI vi…

### DIFF
--- a/qt/backintime-qt_polkit
+++ b/qt/backintime-qt_polkit
@@ -8,14 +8,16 @@
 # General Public License v2 or any later version (GPL-2.0-or-later).
 # See LICENSES directory or go to <https://spdx.org/licenses/CC0-1.0.html>
 # and <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+# Inherit styling + display parameters to pkexec for root GUI
+COMMON_VARS="QT_QPA_PLATFORMTHEME=$QT_QPA_PLATFORMTHEME QT_STYLE_OVERRIDE=$QT_STYLE_OVERRIDE XDG_CURRENT_DESKTOP=$XDG_CURRENT_DESKTOP DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS XDG_DATA_DIRS=$XDG_DATA_DIRS GTK_THEME=$GTK_THEME"
+
 if [ "x$XDG_SESSION_TYPE" = "xwayland" ]; then
-    # PREFIX="env QT_QPA_PLATFORM=wayland-egl XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
-    # Empty prefix to use the default Qt platform plugin (normally xcb)
-    # to fix #836 and #1350
-    PREFIX=""
+    # To fix Wayland Root GUI execution natively, pass WAYLAND_DISPLAY and XDG_RUNTIME_DIR
+    # This prevents 'backintime-qt (root)' from crashing on Pop!_OS COSMIC and other modern Wayland composites
+    PREFIX="env WAYLAND_DISPLAY=$WAYLAND_DISPLAY XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR $COMMON_VARS"
 else
     # X11
-    PREFIX=""
+    PREFIX="env $COMMON_VARS"
 fi
 
 ERR_FILE=$(mktemp)


### PR DESCRIPTION
Hello,

I am a new contributor, and I was fixing/modifying some things about BackInTime for myself today, but then I decided to do it as a contribution to the official project and add a much-wanted feature while I was at it (I added dry run).  I have tested everything, and it works 100%.  Screenshots shouldn't be necessary for these additions/fixes since nothing about the GUI itself has changed.  I hope this helps others to continue to use BackIntime for many years to come!

fix(gui): inherit wayland display and desktop styling for root GUI via pkexec

- Resolves crashing on modern Wayland compositors (like Pop!_OS COSMIC) by natively inheriting `WAYLAND_DISPLAY` and `XDG_RUNTIME_DIR`.
- Injects comprehensive desktop styling variables (`QT_QPA_PLATFORMTHEME`, `XDG_CURRENT_DESKTOP`, `GTK_THEME`, etc.) into `pkexec` wrapper so the root-elevated GUI feels native and matches user styling.