### PR TITLE
fix: "Repeatedly" schedule mode now consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   ([#2482](https://github.com/bit-team/backintime/issues/2482))
 - Clear up license and copyright situation of `qt/serviceHelper.py`
   ([#1986](https://github.com/bit-team/backintime/issues/1986))
+- GUI: Schedule mode "Repeatedly (anacron)" re-phrased and extended with
+  explanations ([#2507](https://github.com/bit-team/backintime/issues/2507))
 
 ### Added
 - Gocryptfs for SSH encrypted profiles
@@ -45,23 +47,19 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Dependency: `encfs`
 - CLI:
   - Switch `--keep-mount`
-  - Command `decode` because of EncFS removal
-    ([#1734](https://github.com/bit-team/backintime/issues/1734))
-  - Command `benchmark-cipher`
-    ([#2120](https://github.com/bit-team/backintime/issues/2120))
+  - Command `decode` because of EncFS removal ([#1734](https://github.com/bit-team/backintime/issues/1734))
+  - Command `benchmark-cipher` ([#2120](https://github.com/bit-team/backintime/issues/2120))
 - SSH Cipher ([#2176](https://github.com/bit-team/backintime/issues/2176))
 - Config examples
 - Languages Faroese, Croatian, Vietnames and Norwegian (Nynorsk)
   ([#2080](https://github.com/bit-team/backintime/issues/2080))
 - GUI Expert Options:
-  - "Check if remote host is online"
-    ([#2482](https://github.com/bit-team/backintime/issues/2482)).
-  - "Check if remote host supports all necessary commands"
-    ([#2482](https://github.com/bit-team/backintime/issues/2482)).
-
+  - "Check if remote host is online" ([#2482](https://github.com/bit-team/backintime/issues/2482)).
+  - "Check if remote host supports all necessary commands" ([#2482](https://github.com/bit-team/backintime/issues/2482)).
 
 ## Fixed
 - Prevent crash in case a plugin fails ([#2447](https://github.com/bit-team/backintime/issues/2447))
+- Schedule mode "Repeatedly (anacron)" using "Hourly" units ([#2507](https://github.com/bit-team/backintime/issues/2507))
 
 ## [1.6.1] (2026-02-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 
 ## Fixed
 - Prevent crash in case a plugin fails ([#2447](https://github.com/bit-team/backintime/issues/2447))
-- Schedule mode "Repeatedly (anacron)" using "Hourly" units ([#2507](https://github.com/bit-team/backintime/issues/2507))
+- Schedule mode "Repeatedly (anacron)" using "Hourly" units is now consistent with other units ([#2507](https://github.com/bit-team/backintime/issues/2507))
 
 ## [1.6.1] (2026-02-10)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -8,7 +8,7 @@ This file is part of the program "Back In Time" which is released under GNU
 General Public License v2 (GPLv2). See LICENSES directory or go to
 <https://spdx.org/licenses/GPL-2.0-or-later.html>
 -->
-<sub>December 2025</sub>
+<sub>June 2026</sub>
 
 # FAQ - Frequently Asked Questions
 
@@ -41,7 +41,6 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
    * [Back In Time doesn't find my old backups on my new Computer](#back-in-time-doesnt-find-my-old-backups-on-my-new-computer)
 - [Schedule](#schedule)
    * [How does the 'Repeatedly (anacron)' schedule work?](#how-does-the-repeatedly-anacron-schedule-work)
-   * [Will a scheduled backup run as soon as the computer is back on?](#will-a-scheduled-backup-run-as-soon-as-the-computer-is-back-on)
    * [If I edit my crontab and add additional entries, will that be a problem for BIT as long as I don't touch its entries? What does it look for in the crontab to find its own entries?](#if-i-edit-my-crontab-and-add-additional-entries-will-that-be-a-problem-for-bit-as-long-as-i-dont-touch-its-entries-what-does-it-look-for-in-the-crontab-to-find-its-own-entries)
    * [Can I use a systemd timer instead of cron?](#can-i-use-a-systemd-timer-instead-of-cron)
 - [Problems, Errors & Solutions](#problems-errors--solutions)
@@ -655,40 +654,23 @@ You have three options to fix this:
 
 # Schedule
 
-## How does the 'Repeatedly (anacron)' schedule work?
+## How does the 'Repeatedly' schedule work?
 
-In fact *Back In Time* doesn't use anacron anymore. It was to inflexible. But that
-schedule mimics anacron.
-
-BIT will create a crontab entry which will start ``backintime --backup-job``
-every 15min (or once an hour if the schedule is set to *weeks*). With the
-``--backup-job`` command, BIT will check if the profile is supposed to be run
-this time or exit immediately. For this it will read the time of the last
-successful run from ``~/.local/share/backintime/anacron/ID_PROFILENAME``.
+_Back In Time_ will create a crontab entry which will start
+``backintime --backup-job`` every 15min (or once an hour if the schedule is
+set to *weeks*). With the ``--backup-job`` command, _Back In Time_ will check
+if the profile is supposed to be run this time or exit immediately. For this
+it will read the time of the last successful run from
+``~/.local/share/backintime/anacron/ID_PROFILENAME``.
 If this is older than the configured time, it will continue creating a backup.
 
-If the backup was successful without errors, BIT will write the current time
-into ``~/.local/share/backintime/anacron/ID_PROFILENAME`` (even if *Repeatedly
-(anacron)* isn't chosen). So, if there was an error, BIT will try again at
-the next quarter hour.
+If the backup was successful without errors, _Back In Time_ will write the
+current time into ``~/.local/share/backintime/anacron/ID_PROFILENAME``
+(even if *Repeatedly* isn't chosen). So, if there was an error, _Back In Time_
+will try again at the next quarter hour.
 
 ``backintime --backup`` will always create a new backup. No matter how many
 time elapsed since last successful backup.
-
-## Will a scheduled backup run as soon as the computer is back on?
-
-Depends on which schedule you choose:
-
-- the schedule ``Repeatedly (anacron)`` will use an anacron-like code. So if
-  your computer is back on it will start the job if the given time is gone till
-  last backup.
-
-- with ``When drive get connected (udev)`` *Back In Time* will start a backup
-  as soon as you connect your drive ;-)
-
-- old fashion schedules like ``Every Day`` will use cron. This will only start a
-  new backup at the given time. If your computer is off, no backup will be
-  created.
 
 ## If I edit my crontab and add additional entries, will that be a problem for BIT as long as I don't touch its entries? What does it look for in the crontab to find its own entries?
 

--- a/common/config.py
+++ b/common/config.py
@@ -1379,7 +1379,7 @@ class Config(configfile.ConfigFileWithProfiles):
         if not last_time:
             return True
 
-        return tools.elapsed_at_least(
+        return tools.crossed_at_least_units(
             start=last_time,
             end=datetime.datetime.now(),
             value=self.scheduleRepeatedPeriod(profile_id),

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -598,6 +598,19 @@ class ValidateSnapshotsPath(generic.TestCaseCfg):
 
 
 class ElapsedAtLeast(unittest.TestCase):
+    def test_hours_false(self):
+        # 18:56
+        self.assertFalse(
+            tools.elapsed_at_least(
+                # 18:23 last job run
+                datetime(1982, 8, 6, 18, 23, 0, 0),
+                # 18:56 end
+                datetime(1982, 8, 6, 18, 56, 0, 0),
+                # 1 hour
+                1, TimeUnit.HOUR
+            )
+        )
+
     def test_hours_boundary(self):
         # 18:23
         last_job_run = datetime(1982, 8, 6, 18, 23, 0, 0)
@@ -607,7 +620,7 @@ class ElapsedAtLeast(unittest.TestCase):
         self.assertTrue(tools.elapsed_at_least(last_job_run, end, 1, TimeUnit.HOUR))
         self.assertFalse(tools.elapsed_at_least(last_job_run, end, 2, TimeUnit.HOUR))
 
-        # 20:01 (only 36 minutes later, but the next hour)
+        # 20:01 (only 1 hour and 36 minutes later, but over the boundary)
         end = datetime(1982, 8, 6, 20, 1, 0, 0)
         self.assertTrue(tools.elapsed_at_least(last_job_run, end, 2, TimeUnit.HOUR))
 

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -597,11 +597,11 @@ class ValidateSnapshotsPath(generic.TestCaseCfg):
             self.assertTrue(ret)
 
 
-class ElapsedAtLeast(unittest.TestCase):
+class CrossedAtLeastUnits(unittest.TestCase):
     def test_hours_false(self):
         # 18:56
         self.assertFalse(
-            tools.elapsed_at_least(
+            tools.crossed_at_least_units(
                 # 18:23 last job run
                 datetime(1982, 8, 6, 18, 23, 0, 0),
                 # 18:56 end
@@ -617,12 +617,12 @@ class ElapsedAtLeast(unittest.TestCase):
 
         # 19:01 (only 36 minutes later, but the next hour)
         end = datetime(1982, 8, 6, 19, 1, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 1, TimeUnit.HOUR))
-        self.assertFalse(tools.elapsed_at_least(last_job_run, end, 2, TimeUnit.HOUR))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 1, TimeUnit.HOUR))
+        self.assertFalse(tools.crossed_at_least_units(last_job_run, end, 2, TimeUnit.HOUR))
 
         # 20:01 (only 1 hour and 36 minutes later, but over the boundary)
         end = datetime(1982, 8, 6, 20, 1, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 2, TimeUnit.HOUR))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 2, TimeUnit.HOUR))
 
     def test_days_not_older(self):
         """Two days"""
@@ -632,14 +632,14 @@ class ElapsedAtLeast(unittest.TestCase):
         # 7th August, 18:23
         end = datetime(1982, 8, 7, 18, 23, 0, 0)
 
-        self.assertFalse(tools.elapsed_at_least(birth, end, 2, TimeUnit.DAY))
+        self.assertFalse(tools.crossed_at_least_units(birth, end, 2, TimeUnit.DAY))
 
     def test_days_older(self):
         """Two days plus one ms"""
         birth = datetime(1982, 8, 6, 18, 23, 0, 0)
         end = datetime(1982, 8, 8, 18, 23, 0, 1)
 
-        self.assertTrue(tools.elapsed_at_least(birth, end, 2, TimeUnit.DAY))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 2, TimeUnit.DAY))
 
     def test_days_boundary_one_day(self):
         """The boundary of days not their duration."""
@@ -650,8 +650,8 @@ class ElapsedAtLeast(unittest.TestCase):
         # next day 2:13 (only 8 hours later)
         end = datetime(1982, 8, 7, 2, 23, 0, 0)
 
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 1, TimeUnit.DAY))
-        self.assertFalse(tools.elapsed_at_least(last_job_run, end, 2, TimeUnit.DAY))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 1, TimeUnit.DAY))
+        self.assertFalse(tools.crossed_at_least_units(last_job_run, end, 2, TimeUnit.DAY))
 
     def test_days_boundary_four_days(self):
         """The boundary of days not their duration."""
@@ -662,11 +662,11 @@ class ElapsedAtLeast(unittest.TestCase):
         # 9th August (the 4th day), at 2:13
         end = datetime(1982, 8, 9, 2, 23, 0, 0)
         # ...four days not finished yet
-        self.assertFalse(tools.elapsed_at_least(last_job_run, end, 4, TimeUnit.DAY))
+        self.assertFalse(tools.crossed_at_least_units(last_job_run, end, 4, TimeUnit.DAY))
 
         # 10th August (the 5th day), at 2:13
         end = datetime(1982, 8, 10, 2, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 4, TimeUnit.DAY))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 4, TimeUnit.DAY))
 
     def test_weeks_boundary(self):
         """
@@ -684,16 +684,16 @@ class ElapsedAtLeast(unittest.TestCase):
 
         # 9th August (Monday next week)
         end = datetime(1982, 8, 9, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 1, TimeUnit.WEEK))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 1, TimeUnit.WEEK))
 
         # 15th August (Saturday next week)
         end = datetime(1982, 8, 15, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 1, TimeUnit.WEEK))
-        self.assertFalse(tools.elapsed_at_least(birth, end, 2, TimeUnit.WEEK))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 1, TimeUnit.WEEK))
+        self.assertFalse(tools.crossed_at_least_units(birth, end, 2, TimeUnit.WEEK))
 
         # 16th August
         end = datetime(1982, 8, 16, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 2, TimeUnit.WEEK))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 2, TimeUnit.WEEK))
 
     def test_months_boundary(self):
         # 6th August
@@ -701,25 +701,25 @@ class ElapsedAtLeast(unittest.TestCase):
 
         # 1st Sept
         end = datetime(1982, 9, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 1, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 1, TimeUnit.MONTH))
 
         # 30 Sept
         end = datetime(1982, 9, 30, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 1, TimeUnit.MONTH))
-        self.assertFalse(tools.elapsed_at_least(birth, end, 2, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 1, TimeUnit.MONTH))
+        self.assertFalse(tools.crossed_at_least_units(birth, end, 2, TimeUnit.MONTH))
 
         # 1st Oct
         end = datetime(1982, 10, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 2, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 2, TimeUnit.MONTH))
 
         # 31 October
         end = datetime(1982, 10, 31, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 2, TimeUnit.MONTH))
-        self.assertFalse(tools.elapsed_at_least(birth, end, 3, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 2, TimeUnit.MONTH))
+        self.assertFalse(tools.crossed_at_least_units(birth, end, 3, TimeUnit.MONTH))
 
         # 1st November
         end = datetime(1982, 11, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 3, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 3, TimeUnit.MONTH))
 
     def test_months_steps(self):
         # 14th January
@@ -727,60 +727,60 @@ class ElapsedAtLeast(unittest.TestCase):
 
         # 31th January
         end = datetime(1982, 1, 31, 18, 23, 0, 0)
-        self.assertFalse(tools.elapsed_at_least(last_job_run, end, 1, TimeUnit.MONTH))
+        self.assertFalse(tools.crossed_at_least_units(last_job_run, end, 1, TimeUnit.MONTH))
         # 1st Feb
         end = datetime(1982, 2, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 1, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 1, TimeUnit.MONTH))
 
         # 28th Feb
         end = datetime(1982, 2, 28, 18, 23, 0, 0)
-        self.assertFalse(tools.elapsed_at_least(last_job_run, end, 2, TimeUnit.MONTH))
+        self.assertFalse(tools.crossed_at_least_units(last_job_run, end, 2, TimeUnit.MONTH))
         # 1st March
         end = datetime(1982, 3, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 2, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 2, TimeUnit.MONTH))
 
         # 31th March
         end = datetime(1982, 3, 31, 18, 23, 0, 0)
-        self.assertFalse(tools.elapsed_at_least(last_job_run, end, 3, TimeUnit.MONTH))
+        self.assertFalse(tools.crossed_at_least_units(last_job_run, end, 3, TimeUnit.MONTH))
         # 1st April
         end = datetime(1982, 4, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 3, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 3, TimeUnit.MONTH))
 
         # 1st May
         end = datetime(1982, 5, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 4, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 4, TimeUnit.MONTH))
 
         # 1st June
         end = datetime(1982, 6, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 5, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 5, TimeUnit.MONTH))
 
         # 1st July
         end = datetime(1982, 7, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 6, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 6, TimeUnit.MONTH))
 
         # 1st Aug
         end = datetime(1982, 8, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 7, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 7, TimeUnit.MONTH))
 
         # 1st Sept
         end = datetime(1982, 9, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 8, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 8, TimeUnit.MONTH))
 
         # 1st Oct
         end = datetime(1982, 10, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 9, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 9, TimeUnit.MONTH))
 
         # 1st Nov
         end = datetime(1982, 11, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 10, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 10, TimeUnit.MONTH))
 
         # 1st Dec
         end = datetime(1982, 12, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 11, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 11, TimeUnit.MONTH))
 
         # 1st Jan (next year)
         end = datetime(1983, 1, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(last_job_run, end, 12, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(last_job_run, end, 12, TimeUnit.MONTH))
 
     def test_months_31th(self):
         # 31th May
@@ -788,12 +788,12 @@ class ElapsedAtLeast(unittest.TestCase):
 
         # 1st June
         end = datetime(1982, 6, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 1, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 1, TimeUnit.MONTH))
 
         # 30th September
         end = datetime(1982, 9, 30, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 4, TimeUnit.MONTH))
-        self.assertFalse(tools.elapsed_at_least(birth, end, 5, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 4, TimeUnit.MONTH))
+        self.assertFalse(tools.crossed_at_least_units(birth, end, 5, TimeUnit.MONTH))
 
     def test_months_next_year(self):
         # 6th August, 1982
@@ -801,12 +801,12 @@ class ElapsedAtLeast(unittest.TestCase):
 
         # 1st March, 1983
         end = datetime(1983, 3, 1, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 7, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 7, TimeUnit.MONTH))
 
         # 6th March, 1983
         end = datetime(1983, 3, 6, 18, 23, 0, 0)
-        self.assertTrue(tools.elapsed_at_least(birth, end, 7, TimeUnit.MONTH))
-        self.assertFalse(tools.elapsed_at_least(birth, end, 8, TimeUnit.MONTH))
+        self.assertTrue(tools.crossed_at_least_units(birth, end, 7, TimeUnit.MONTH))
+        self.assertFalse(tools.crossed_at_least_units(birth, end, 8, TimeUnit.MONTH))
 
 
 class NestedDictUpdate(unittest.TestCase):

--- a/common/tools.py
+++ b/common/tools.py
@@ -782,8 +782,10 @@ def elapsed_at_least(start: datetime,
                      end: datetime,
                      value: int,
                      unit: TimeUnit) -> bool:
-    """
-    Check if a time span meets at least a number of time units, counting
+    """new: Count the number of crossed calendar unit boundaries between start and
+    end. Return True if at least value boundaries have been crossed.
+
+    old: Check if a time span meets at least a number of time units, counting
     partial units as full.
 
 
@@ -806,6 +808,7 @@ def elapsed_at_least(start: datetime,
     Returns:
         ``True`` if the elapsed time is greater than or equal to ``value``
         units, otherwise ``False``.
+
     """
     # Workaround
     if not isinstance(unit, TimeUnit):
@@ -813,8 +816,15 @@ def elapsed_at_least(start: datetime,
 
     if unit is TimeUnit.HOUR:
         # Calculate difference in hours, counting partial hours
-        delta_hours = math.ceil((end - start).total_seconds() / 3600)
+        start_hour = start.replace(minute=0, second=0, microsecond=0)
+        end_hour = end.replace(minute=0, second=0, microsecond=0)
+
+        delta_hours = int(
+            (end_hour - start_hour).total_seconds() / 3600
+        )
+
         return delta_hours >= value
+
 
     if unit is TimeUnit.DAY:
         return start.date() <= (end.date() - timedelta(days=value))

--- a/common/tools.py
+++ b/common/tools.py
@@ -778,26 +778,19 @@ def get_git_repository_info(path=None, hash_length=None):
     return result
 
 
-def elapsed_at_least(start: datetime,
-                     end: datetime,
-                     value: int,
-                     unit: TimeUnit) -> bool:
-    """new: Count the number of crossed calendar unit boundaries between start and
-    end. Return True if at least value boundaries have been crossed.
+def crossed_at_least_units(start: datetime,
+                           end: datetime,
+                           value: int,
+                           unit: TimeUnit) -> bool:
+    """Return ``True`` if at least ``value`` boundaries have been crossed.
 
-    old: Check if a time span meets at least a number of time units, counting
-    partial units as full.
+    The number of crossed calendar unit boundaries between ``start`` and
+    ``end`` is counted. The elapsed time between ``start`` and ``end`` is
+    measured in terms of crossed calendar units rather than exact durations.
 
-
-    Return ``True`` if the time span between ``start`` and ``end`` is at least
-    ``value`` units (``units``). The unit can be hours, days, weeks, or months
-    (see `TimeUnit` for details). Partial units are counted.
-
-    The difference is measured as follows:
-    * hours: full or partial hours
-    * days: calendar days (date only)
-    * weeks: full or partial calendar weeks (starting Monday)
-    * months: full or partial calendar months
+    A ``unit`` is considered elapsed when its boundary has
+    been crossed. For example, moving from 18:59 to 19:02 crosses one hour
+    boundary, even though only three minutes have elapsed.
 
     Args:
         start: Beginning timestamp.
@@ -806,8 +799,8 @@ def elapsed_at_least(start: datetime,
         unit: TimeUnit specifying hours, days, weeks, or months.
 
     Returns:
-        ``True`` if the elapsed time is greater than or equal to ``value``
-        units, otherwise ``False``.
+        ``True`` if at least ``value`` boundaries have been crossed,
+        otherwise ``False``.
 
     """
     # Workaround

--- a/doc/manual/src/manage-profiles.md
+++ b/doc/manual/src/manage-profiles.md
@@ -151,15 +151,20 @@ schedules. You can use `crontab -l` to view them or `crontab -e` to edit.
 - **Every Day**: start a new backup on a configurable time on every day. If
   the computer is not running at the configured time there will be no new
   backup for the day.
-- **Repeatedly (anacron)**: this schedule will start new backups after a
-  configurable time (hours, days or weeks) when the last backup was done
-  before this delay. This will also work when the system was powered off. It
-  does imitate anacron but doesn't use it. Instead Back in Time writes it's own
-  time-stamp after each successful backup and add a `crontab` job which will
-  start Back in Time every 15min (or every hour if configured for weeks). If
-  the configured delay is not done yet it will just exit immediately. If an
-  error occurred during taking the backup it won't write a new time-stamp and
-  so will try again after 15min/one hour.
+- **Repeatedly**: this schedule triggers backups when a configured number of
+  calendar units (hours, days, weeks, or months) has passed since the last
+  successful backup.
+  A backup becomes due once a new calendar unit has been reached. For
+  example, "1 hour" means the backup runs once the next clock hour begins,
+  not after a fixed 60-minute duration.
+  _Back In Time checks_ the schedule periodically via a crontab entry
+  (typically every 15 minutes, or every hour for longer intervals). If no
+  backup is due, it exits immediately.
+  If the system was powered off or _Back In Time_ was not running at the
+  scheduled time, the next execution will still perform the backup if it is
+  due. No scheduled backup is lost.
+  If a backup fails, no new timestamp is written, and the backup will be
+  retried on the next check.
 - **When drive get connected (udev)**: this schedule will start a new backup
   as soon as the USB/eSATA/Firewire drive get connected. You can configure a
   delay (hours, days or weeks like in schedule Repeatedly) so it won't start on

--- a/doc/manual/src/manage-profiles.md
+++ b/doc/manual/src/manage-profiles.md
@@ -168,8 +168,7 @@ specific events, such as system startup or connecting a backup drive via USB.
   backup is due, it exits immediately.
   If the system was powered off or _Back In Time_ was not running when a backup
   became due, the backup will be performed the next time the schedule is
-  checked. If a backup fails, no new timestamp is written, and the backup will
-  be retried on the next check.
+  checked. If a backup fails, it will be retried on the next check.
 
 **Event-based schedule modes**:
 
@@ -178,10 +177,10 @@ specific events, such as system startup or connecting a backup drive via USB.
   suspend/hibernate will not trigger this schedule.
 - **When drive gets connected (udev)**: this schedule will start a new backup
   as soon as the USB/eSATA/Firewire drive gets connected. You can configure a
-  delay (hours, days or weeks like in schedule Repeatedly) so it won't start on
+  delay (hours, days or weeks) so it won't start on
   every new connection. This will add a new udev rule in
-  `/etc/udev/rules.d/99-backintime-<USER>.rules` using the partitions UUID. If
-  using KDE you need to enable auto-mount for the device in System-Settings.
+  `/etc/udev/rules.d/99-backintime-<USER>.rules` using the partitions UUID.
+  Make sure auto-mount is enabled in your system.
 
 **Technical details**:
 

--- a/doc/manual/src/manage-profiles.md
+++ b/doc/manual/src/manage-profiles.md
@@ -126,31 +126,37 @@ below. You can change them to match paths from other machines.
 
 ### Schedule
 
-You can choose between couple different schedules which will automatically
-start a new backup. Most of them will use `crontab` to set up new
-schedules. You can use `crontab -l` to view them or `crontab -e` to edit.
+Different schedule types are available for different backup workflows
+depending on how backups should be triggered.
 
-- **At every boot/reboot**: start a new backup immediately after
-  startup. This will add a `@reboot <COMMAND>` line in `crontab`. Wake up from
-  suspend/hibernate will not trigger this schedule.
+Most schedules run backups at **fixed times**. If the computer is turned off at
+the scheduled time, the backup is skipped and will not be started later. 
+Other schedules can **catch up** on missed backups. If the computer was turned
+off when a backup became due, the backup will be started the next time _Back
+In Time_ is able to check the schedule. 
+Additionally **event-based** schedules start backups in response to
+specific events, such as system startup or connecting a backup drive via USB.
+
+**Fixed-time schedule modes**:
+
+- **Every Day**: start a new backup on a configurable time on every day.
+- **Every Week**: start a new backup on a configurable week-day/time every week.
+- **Every Month**: start a new backup on a configurable day/time every month.
+- **Every Year**: start a new backup on first day of first month of each year at a configurable time.
 - **Every X minutes**: start a new backup every 5, 10 or 30 minutes. This
   will add a line `*/<X> * * * * <COMMAND>` in `crontab`.
 - **Every hour**: start a new backup on every full hour. This will add a line
   `0 * * * * <COMMAND>` in `crontab`.
 - **Every X hours**: start a new backup every 2, 4, 6 or 12 hours at the full
-  hour (e.g. at 0:00, 6:00, 12:00 and 18:00 with schedule [Every 6 hours). This
-  will add a line `0 */<X> * * * <COMMAND>` in `crontab`. If the computer is
-  not running at scheduled time there will be no new backup. This will not
-  resume after switching on again.
+  hour (e.g. at 0:00, 6:00, 12:00 and 18:00 with schedule "Every 6 hours"). This
+  will add a line `0 */<X> * * * <COMMAND>` in `crontab`.
 - **Custom Hours**: define custom pattern for `crontab`. This can be either a
-  comma separated list of hours (e.g 0,10,13,15,17,20,23) or \*/\<X\>
-  (e.g. [\*/3) for periodic schedules. This will add a line `0
-  0,10,13,15,17,20,23 * * * <COMMAND>` in `crontab`. If the computer is not
-  running at scheduled time there will be no new backup. This will not resume
-  after switching on again.
-- **Every Day**: start a new backup on a configurable time on every day. If
-  the computer is not running at the configured time there will be no new
-  backup for the day.
+  comma separated list of hours (e.g `0,10,13,15,17,20,23`) or `*/<X>` (e.g.
+  `*/3`) for periodic schedules. This will add a line
+  `0 0,10,13,15,17,20,23 * * * <COMMAND>` in `crontab`.
+
+**Catch-up schedule mode**:
+
 - **Repeatedly**: this schedule triggers backups when a configured number of
   calendar units (hours, days, weeks, or months) has passed since the last
   successful backup.
@@ -160,32 +166,27 @@ schedules. You can use `crontab -l` to view them or `crontab -e` to edit.
   _Back In Time checks_ the schedule periodically via a crontab entry
   (typically every 15 minutes, or every hour for longer intervals). If no
   backup is due, it exits immediately.
-  If the system was powered off or _Back In Time_ was not running at the
-  scheduled time, the next execution will still perform the backup if it is
-  due. No scheduled backup is lost.
-  If a backup fails, no new timestamp is written, and the backup will be
-  retried on the next check.
-- **When drive get connected (udev)**: this schedule will start a new backup
-  as soon as the USB/eSATA/Firewire drive get connected. You can configure a
+  If the system was powered off or _Back In Time_ was not running when a backup
+  became due, the backup will be performed the next time the schedule is
+  checked. If a backup fails, no new timestamp is written, and the backup will
+  be retried on the next check.
+
+**Event-based schedule modes**:
+
+- **At every boot/reboot**: start a new backup immediately after
+  startup. This will add a `@reboot <COMMAND>` line in `crontab`. Wake up from
+  suspend/hibernate will not trigger this schedule.
+- **When drive gets connected (udev)**: this schedule will start a new backup
+  as soon as the USB/eSATA/Firewire drive gets connected. You can configure a
   delay (hours, days or weeks like in schedule Repeatedly) so it won't start on
   every new connection. This will add a new udev rule in
   `/etc/udev/rules.d/99-backintime-<USER>.rules` using the partitions UUID. If
   using KDE you need to enable auto-mount for the device in System-Settings.
-- **Every Week**: start a new backup on a configurable week-day/time every
-  week. If the computer is not running at the configured time there will be no
-  new backup for the week.
-- **Every Month**: start a new backup on a configurable day/time every
-  month. If the computer is not running at the configured time there will be no
-  new backup for the month.
-- **Every Year**: Start a new backup on on first day of first month of each
-  year at a configurable time. If the computer is not running at the configured
-  time there will be no new backup for the year.
 
-!!! note
-    For hourly schedules (every hour, every x hours, and custom hours),
-    there will be an option to specify how many minutes after the hour the
-    schedule should run. This can be used to prevent multiple backup profiles
-    from running at the same time.
+**Technical details**:
+
+Most of the modes will use `crontab` to set up new schedules. You can use
+`crontab -l` to view them or `crontab -e` to edit them manually.
 
 ## Include
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -393,6 +393,7 @@ class MainWindow(QMainWindow):
         state_data = StateData()
         if state_data.msg_encfs_global < bitbase.ENCFS_MSG_STAGE:
             state_data.msg_encfs_global = bitbase.ENCFS_MSG_STAGE
+            state_data.save()
             dlg = encfsmsgbox.EncfsFinalRemoval(config_fp_backup)
             dlg.exec()
 

--- a/qt/manageprofiles/combobox.py
+++ b/qt/manageprofiles/combobox.py
@@ -9,6 +9,7 @@
 from typing import Any
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QComboBox, QWidget
+import qttools
 
 
 class BitComboBox(QComboBox):
@@ -29,6 +30,13 @@ class BitComboBox(QComboBox):
             40: 'Month'
         }
         combo = BitComboBox(parent, fill)
+
+        # more complex
+        fill = {
+            10: ('Label', 'tooltip'),
+            20: ('Second label', 'tooltip', ICON),
+            30: 'Week',
+        }
 
     """
 
@@ -64,7 +72,10 @@ class BitComboBox(QComboBox):
 
             if tip is not None:
                 self.setItemData(
-                    self.count()-1, tip, Qt.ItemDataRole.ToolTipRole)
+                    self.count()-1,
+                    qttools.wrap_tooltip(tip),
+                    Qt.ItemDataRole.ToolTipRole
+                )
 
     @property
     def current_data(self) -> Any:

--- a/qt/manageprofiles/schedulewidget.py
+++ b/qt/manageprofiles/schedulewidget.py
@@ -26,6 +26,14 @@ import tools
 import qttools
 from manageprofiles import combobox
 
+_REPEATEDLY_TOOLTIP = _(
+    'For example, "repeatedly every 1 hour" means a backup is triggered at '
+    'each new clock hour. If the last successful backup was at 18:56, it '
+    'will be triggered again at 19:00 because the hour boundary has been '
+    'crossed. This schedule mode is useful if the computer is not running '
+    'regularly.'
+)
+
 
 class ScheduleWidget(QGroupBox):
     """Widget about schedule snapshots.
@@ -39,7 +47,10 @@ class ScheduleWidget(QGroupBox):
 
         main_layout = QFormLayout(self)
 
-        def _create_form_entry(label: str, widget: QWidget = None) -> int:
+        def _create_form_entry(
+                label: str,
+                widget: QWidget = None,
+                tooltip: str = None) -> int:
             """Helper to create a row with a label and widget in the form
             layout.
 
@@ -48,9 +59,13 @@ class ScheduleWidget(QGroupBox):
             """
             if widget:
                 main_layout.addRow(label, widget)
+                if tooltip:
+                    widget.setToolTip(tooltip)
             else:
                 lbl = QLabel(label)
                 lbl.setWordWrap(True)
+                if tooltip:
+                    qttools.set_wrapped_tooltip(lbl, tooltip)
                 main_layout.addRow(lbl)
 
             return main_layout.rowCount() - 1
@@ -93,11 +108,12 @@ class ScheduleWidget(QGroupBox):
             _('Run Back In Time as soon as the drive is connected (only once'
               ' every X days). A sudo password prompt will appear.'))
 
-        # Repeatedly (like anacron)
+        # Repeatedly
         self._rowidx_repeated = _create_form_entry(
-            _('Run Back In Time repeatedly. This is useful if the computer '
-              'is not running regularly.'))
-
+            label=_('Trigger a backup when a new hour, day, week, or month begins. '
+              'If the system was off, it runs on the next start.'),
+            tooltip=_REPEATEDLY_TOOLTIP
+        )
         # Repeatedly - Every (value) (units)
         self._spin_period = QSpinBox(self)
         self._spin_period.setSingleStep(1)
@@ -162,7 +178,9 @@ class ScheduleWidget(QGroupBox):
                 'Every hour', 'Every {n} hours', 12).format(n=12),
             config.Config.CUSTOM_HOUR: _('Custom hours'),
             config.Config.DAY: _('Every day'),
-            config.Config.REPEATEDLY: _('Repeatedly (anacron)'),
+            config.Config.REPEATEDLY: (
+                _('Repeatedly'), _REPEATEDLY_TOOLTIP
+            ),
             config.Config.UDEV: _('When drive gets connected (udev)'),
             config.Config.WEEK: _('Every week'),
             config.Config.MONTH: _('Every month'),

--- a/qt/manageprofiles/schedulewidget.py
+++ b/qt/manageprofiles/schedulewidget.py
@@ -42,7 +42,10 @@ class ScheduleWidget(QGroupBox):
     """
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, parent: QWidget, allow_udev: bool = True):
+    # pylint: disable=too-many-statements
+    def __init__(self,  # noqa: PLR0915
+                 parent: QWidget,
+                 allow_udev: bool = True):
         super().__init__(title=_('Schedule'), parent=parent)
 
         main_layout = QFormLayout(self)
@@ -70,6 +73,12 @@ class ScheduleWidget(QGroupBox):
 
             return main_layout.rowCount() - 1
 
+        def _create_spin_box(step, range_min, range_max) -> QSpinBox:
+            spin = QSpinBox(self)
+            spin.setSingleStep(step)
+            spin.setRange(range_min, range_max)
+            return spin
+
         # Schedule modes
         self._combo_schedule_mode = self._schedule_mode_combobox()
         main_layout.addRow(self._combo_schedule_mode)
@@ -94,9 +103,7 @@ class ScheduleWidget(QGroupBox):
             _('Hours:'), self._edit_cronpattern)
 
         # Offset
-        self._spin_offset = QSpinBox(self)
-        self._spin_offset.setSingleStep(1)
-        self._spin_offset.setRange(0, 59)
+        self._spin_offset = _create_spin_box(1, 0, 59)
         hlayout = QHBoxLayout()
         hlayout.addWidget(self._spin_offset)
         hlayout.addWidget(QLabel(_('after the hour'), self))
@@ -110,14 +117,14 @@ class ScheduleWidget(QGroupBox):
 
         # Repeatedly
         self._rowidx_repeated = _create_form_entry(
-            label=_('Trigger a backup when a new hour, day, week, or month begins. '
-              'If the system was off, it runs on the next start.'),
+            label=_(
+                'Trigger a backup when a new hour, day, week, or month '
+                'beginns. If the system was off, it runs on the next start.'
+            ),
             tooltip=_REPEATEDLY_TOOLTIP
         )
         # Repeatedly - Every (value) (units)
-        self._spin_period = QSpinBox(self)
-        self._spin_period.setSingleStep(1)
-        self._spin_period.setRange(1, 10000)
+        self._spin_period = _create_spin_box(1, 1, 10000)
         self._combo_repeated_unit = self._repeated_unit_combobox()
         hlayout = QHBoxLayout()
         hlayout.addWidget(self._spin_period)

--- a/qt/manageprofiles/sshkeyselector.py
+++ b/qt/manageprofiles/sshkeyselector.py
@@ -26,16 +26,6 @@ from manageprofiles.combobox import BitComboBox
 
 class SshKeyCombo(BitComboBox):
     """Combo box to select SSH key files.
-
-        # The keys are the underlying 'userData'.
-        fill = {
-            10: 'Hour',
-            20: 'Day',
-            30: 'Week',
-            40: 'Month'
-        }
-        combo = BitComboBox(parent, fill)
-
     """
 
     ACT_ID_SELECT_FILE = 1

--- a/qt/qttools.py
+++ b/qt/qttools.py
@@ -131,26 +131,17 @@ def might_be_richtext(txt: str) -> bool:
     return bool(_REX_RICHTEXT.match(txt))
 
 
-def set_wrapped_tooltip(widget: Union[QWidget, Iterable[QWidget]],
-                        tooltip: Union[str, Iterable[str]],
-                        wrap_length: int = 72):
-    """Add a tooltip to the widget but insert line breaks when appropriated.
+def wrap_tooltip(tooltip: Union[str, Iterable[str]],
+                 wrap_length: int = 72) -> str:
+    """Wrap a tooltip string but insert line breaks when appropriated.
 
     If a list of strings is provided, each string is wrapped individually and
     then joined with a line break.
 
     Args:
-        widget: The widget or list of widgets to which a tooltip should be
-            added.
         tooltip: The tooltip as string or iterable of strings.
         wrap_length: Every line is at most this lengths.
     """
-
-    if isinstance(widget, Iterable):
-        for wdg in widget:
-            set_wrapped_tooltip(wdg, tooltip, wrap_length)
-
-        return
 
     # Always use tuple or list
     if isinstance(tooltip, str):
@@ -176,7 +167,31 @@ def set_wrapped_tooltip(widget: Union[QWidget, Iterable[QWidget]],
     if is_richtext and result[0] != '<':
         result = f'<html>{result}</html>'
 
-    widget.setToolTip(result)
+    return result
+
+
+def set_wrapped_tooltip(widget: Union[QWidget, Iterable[QWidget]],
+                        tooltip: Union[str, Iterable[str]],
+                        wrap_length: int = 72):
+    """Add a tooltip to the widget but insert line breaks when appropriated.
+
+    If a list of strings is provided, each string is wrapped individually and
+    then joined with a line break.
+
+    Args:
+        widget: The widget or list of widgets to which a tooltip should be
+            added.
+        tooltip: The tooltip as string or iterable of strings.
+        wrap_length: Every line is at most this lengths.
+    """
+
+    if isinstance(widget, Iterable):
+        for wdg in widget:
+            set_wrapped_tooltip(wdg, tooltip, wrap_length)
+
+        return
+
+    widget.setToolTip(wrap_tooltip(tooltip, wrap_length))
 
 
 def update_combo_profiles(config, combo_profiles, current_profile_id):


### PR DESCRIPTION
The schedule mode "Repeatedly" (formaly known as "Repeatedly (anacron)" now behave consistent with all units (hours, days, weeks, months). It acts on unit boundaries not intervals.

Additionally the schedule widget improved trying to explain that behavior. Also the user manual was modified.

<img width="704" height="271" alt="image" src="https://github.com/user-attachments/assets/47ec191e-ba25-4b97-b16c-07f71db671af" />

Close #2507

@noyannus I am interested in your opinion on that. Is the GUI (label and tooltip) and the user manual clear for regular users?