### PR TITLE
fix!: Drop migration of old config file formats

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -144,61 +144,6 @@ class Config(configfile.ConfigFileWithProfiles):
         # Append local config file
         self.append(self._LOCAL_CONFIG_PATH)
 
-        # Get the version of the config file
-        # or assume the highest config version if it isn't set.
-        currentConfigVersion \
-            = self.intValue('config.version', self.CONFIG_VERSION)
-
-        if currentConfigVersion < self.CONFIG_VERSION:
-            if currentConfigVersion < 5:
-                logger.error(
-                    'The config file version is 4 or lower. This config was '
-                    'made with a version of Back In Time that is out dated. '
-                    'Because of that upgrading config to the current version '
-                    'is not possible. The latest Back In Time version '
-                    'supporting upgrade the config file was v1.5.2.',
-                    self)
-                sys.exit(2)
-
-            if currentConfigVersion < 6:
-                logger.info('Update to config version 6', self)
-                # remap some keys
-                for profile in self.profiles():
-                    # make a 'schedule' domain for everything relating schedules
-                    self.remapProfileKey('snapshots.automatic_backup_anacron_period',
-                                         'schedule.repeatedly.period',
-                                         profile)
-                    self.remapProfileKey('snapshots.automatic_backup_anacron_unit',
-                                         'schedule.repeatedly.unit',
-                                         profile)
-                    self.remapProfileKey('snapshots.automatic_backup_day',
-                                         'schedule.day',
-                                         profile)
-                    self.remapProfileKey('snapshots.automatic_backup_mode',
-                                         'schedule.mode',
-                                         profile)
-                    self.remapProfileKey('snapshots.automatic_backup_time',
-                                         'schedule.time',
-                                         profile)
-                    self.remapProfileKey('snapshots.automatic_backup_weekday',
-                                         'schedule.weekday',
-                                         profile)
-                    self.remapProfileKey('snapshots.custom_backup_time',
-                                         'schedule.custom_time',
-                                         profile)
-
-                    # we don't have 'full rsync mode' anymore
-                    self.remapProfileKey('snapshots.full_rsync.take_snapshot_regardless_of_changes',
-                                         'snapshots.take_snapshot_regardless_of_changes',
-                                         profile)
-                # remap 'qt4' keys
-                self.remapKeyRegex(r'qt4', 'qt')
-                # remove old gnome and kde keys
-                self.removeKeysStartsWith('gnome')
-                self.removeKeysStartsWith('kde')
-
-            self.save()
-
         self.current_hash_id = 'local'
         self.pw = None
         self.forceUseChecksum = False

--- a/common/config.py
+++ b/common/config.py
@@ -22,7 +22,6 @@ Development notes:
     parses this module for that.
 """
 import os
-import sys
 import datetime
 import socket
 import random

--- a/common/configfile.py
+++ b/common/configfile.py
@@ -142,41 +142,6 @@ class ConfigFile:
             if len(items) == 2:
                 self.dict[items[0]] = items[1]
 
-    def remapKey(self, old_key, new_key):
-        """
-        Remap keys to a new key name.
-
-        Args:
-            old_key (str):  old key name
-            new_key (str):  new key name
-        """
-        if old_key != new_key:
-
-            if old_key in self.dict:
-
-                if new_key not in self.dict:
-                    self.dict[new_key] = self.dict[old_key]
-
-                del self.dict[old_key]
-
-    def remapKeyRegex(self, pattern, replace):
-        """
-        Remap keys to a new key name using :py:func:`re.sub`.
-
-        Args:
-            pattern (str):  part of key name that should be replaced
-            replace (:py:class:`str`, method):
-                            string or a callable function which will be used
-                            to replace all matches of ``pattern``.
-        """
-        c = re.compile(pattern)
-
-        for key in list(self.dict):
-            newKey = c.sub(replace, key)
-
-            if key != newKey:
-                self.remapKey(key, newKey)
-
     def hasKey(self, key):
         """
         ``True`` if key is set.
@@ -833,18 +798,6 @@ class ConfigFileWithProfiles(ConfigFile):
             profile_id (str, int):  valid profile ID
         """
         self.removeKeysStartsWith(self.profileKey(prefix, profile_id))
-
-    def remapProfileKey(self, oldKey, newKey, profileId=None):
-        """
-        Remap profile keys to a new key name.
-
-        Args:
-            oldKey (str):           old key name
-            newKey (str):           new key name
-            profileId (str, int):   valid profile ID
-        """
-        self.remapKey(self.profileKey(oldKey, profileId),
-                      self.profileKey(newKey, profileId))
 
     def hasProfileKey(self, key, profile_id=None):
         """

--- a/common/test/test_configfile.py
+++ b/common/test/test_configfile.py
@@ -60,42 +60,6 @@ class TestConfigFile(generic.TestCase):
                     self.assertTrue(cf.hasKey(k), msg)
                     self.assertEqual(original_cf.strValue(k), cf.strValue(k))
 
-    def test_remapKey(self):
-        cfg = configfile.ConfigFile()
-        cfg.dict = {'foo': '123',
-                    'bar': '456'}
-        #old key not in dict
-        cfg.remapKey('notExistedKey', 'baz')
-        self.assertEqual(cfg.strValue('foo'), '123')
-        self.assertEqual(cfg.strValue('bar'), '456')
-
-        #valid remap
-        cfg.remapKey('foo', 'baz')
-        self.assertEqual(cfg.strValue('foo'), '')
-        self.assertEqual(cfg.strValue('baz'), '123')
-        self.assertEqual(cfg.strValue('bar'), '456')
-
-        #do not overwrite existing keys
-        cfg.remapKey('baz', 'bar')
-        self.assertEqual(cfg.strValue('baz'), '')
-        self.assertEqual(cfg.strValue('bar'), '456')
-
-    def test_remapKeyRegex(self):
-        cfg = configfile.ConfigFile()
-        cfg.dict = {'asdf.foo.qwertz': '123',
-                    'foo.qwertz': '456',
-                    'asdf.foo': '789',
-                    'yxcv': 'jkl'}
-
-        cfg.remapKeyRegex('foo', 'bar')
-        self.assertEqual(cfg.strValue('asdf.bar.qwertz', 'WrongValue'), '123')
-        self.assertEqual(cfg.strValue('bar.qwertz', 'WrongValue'), '456')
-        self.assertEqual(cfg.strValue('asdf.bar', 'WrongValue'), '789')
-        self.assertEqual(cfg.strValue('asdf.foo.qwertz', ''), '')
-        self.assertEqual(cfg.strValue('foo.qwertz', ''), '')
-        self.assertEqual(cfg.strValue('asdf.foo', ''), '')
-        self.assertEqual(cfg.strValue('yxcv', 'WrongValue'), 'jkl')
-
     def test_hasKey(self):
         cfg = configfile.ConfigFile()
         cfg.dict = {'foo': 'bar'}
@@ -599,30 +563,6 @@ class TestConfigFileWithProfiles(generic.TestCase):
         self.assertIn('profile3.foo', self.cfg.dict)
         self.cfg.removeProfileKeysStartsWith('f', '3')
         self.assertNotIn('profile3.foo', self.cfg.dict)
-
-    def test_remapProfileKey(self):
-        for profile in self.cfg.profiles():
-            self.cfg.setProfileStrValue('foo', '123', profile)
-            self.cfg.setProfileStrValue('bar', '456', profile)
-
-        # old key not in cfg
-        self.cfg.remapProfileKey('notExistedKey', 'baz', 1)
-        self.assertEqual(self.cfg.profileStrValue('foo', '', 1), '123')
-        self.assertEqual(self.cfg.profileStrValue('bar', '', 1), '456')
-
-
-        # valid remap
-        self.cfg.remapProfileKey('foo', 'baz', 1)
-        self.assertEqual(self.cfg.profileStrValue('foo', '', 1), '')
-        self.assertEqual(self.cfg.profileStrValue('baz', '', 1), '123')
-        self.assertEqual(self.cfg.profileStrValue('foo', '', 2), '123')
-        self.assertEqual(self.cfg.profileStrValue('foo', '', 3), '123')
-
-        # do not overwrite existing keys
-        self.cfg.remapProfileKey('foo', 'bar', 1)
-        self.assertEqual(self.cfg.profileStrValue('foo', '', 2), '123')
-        self.assertEqual(self.cfg.profileStrValue('baz', '', 2), '')
-        self.assertEqual(self.cfg.profileStrValue('bar', '', 2), '456')
 
     def test_hasProfileKey(self):
         for profile in self.cfg.profiles():


### PR DESCRIPTION
In year 2016 BIT introduced a new config file version numbered as 6 (see commit 72fc490) and migrated config files of older versions into that new version.

This migration is dropped in preparation of #1923 