### PR TITLE
fix(cli): don't log misleading error when LICENSES directory is not found

### DIFF
--- a/common/cliarguments.py
+++ b/common/cliarguments.py
@@ -94,11 +94,15 @@ def _license_info() -> tuple[str, str]:
         logger.error(result[0])
 
     if not result[1]:
-        result = (
-            result[0],
-            'Unable to extract licenses from LICENSES '
-            f'directory "{bitlicense.DIR_LICENSES}".')
-        logger.error(result[1])
+        if bitlicense.DIR_LICENSES:
+            result = (
+                result[0],
+                'Unable to extract licenses from LICENSES '
+                f'directory "{bitlicense.DIR_LICENSES}".')
+            logger.error(result[1])
+        else:
+            # LICENSES directory not found on disk, use fallback
+            result = (result[0], None)
 
     return result
 


### PR DESCRIPTION
When the LICENSES directory doesn't exist on disk (`DIR_LICENSES` is `None`), the code still logged an error:

```
ERROR: Unable to extract licenses from LICENSES directory "None".
```

This happens on every invocation for some installations (e.g. openSUSE) where the LICENSES directory is in a non-standard location.

The fix: only log the extraction error when `DIR_LICENSES` is set (meaning the directory was found but extraction failed). When it's `None`, the directory simply doesn't exist and the fallback URL should be used instead.

Fixes #2465
