### PR TITLE
fix(qt): catch ProcessLookupError when signaling snapshot process

### DIFF
--- a/qt/app.py
+++ b/qt/app.py
@@ -490,11 +490,11 @@ class MainWindow(QMainWindow):
                 _('Use checksums for file change detection.')),
             'act_pause_take_snapshot': (
                 icon.PAUSE, _('Pause backup process'),
-                lambda: os.kill(self.snapshots.pid(), signal.SIGSTOP), None,
+                lambda: self._safe_signal(signal.SIGSTOP), None,
                 None),
             'act_resume_take_snapshot': (
                 icon.RESUME, _('Resume backup process'),
-                lambda: os.kill(self.snapshots.pid(), signal.SIGCONT), None,
+                lambda: self._safe_signal(signal.SIGCONT), None,
                 None),
             'act_stop_take_snapshot': (
                 icon.STOP, _('Stop backup process'),
@@ -1848,8 +1848,15 @@ class MainWindow(QMainWindow):
         backintime.takeSnapshotAsync(self.config, checksum=checksum)
         self._update_backup_status(True)
 
+    def _safe_signal(self, sig):
+        """Send a signal to the snapshot process, ignoring if it has already exited."""
+        try:
+            os.kill(self.snapshots.pid(), sig)
+        except ProcessLookupError:
+            pass
+
     def _slot_backup_stop(self):
-        os.kill(self.snapshots.pid(), signal.SIGKILL)
+        self._safe_signal(signal.SIGKILL)
         self.act_stop_take_snapshot.setEnabled(False)
         self.act_pause_take_snapshot.setEnabled(False)
         self.act_resume_take_snapshot.setEnabled(False)


### PR DESCRIPTION
The pause/resume/stop buttons call `os.kill()` on the snapshot process, which raises `ProcessLookupError` if the process has already exited. This is a race condition — on slow systems, the process can finish between the user clicking the button and the signal being sent.

Added a `_safe_signal()` helper that wraps `os.kill()` in a try/except for `ProcessLookupError`, so the UI doesn't crash if the process is already gone. All three signal sites (SIGSTOP, SIGCONT, SIGKILL) now use this helper.

Fixes #1604
