### PR TITLE
fix!: Drop global config support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ os: linux
 # Support End of "Jammy" (22.04 LTS) is April 2027
 # dist: jammy
 # Support End of "noble" (24.04 LTS) is April 2029
-# dist: noble
+dist: noble
 # Support End of "resolute" (or raccoon?) (26.04 LTS) is April 2031
-dist: raccoon
+# dist: resolute
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ os: linux
 # Support End of "Jammy" (22.04 LTS) is April 2027
 # dist: jammy
 # Support End of "noble" (24.04 LTS) is April 2029
-dist: noble
+# dist: noble
+# Support End of "resolute" (or raccoon?) (26.04 LTS) is April 2031
+dist: resolute
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ os: linux
 # Support End of "noble" (24.04 LTS) is April 2029
 # dist: noble
 # Support End of "resolute" (or raccoon?) (26.04 LTS) is April 2031
-dist: resolute
+dist: raccoon
 
 language: python
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - **Rewritten from scratch**: Mount subsystem (backend and encryption).
   Behavior is intended to remain unchanged; regressions cannot be fully ruled
   out. ([PR#2449](https://github.com/bit-team/backintime/pull/2449))
+- **Breaking**: Minimal Python version 3.13 increased
 - Default mountpoint permissions changed from 700 to 711
   ([PR#2451](https://github.com/bit-team/backintime/pull/2451)) to avoid
   FUSE mount failures when accessing via different user contexts.
-- **Breaking**: Minimal Python version 3.13 increased
 - Changelog migrated to _Common Changelog_ standard
 - Build: Changelog shipped as HTML
 - GUI: Improved import config dialog on first start (Dominic Maluski, @maluskid, [#2483](https://github.com/bit-team/backintime/issues/2483))
@@ -30,28 +30,34 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Clear up license and copyright situation of `qt/serviceHelper.py`
   ([#1986](https://github.com/bit-team/backintime/issues/1986))
 
-
 ### Added
 - Gocryptfs for SSH encrypted profiles
   ([PR#2486](https://github.com/bit-team/backintime/pull/2486))
-- Dependency(build): `pandoc` to convert markdown changelog into HTML
-- Dependency(runtime-cli): `gocryptfs`
+- Dependencies:
+  - build: `pandoc` to convert markdown changelog into HTML
+  - runtime-cli: `gocryptfs`
 
 ### Removed
 - **Breaking**: EncFS support including existing EncFS profiles
   ([PR#2492](https://github.com/bit-team/backintime/pull/2492))
+- **Breaking**: Global config file support
+  ([PR#2493](https://github.com/bit-team/backintime/issues/2493))
 - Dependency: `encfs`
-- Command line switch `--keep-mount`
-- CLI Command `decode` because of EncFS removal ([#1734](https://github.com/bit-team/backintime/issues/1734))
-- CLI Command `benchmark-cipher` ([#2120](https://github.com/bit-team/backintime/issues/2120))
+- CLI:
+  - Switch `--keep-mount`
+  - Command `decode` because of EncFS removal
+    ([#1734](https://github.com/bit-team/backintime/issues/1734))
+  - Command `benchmark-cipher`
+    ([#2120](https://github.com/bit-team/backintime/issues/2120))
 - SSH Cipher ([#2176](https://github.com/bit-team/backintime/issues/2176))
 - Config examples
 - Languages Faroese, Croatian, Vietnames and Norwegian (Nynorsk)
   ([#2080](https://github.com/bit-team/backintime/issues/2080))
-- GUI Expert Options: Check if remote host is online
-  ([#2482](https://github.com/bit-team/backintime/issues/2482)).
-- GUI Expert Options: Check if remote host supports all necessary commands
-  ([#2482](https://github.com/bit-team/backintime/issues/2482)).
+- GUI Expert Options:
+  - "Check if remote host is online"
+    ([#2482](https://github.com/bit-team/backintime/issues/2482)).
+  - "Check if remote host supports all necessary commands"
+    ([#2482](https://github.com/bit-team/backintime/issues/2482)).
 
 
 ## Fixed

--- a/common/bitbase.py
+++ b/common/bitbase.py
@@ -178,3 +178,6 @@ IS_IN_DEBUG_MODE = False
 ENCFS_MSG_STAGE = 42  # FINAL!
 
 DEFAULT_SSH_PORT = 22
+
+# Used for warnings only. Not supported anymore. #2493
+GLOBAL_CONFIG_PATH = Path('/etc/backintime/config')

--- a/common/cli.py
+++ b/common/cli.py
@@ -394,6 +394,20 @@ def detect_cipher_settings(cfg: config.Config) -> tuple[str, str, str]:
     return result
 
 
+def _warn_about_global_config():
+    """See issue #2493. Global config is not supported anymore.
+    """
+
+    if not bitbase.GLOBAL_CONFIG_PATH.exists():
+        return
+
+    logger.critical(
+        f'The global config file ({bitbase.GLOBAL_CONFIG_PATH}) is no longer '
+        'supported. Remove it. Back In Time only supports per-user '
+        'configuration files.'
+    )
+
+
 def _warn_about_cipher(cfg: config.Config) -> None:
     """See issue #2176. Cipher options is not used anymore by BIT.
     Therefore, users having it in config need to be warned about it.
@@ -524,6 +538,8 @@ def get_config_and_select_profile(
         profile. 2 if ``check`` is ``True`` and config is not configured
 
     """
+    _warn_about_global_config()
+
     cfg = config.Config(config_path=config_path, data_path=data_path)
 
     # detect and remove encfs profiles

--- a/common/config.py
+++ b/common/config.py
@@ -54,6 +54,7 @@ from exceptions import PermissionDeniedByPolicy
 class Config(configfile.ConfigFileWithProfiles):
     APP_NAME = bitbase.APP_NAME
 
+    # Version was introduced with 72fc490 in Sept. 2016 by Germar
     CONFIG_VERSION = 6
     """Latest or highest possible version of Back in Time's config file."""
 
@@ -108,8 +109,6 @@ class Config(configfile.ConfigFileWithProfiles):
 
         self._unsaved_profiles = []
 
-        self._GLOBAL_CONFIG_PATH = '/etc/backintime/config'
-
         HOME_FOLDER = os.path.expanduser('~')
         DATA_FOLDER = '.local/share'
         CONFIG_FOLDER = '.config'
@@ -141,9 +140,6 @@ class Config(configfile.ConfigFileWithProfiles):
         else:
             self._LOCAL_CONFIG_PATH = os.path.abspath(config_path)
             self._LOCAL_CONFIG_FOLDER = os.path.dirname(self._LOCAL_CONFIG_PATH)
-
-        # Load global config file
-        self.load(self._GLOBAL_CONFIG_PATH)
 
         # Append local config file
         self.append(self._LOCAL_CONFIG_PATH)

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -63,10 +63,8 @@ def collect_diagnostics():
 
     result['backintime'].update({
         'latest-config-version': config.Config.CONFIG_VERSION,
-        'local-config-file': cfg._LOCAL_CONFIG_PATH,
-        'local-config-file-found': Path(cfg._LOCAL_CONFIG_PATH).exists(),
-        'global-config-file': cfg._GLOBAL_CONFIG_PATH,
-        'global-config-file-found': Path(cfg._GLOBAL_CONFIG_PATH).exists(),
+        'config-file': cfg._LOCAL_CONFIG_PATH,
+        'config-file-found': Path(cfg._LOCAL_CONFIG_PATH).exists(),
         # 'distribution-package': str(distro_path),
         'started-from': str(Path(config.__file__).parent),
         'user-callback': cfg.takeSnapshotUserCallback(),

--- a/common/sshsetupvalidator.py
+++ b/common/sshsetupvalidator.py
@@ -306,7 +306,7 @@ class SSHSetupValidator:  # pylint: disable=too-few-public-methods
         if proc.returncode != 0:
             raise SSHSetupError(
                 f'Adding SSH key failed ({cmd=}): "{err}"',
-                _('Faild to add SSH key.') + '\n\n'
+                _('Failed to add SSH key.') + '\n\n'
                 + _('Details:') + f'\n{err.strip()}\n{cmd}'
             )
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -399,9 +399,19 @@ class MainWindow(QMainWindow):
     def _handle_user_messages(self):
         self._message_about_encfs_config_backup()
 
-        # Ignore if debug or release/testing candidate
-        if version.IS_RELEASE_CANDIDATE or logger.DEBUG:
-            return
+        # # Ignore if debug or release/testing candidate
+        # if version.IS_RELEASE_CANDIDATE or logger.DEBUG:
+        #     return
+
+        # See issue #2493. Global config is not supported anymore.
+        if bitbase.GLOBAL_CONFIG_PATH.exists():
+            messagebox.critical(
+                self,
+                f'The global config file ({bitbase.GLOBAL_CONFIG_PATH}) is '
+                'no longer supported.\n\nRemove it.\n\nBack In Time only '
+                'supports per-user configuration files.',
+                'Global config file support dropped'
+            )
 
         state_data = StateData()
 


### PR DESCRIPTION
Drop support for global config file (/etc/backintime/config).

See no use case for it. User are warned in CLI and GUI if such a file exist.

Close #2493