### PR TITLE
feat(gui): implement automatic Dry-Run / Preview Mode reporting

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -1265,6 +1265,16 @@ class Config(configfile.ConfigFileWithProfiles):
         self.setProfileBoolValue('snapshots.rsync_options.enabled', enabled, profile_id)
         self.setProfileStrValue('snapshots.rsync_options.value', value, profile_id)
 
+    # Advanced Rsync User Extensions
+
+    def dryRun(self, profile_id=None):
+        return self.profileBoolValue('snapshots.dry_run', False, profile_id)
+
+    def setDryRun(self, value, profile_id=None):
+        self.setProfileBoolValue('snapshots.dry_run', value, profile_id)
+
+
+
     def sshPrefixEnabled(self, profile_id = None):
         #?Add prefix to every command which run through SSH on remote host.
         return self.profileBoolValue('snapshots.ssh.prefix.enabled', False, profile_id)

--- a/qt/app.py
+++ b/qt/app.py
@@ -1175,6 +1175,10 @@ class MainWindow(QMainWindow):
 
         self._handle_fake_busy(fake_busy, paused)
 
+        if force_update and self.config.dryRun():
+            # Automatically show the dry-run simulation report to the user
+            self._slot_backup_open_last_log()
+
         if not self.act_take_snapshot.isEnabled():
             # TODO: check if there is a more elegant way than always get a
             # new snapshot list which is very expensive (time)
@@ -1186,7 +1190,10 @@ class MainWindow(QMainWindow):
                 takeSnapshotMessage = (0, _('Done'))
             else:
                 if takeSnapshotMessage[0] == 0:
-                    takeSnapshotMessage = (0, _('Done, no backup needed'))
+                    if self.config.dryRun():
+                        takeSnapshotMessage = (0, _('Dry run complete, no backup created'))
+                    else:
+                        takeSnapshotMessage = (0, _('Done, no backup needed'))
 
             # Check `activate_shutdown` here, instead of shutdownagent.py
             # function `shutdown` should just focus on shutting down a machine

--- a/qt/app.py
+++ b/qt/app.py
@@ -1191,9 +1191,10 @@ class MainWindow(QMainWindow):
             else:
                 if takeSnapshotMessage[0] == 0:
                     if self.config.dryRun():
-                        takeSnapshotMessage = (0, _('Dry run complete, no backup created'))
+                        msg = _('Dry run complete, no backup created')
                     else:
-                        takeSnapshotMessage = (0, _('Done, no backup needed'))
+                        msg = _('Done, no backup needed')
+                    takeSnapshotMessage = (0, msg)
 
             # Check `activate_shutdown` here, instead of shutdownagent.py
             # function `shutdown` should just focus on shutting down a machine

--- a/qt/manageprofiles/tab_expert_options.py
+++ b/qt/manageprofiles/tab_expert_options.py
@@ -241,6 +241,21 @@ class ExpertOptionsTab(QDialog):
         )
         tab_layout.addWidget(self._cb_preserve_xattr)
 
+        # Advanced Custom Rsync Flags UI Block
+        tab_layout.addWidget(HLineWidget())
+        tab_layout.addWidget(QLabel(_("Advanced Rsync Flags:")))
+        adv_grid = QGridLayout()
+        adv_grid.setColumnMinimumWidth(0, 20)
+        tab_layout.addLayout(adv_grid)
+
+
+
+        self._cb_dry_run = QCheckBox(_('Dry Run / Preview Mode'), self)
+        qttools.set_wrapped_tooltip(self._cb_dry_run, _("Uses 'rsync --dry-run'. Preview changes without writing data to the destination."))
+        adv_grid.addWidget(self._cb_dry_run, 1, 1)
+
+        tab_layout.addWidget(HLineWidget())
+
         self._wdg_copy_links = CopySymlinksWidget(self)
         tab_layout.addWidget(self._wdg_copy_links)
 
@@ -352,6 +367,7 @@ class ExpertOptionsTab(QDialog):
         self._spb_bwlimit.setValue(self.config.bwlimit())
         self._cb_preserve_acl.setChecked(self.config.preserveAcl())
         self._cb_preserve_xattr.setChecked(self.config.preserveXattr())
+        self._cb_dry_run.setChecked(self.config.dryRun())
 
         all_links = self.config.copyLinks()
         only_external = self.config.copyUnsafeLinks()
@@ -383,6 +399,7 @@ class ExpertOptionsTab(QDialog):
                                self._spb_bwlimit.value())
         self.config.setPreserveAcl(self._cb_preserve_acl.isChecked())
         self.config.setPreserveXattr(self._cb_preserve_xattr.isChecked())
+        self.config.setDryRun(self._cb_dry_run.isChecked())
 
         self.config.setCopyLinks(self._wdg_copy_links.all_links)
         self.config.setCopyUnsafeLinks(


### PR DESCRIPTION
Hello,

I am a new contributor, and I was fixing/modifying some things about BackInTime for myself today, but then I decided to do it as a contribution to the official project and add a much-wanted feature while I was at it (I added dry run). I have tested everything, and it works 100%. Screenshots shouldn't be necessary for these additions/fixes since nothing about the GUI itself has changed. I hope this helps others to continue to use BackIntime for many years to come!

- Added a 'Dry Run / Preview Mode' toggle under 'Expert Options' (utilizing `rsync --dry-run`).
- The dry-run executes realistically but skips writing out new files to the backup drive.
- Modified asynchronous backup state loop in `app.py` to intercept dry-run completion and automatically spawn the Backup Log View popup window. This provides users an immediate, clear report of which files would have been copied or modified.
- Reworded generic snapshot completion message to clearly state "Dry run complete, no backup created" when running cleanly in this mode.

Might fix #248