### PR TITLE
fix: Deprecate options to disable SSH remote host check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,9 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Build: Changelog shipped as HTML
 - Improved import config dialog on first start (Dominic Maluski, @maluskid, [#2483](https://github.com/bit-team/backintime/issues/2483))
 - Deprecate and warn about disabled SSH remote check (Expert Options)
-  [#2482](https://github.com/bit-team/backintime/issues/2482)). These options
-  are removed from the GUI and users given a clear error about it if one of
-  these are disabled (non-default):
-   - Check if remote host is online
-   - Check if remote host supports all necessary commands
+  if one of these two options is (non-default) disabled: "Check if remote host
+  is online", "Check if remote host supports all necessary commands"
+  ([#2482](https://github.com/bit-team/backintime/issues/2482)).
 
 ### Added
 - Gocryptfs for SSH encrypted profiles
@@ -47,6 +45,11 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Config examples
 - Languages Faroese, Croatian, Vietnames and Norwegian (Nynorsk)
   ([#2080](https://github.com/bit-team/backintime/issues/2080))
+- Expert Options: Check if remote host is online
+  ([#2482](https://github.com/bit-team/backintime/issues/2482)).
+- Expert Options: Check if remote host supports all necessary commands
+  ([#2482](https://github.com/bit-team/backintime/issues/2482)).
+
 
 ## Fixed
 - Prevent crash in case a plugin fails ([#2447](https://github.com/bit-team/backintime/issues/2447))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Changelog migrated to _Common Changelog_ standard
 - Build: Changelog shipped as HTML
 - Improved import config dialog on first start (Dominic Maluski, @maluskid, [#2483](https://github.com/bit-team/backintime/issues/2483))
-- Deprecate and warn about disabled SSH remote check (Expert Options)
+- Expert Options: Deprecate and warn about disabled SSH remote checks
   if one of these two options is (non-default) disabled: "Check if remote host
   is online", "Check if remote host supports all necessary commands"
   ([#2482](https://github.com/bit-team/backintime/issues/2482)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,11 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - **Breaking**: Minimal Python version 3.13 increased
 - Changelog migrated to _Common Changelog_ standard
 - Build: Changelog shipped as HTML
-- Improved import config dialog on first start (Dominic Maluski, @maluskid, [#2483](https://github.com/bit-team/backintime/issues/2483))
+- GUI: Improved import config dialog on first start (Dominic Maluski, @maluskid, [#2483](https://github.com/bit-team/backintime/issues/2483))
 - Expert Options: Deprecate and warn about disabled SSH remote checks
   if one of these two options is (non-default) disabled: "Check if remote host
   is online", "Check if remote host supports all necessary commands"
-  ([#2482](https://github.com/bit-team/backintime/issues/2482)).
+  ([#2482](https://github.com/bit-team/backintime/issues/2482))
 
 ### Added
 - Gocryptfs for SSH encrypted profiles
@@ -45,9 +45,9 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Config examples
 - Languages Faroese, Croatian, Vietnames and Norwegian (Nynorsk)
   ([#2080](https://github.com/bit-team/backintime/issues/2080))
-- Expert Options: Check if remote host is online
+- GUI Expert Options: Check if remote host is online
   ([#2482](https://github.com/bit-team/backintime/issues/2482)).
-- Expert Options: Check if remote host supports all necessary commands
+- GUI Expert Options: Check if remote host supports all necessary commands
   ([#2482](https://github.com/bit-team/backintime/issues/2482)).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Changelog migrated to _Common Changelog_ standard
 - Build: Changelog shipped as HTML
 - Improved import config dialog on first start (Dominic Maluski, @maluskid, [#2483](https://github.com/bit-team/backintime/issues/2483))
+- Deprecate and warn about disabled SSH remote check (Expert Options)
+  [#2482](https://github.com/bit-team/backintime/issues/2482)). These options
+  are removed from the GUI and users given a clear error about it if one of
+  these are disabled (non-default):
+   - Check if remote host is online
+   - Check if remote host supports all necessary commands
 
 ### Added
 - Gocryptfs for SSH encrypted profiles

--- a/FAQ.md
+++ b/FAQ.md
@@ -45,7 +45,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
    * [If I edit my crontab and add additional entries, will that be a problem for BIT as long as I don't touch its entries? What does it look for in the crontab to find its own entries?](#if-i-edit-my-crontab-and-add-additional-entries-will-that-be-a-problem-for-bit-as-long-as-i-dont-touch-its-entries-what-does-it-look-for-in-the-crontab-to-find-its-own-entries)
    * [Can I use a systemd timer instead of cron?](#can-i-use-a-systemd-timer-instead-of-cron)
 - [Problems, Errors & Solutions](#problems-errors--solutions)
-   * [Critical errors about "`snapshots.ssh_check_commands` or `snapshots.ssh.check_ping` not set to default..."]()
+   * [Critical errors about "`snapshots.ssh_check_commands` or `snapshots.ssh.check_ping` not set to default..."](#critical-errors-about-snapshotsssh_check_commands-or-snapshotssshcheck_ping-not-set-to-default)
    * [OverflowError: Value 1702441408 out of range for UInt32](#overflowerror-value-1702441408-out-of-range-for-uint32)
    * [`SettingsDialog` object has no attribute `cbCopyUnsafeLinks`](#settingsDialog-object-has-no-attribute-cbcopyunsafelinks)
    * [WARNING: A backup is already running](#warning-a-backup-is-already-running)
@@ -758,7 +758,7 @@ There seems to be no good reason to disable these options. Regarding issue
 deprecated and will be removed.
 
 User have the [option to
-contact](https://github.com/bit-team/backintime#contact--social] the project
+contact](https://github.com/bit-team/backintime#contact--social) the project
 and give objections against this decission. Please do so if you have good
 reason to disable these options.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -45,6 +45,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
    * [If I edit my crontab and add additional entries, will that be a problem for BIT as long as I don't touch its entries? What does it look for in the crontab to find its own entries?](#if-i-edit-my-crontab-and-add-additional-entries-will-that-be-a-problem-for-bit-as-long-as-i-dont-touch-its-entries-what-does-it-look-for-in-the-crontab-to-find-its-own-entries)
    * [Can I use a systemd timer instead of cron?](#can-i-use-a-systemd-timer-instead-of-cron)
 - [Problems, Errors & Solutions](#problems-errors--solutions)
+   * [Critical errors about "`snapshots.ssh_check_commands` or `snapshots.ssh.check_ping` not set to default..."]()
    * [OverflowError: Value 1702441408 out of range for UInt32](#overflowerror-value-1702441408-out-of-range-for-uint32)
    * [`SettingsDialog` object has no attribute `cbCopyUnsafeLinks`](#settingsDialog-object-has-no-attribute-cbcopyunsafelinks)
    * [WARNING: A backup is already running](#warning-a-backup-is-already-running)
@@ -735,6 +736,44 @@ ExecStart=/usr/bin/nice -n19 /usr/bin/ionice -c2 -n7 /usr/bin/backintime backup 
 ```
 
 # Problems, Errors & Solutions
+## Critical errors about "`snapshots.ssh_check_commands` or `snapshots.ssh.check_ping` not set to default..."
+_Back In Time_ might displays critical errors like this in the terminal, syslog or GUI:
+
+```
+CRITICAL DEPRECATED setting "profile1.snapshots.ssh.check_commands" not set
+to default "true" detected in profile "Main profile" (1). Please contact 
+the project and describe your use case and why you need this setting be disabled.
+
+CRITICAL DEPRECATED setting "profile1.snapshots.ssh.check_ping" not set ...
+```
+
+For SSH profiles the _Expert Options_ tab in the _Manage profiles_ dialog
+provides these two options, which are enabled by default:
+
+ - Check if remote host is online
+ - Check if remote host supports all necessary commands
+ 
+There seems to be no good reason to disable these options. Regarding issue
+[#2482](https://github.com/bit-team/backintime/issues/2482) these options are
+deprecated and will be removed.
+
+User have the [option to
+contact](https://github.com/bit-team/backintime#contact--social] the project
+and give objections against this decission. Please do so if you have good
+reason to disable these options.
+
+To disable the critical errors the config file need to be edited manually. The
+files location is usually at `~/.config/backintime/config`. After creating a
+backup of that file, open it in a text editor of your choice. Find lines like
+this:
+
+```ini
+profile1.snapshots.ssh.check_commands=false
+profile1.snapshots.ssh.check_ping=false
+```
+
+Set the value from `false` to `true` (lower case!).
+
 ## OverflowError: Value 1702441408 out of range for UInt32
 The _Back In Time_ GUI crashes and this exception appears in its terminal
 output. Known to happen on restoring (#2084) and removing (#2192) of backups.

--- a/FAQ.md
+++ b/FAQ.md
@@ -759,7 +759,7 @@ deprecated and will be removed.
 
 User have the [option to
 contact](https://github.com/bit-team/backintime#contact--social) the project
-and give objections against this decission. Please do so if you have good
+and give objections against this decision. Please do so if you have good
 reason to disable these options.
 
 To disable the critical errors the config file need to be edited manually. The

--- a/common/cli.py
+++ b/common/cli.py
@@ -418,7 +418,7 @@ def _warn_about_remote_host_check(cfg: config.Config) -> None:
 
 
 def detect_remote_host_check_settings(cfg: config.Config) -> tuple[str, str, str]:
-    """See issue #282."""
+    """See issue #2482."""
     result = []
 
     cipher_keys = sorted(filter(

--- a/common/cli.py
+++ b/common/cli.py
@@ -406,6 +406,47 @@ def _warn_about_cipher(cfg: config.Config) -> None:
         )
 
 
+def _warn_about_remote_host_check(cfg: config.Config) -> None:
+    """See issue #2482. Those settings are deprecated.
+    """
+    for name, key in detect_remote_host_check_settings(cfg):
+        logger.critical(
+            f'DEPRECATED setting "{key}" not set to default "true" detected '
+            f'in profile {name}. Please contact the project and describe '
+            'your use case and why you need this setting be disabled.'
+        )
+
+
+def detect_remote_host_check_settings(cfg: config.Config) -> tuple[str, str, str]:
+    """See issue #282."""
+    result = []
+
+    cipher_keys = sorted(filter(
+        lambda key: 'snapshots.ssh.check_' in key, cfg.dict.keys()
+    ))
+
+    for key in cipher_keys:
+        # ignore default (true)
+        if cfg.dict[key].lower() == 'true':
+            continue
+
+        pid = key.split('.')[0].replace('profile', '')
+
+        # SSH mode ?
+        if 'ssh' not in cfg.dict[f'profile{pid}.snapshots.mode']:
+            # irrelevant not SSH
+            continue
+
+        if pid == '1':
+            name = 'Main profile'
+        else:
+            name = cfg.dict[f'{key.split('.')[0]}.name']
+
+        result.append((f'"{name}" ({pid})', key))
+
+    return result
+
+
 def _backup_and_remove_encfs_config(cfg: config.Config) -> bool:
     """EncFS encryption feature was removed from Back In Time (#1734).
     This function detects existing EncFS profiles. If detected a backup is
@@ -491,8 +532,10 @@ def get_config_and_select_profile(
         cfg = config.Config(config_path=config_path, data_path=data_path)
 
     # Just warn about cipher settings if present.
-    # Removal happen only in the GUI.
     _warn_about_cipher(cfg)
+
+    # Warn about deprecated remote host check settings (#2482)
+    _warn_about_remote_host_check(cfg)
 
     # explicit profile?
     if profile:

--- a/qt/app.py
+++ b/qt/app.py
@@ -405,7 +405,7 @@ class MainWindow(QMainWindow):
 
         state_data = StateData()
 
-        # SSH Cipher removal
+        # SSH Cipher removal (#2176)
         cipher = cli.detect_cipher_settings(self.config)
         if cipher:
             self._open_ssh_cipher_remove_dialog(
@@ -414,6 +414,13 @@ class MainWindow(QMainWindow):
         # remove the cipher keys from config
         for _name, _val, key in cipher:
             del self.config.dict[key]
+
+        # SSH Remote host checks deprecation (#2482)
+        check_settings = cli.detect_remote_host_check_settings(self.config)
+        if check_settings:
+            self._open_remote_host_check_deprecation_dialog(
+                [entry[0] for entry in check_settings]
+            )
 
         # Issue: https://github.com/bit-team/backintime/issues/2080
         lang_planed_for_removal = [
@@ -1849,6 +1856,42 @@ class MainWindow(QMainWindow):
             parent=self,
             title='Removing SSH cipher setting',
             full_label=_complete_text(ssh_cipher_profiles))
+        dlg.exec()
+
+    def _open_remote_host_check_deprecation_dialog(self, profiles):
+        """SSH check remote host deprecation (#2482)"""
+
+        def _complete_text(profiles) -> str:
+            txt = (
+                'Some of the profiles <strong>disabled</strong> one or two '
+                'of these settings:',
+                '<ul>'
+                '<li>' + _('Check if remote host is online') + '</li>'
+                '<li>' + _('Check if remote host supports all '
+                         'necessary commands.') + '</li></ul>',
+                'Those might not be supported anymore in the near future. '
+                'Please contact the project and describe your needs.',
+                'The affected backup profiles are:',
+                '{profiles}',
+            )
+            txt = '\n'.join(txt)
+
+            # Wrap paragraphs in <p> tags.
+            result = ''
+            for t in txt.split('\n'):
+                result = f'{result}<p>{t}</p>'
+
+            profiles = '<ul>' \
+                + ''.join(f'<li>{profile}</li>' for profile in set(profiles)) \
+                + '</ul>'
+
+            return result.format(profiles=profiles)
+
+        dlg = UserMessageDialog(
+            parent=self,
+            title='Deprecation of SSH Check Remote Host settings',
+            full_label=_complete_text(profiles)
+        )
         dlg.exec()
 
     # |---------------|

--- a/qt/manageprofiles/tab_expert_options.py
+++ b/qt/manageprofiles/tab_expert_options.py
@@ -364,7 +364,8 @@ class ExpertOptionsTab(QDialog):
         self._cb_ssh_prefix.setChecked(self.config.sshPrefixEnabled())
         self._txt_ssh_prefix.setText(self.config.sshPrefix())
         # self._cb_ssh_ping.setChecked(self.config.sshCheckPingHost())
-        # self._cb_ssh_check_commands.setChecked(self.config.sshCheckCommands())
+        # self._cb_ssh_check_commands.setChecked(
+        #    self.config.sshCheckCommands())
 
     def store_values(self):
         """Store values from GUI into the config"""

--- a/qt/manageprofiles/tab_expert_options.py
+++ b/qt/manageprofiles/tab_expert_options.py
@@ -305,21 +305,22 @@ class ExpertOptionsTab(QDialog):
         sub_grid.addWidget(self._txt_ssh_prefix, 1, 1)
         tab_layout.addLayout(sub_grid)
 
-        self._cb_ssh_ping = QCheckBox(_('Check if remote host is online'))
-        qttools.set_wrapped_tooltip(
-            self._cb_ssh_ping,
-            _('Warning: If disabled and the remote host is not available, '
-              'this could lead to some weird errors.')
-        )
-        self._cb_ssh_check_commands = QCheckBox(
-            _('Check if remote host supports all necessary commands.'))
-        qttools.set_wrapped_tooltip(
-            self._cb_ssh_check_commands,
-            _('Warning: If disabled and the remote host does not support all '
-              'necessary commands, this could lead to some weird errors.')
-        )
-        tab_layout.addWidget(self._cb_ssh_ping)
-        tab_layout.addWidget(self._cb_ssh_check_commands)
+        # Deprecated: #2482
+        # self._cb_ssh_ping = QCheckBox(_('Check if remote host is online'))
+        # qttools.set_wrapped_tooltip(
+        #     self._cb_ssh_ping,
+        #     _('Warning: If disabled and the remote host is not available, '
+        #       'this could lead to some weird errors.')
+        # )
+        # self._cb_ssh_check_commands = QCheckBox(
+        #     _('Check if remote host supports all necessary commands.'))
+        # qttools.set_wrapped_tooltip(
+        #     self._cb_ssh_check_commands,
+        #     _('Warning: If disabled and the remote host does not support all'
+        #       ' necessary commands, this could lead to some weird errors.')
+        # )
+        # tab_layout.addWidget(self._cb_ssh_ping)
+        # tab_layout.addWidget(self._cb_ssh_check_commands)
 
         tab_layout.addStretch()
 
@@ -362,8 +363,8 @@ class ExpertOptionsTab(QDialog):
         self._txt_rsync_options.setText(self.config.rsyncOptions())
         self._cb_ssh_prefix.setChecked(self.config.sshPrefixEnabled())
         self._txt_ssh_prefix.setText(self.config.sshPrefix())
-        self._cb_ssh_ping.setChecked(self.config.sshCheckPingHost())
-        self._cb_ssh_check_commands.setChecked(self.config.sshCheckCommands())
+        # self._cb_ssh_ping.setChecked(self.config.sshCheckPingHost())
+        # self._cb_ssh_check_commands.setChecked(self.config.sshCheckCommands())
 
     def store_values(self):
         """Store values from GUI into the config"""
@@ -393,9 +394,9 @@ class ExpertOptionsTab(QDialog):
                                     self._txt_rsync_options.text())
         self.config.setSshPrefix(self._cb_ssh_prefix.isChecked(),
                                  self._txt_ssh_prefix.text())
-        self.config.setSshCheckPingHost(self._cb_ssh_ping.isChecked())
-        self.config.setSshCheckCommands(
-            self._cb_ssh_check_commands.isChecked())
+        # self.config.setSshCheckPingHost(self._cb_ssh_ping.isChecked())
+        # self.config.setSshCheckCommands(
+        #     self._cb_ssh_check_commands.isChecked())
 
     def update_items_state(self, enabled: bool):
         """Update state of widgets based on changed profile mode."""
@@ -404,8 +405,8 @@ class ExpertOptionsTab(QDialog):
         self._cb_nocache_on_remote.setEnabled(enabled)
         self._cb_ssh_prefix.setVisible(enabled)
         self._txt_ssh_prefix.setVisible(enabled)
-        self._cb_ssh_ping.setVisible(enabled)
-        self._cb_ssh_check_commands.setVisible(enabled)
+        # self._cb_ssh_ping.setVisible(enabled)
+        # self._cb_ssh_check_commands.setVisible(enabled)
 
     def _slot_rsync_options_editing_finished(self):
         """When editing the rsync options is finished warn and remove


### PR DESCRIPTION
About these two options in the Expert Options tab of the Manage profiles dialog:
 - Check if remote host is online
 - Check if remote host supports all necessary commands

These are enable by default. This PR detects profiles with one of this options disabled and give a critical error to the user in CLI/syslog and GUI. The error also encourages users to contact the project and describe why they need to disable that option.

Close #2482