### PR TITLE
refactor: Decouple ConfigFile class from snapshots module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   Behavior is intended to remain unchanged; regressions cannot be fully ruled
   out. ([PR#2449](https://github.com/bit-team/backintime/pull/2449))
 - **Breaking**: Minimal Python version 3.13 increased
+- **Breaking**: Part of the backup metadata ("info" file) migrated from an
+  INI-like format to JSON. Older versions of _Back In Time_ (before 2.0.0) may
+  have issues with backups created in 2.0.0 or later. Restoring still works,
+  but ownership and permission information is not restored correctly.
+  ([PR#2527](https://github.com/bit-team/backintime/pull/2527)) to avoid
 - Default mountpoint permissions changed from 700 to 711
   ([PR#2451](https://github.com/bit-team/backintime/pull/2451)) to avoid
   FUSE mount failures when accessing via different user contexts.

--- a/common/config.py
+++ b/common/config.py
@@ -954,7 +954,6 @@ class Config(configfile.ConfigFileWithProfiles):
 
     def minFreeSpaceAsStorageSize(self, profile_id = None):
         enabled, value, unit = self.minFreeSpace(profile_id)
-        print(f'minFreeSpaceAsStorageSize() :: {enabled=} {value=} {unit=}')  # DEBUG
 
         return (
             enabled,

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -2952,9 +2952,9 @@ class SID:  # -> "BackupID" will be its new name
         Returns:
             str:    date and time of last check (YYYY-MM-DD HH:MM:SS)
         """
-        fp = Path(self.path) / self.INFO
+        fp = Path(self.path()) / self.INFO_JSON
         if not fp.exists():
-            fp = Path(self.path) / self.INFO_JSON
+            fp = Path(self.path()) / self.INFO
 
         if fp.exists():
             return time.strftime(
@@ -2971,9 +2971,9 @@ class SID:  # -> "BackupID" will be its new name
         Set info files atime to current time to indicate this snapshot was
         checked against source without changes right now.
         """
-        fp = Path(self.path) / self.INFO
+        fp = Path(self.path()) / self.INFO_JSON
         if not fp.exists():
-            fp = Path(self.path) / self.INFO_JSON
+            fp = Path(self.path()) / self.INFO
 
         if fp.exists():
             os.utime(fp, None)
@@ -3020,12 +3020,13 @@ class SID:  # -> "BackupID" will be its new name
         one is in JSON format.
 
         """
-        # Check if the "old" format is present
-        old_fp = Path(self.path()) / self.INFO
+        new_fp = Path(self.path()) / self.INFO_JSON
+
         old_stat = None
 
-        if old_fp.exists():
-            # preserve the files timestamps
+        # Check if the new new format is used
+        if not new_fp.exists():
+            old_fp = Path(self.path()) / self.INFO
             old_stat = old_fp.stat()
 
             info_dict = tools.convert_info_ini_file_to_dict(old_fp)
@@ -3033,17 +3034,11 @@ class SID:  # -> "BackupID" will be its new name
             # store into new file
             self.store_to_info_file(info_dict)
 
-            # delete the old one
-            old_fp.unlink()
-
-        # load from new file
-        fp = Path(self.path()) / self.INFO_JSON
-
-        if old_stat:
             # set back the old timestamps because BIT is using them
-            os.utime(fp, (old_stat.st_atime, old_stat.st_mtime))
+            os.utime(new_fp, (old_stat.st_atime, old_stat.st_mtime))
 
-        info_dict = json.loads(fp.read_text(encoding='utf-8'))
+        # read from new file
+        info_dict = json.loads(new_fp.read_text(encoding='utf-8'))
 
         return info_dict
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -225,7 +225,7 @@ class Snapshots:
         self.uidCache = {}
         self.gidCache = {}
 
-    def uid(self, name, callback = None, backup = None):
+    def uid(self, name, callback=None, backup=None):
         """
         Get the User identifier (UID) for the user in ``name``.
         name->uid will be cached to speed up subsequent requests.
@@ -245,28 +245,34 @@ class Snapshots:
 
         if name in self.uidCache:
             return self.uidCache[name]
-        else:
-            uid = -1
-            try:
-                uid = pwd.getpwnam(name).pw_uid
-            except Exception as e:
-                if backup:
-                    uid = backup
-                    msg = "UID for '%s' is not available on this system. Using UID %s from snapshot." %(name, backup)
-                    logger.info(msg, self)
-                    if callback is not None:
-                        callback(msg)
-                else:
-                    self.restorePermissionFailed = True
-                    msg = 'Failed to get UID for %s: %s' %(name, str(e))
-                    logger.error(msg, self)
-                    if callback:
-                        callback(msg)
 
-            self.uidCache[name] = uid
-            return uid
+        uid = -1
+        try:
+            uid = pwd.getpwnam(name).pw_uid
+        except Exception as e:
+            if backup:
+                uid = backup
+                msg = (
+                    f"UID for '{name}' is not available on this system. Using "
+                    f"UID {backup} from snapshot."
+                )
+                logger.info(msg, self)
 
-    def gid(self, name, callback = None, backup = None):
+                if callback is not None:
+                    callback(msg)
+
+            else:
+                self.restorePermissionFailed = True
+                msg = f'Failed to get UID for {name}: {str(e)}'
+                logger.error(msg, self)
+                if callback:
+                    callback(msg)
+
+        self.uidCache[name] = uid
+
+        return uid
+
+    def gid(self, name, callback=None, backup=None):
         """
         Get the Group identifier (GID) for the group in ``name``.
         name->gid will be cached to speed up subsequent requests.
@@ -286,26 +292,27 @@ class Snapshots:
 
         if name in self.gidCache:
             return self.gidCache[name]
-        else:
-            gid = -1
-            try:
-                gid = grp.getgrnam(name).gr_gid
-            except Exception as e:
-                if backup is not None:
-                    gid = backup
-                    msg = "GID for '%s' is not available on this system. Using GID %s from snapshot." %(name, backup)
-                    logger.info(msg, self)
-                    if callback:
-                        callback(msg)
-                else:
-                    self.restorePermissionFailed = True
-                    msg = 'Failed to get GID for %s: %s' %(name, str(e))
-                    logger.error(msg, self)
-                    if callback:
-                        callback(msg)
 
-            self.gidCache[name] = gid
-            return gid
+        gid = -1
+        try:
+            gid = grp.getgrnam(name).gr_gid
+        except Exception as e:
+            if backup is not None:
+                gid = backup
+                msg = "GID for '%s' is not available on this system. Using GID %s from snapshot." %(name, backup)
+                logger.info(msg, self)
+                if callback:
+                    callback(msg)
+            else:
+                self.restorePermissionFailed = True
+                msg = 'Failed to get GID for %s: %s' %(name, str(e))
+                logger.error(msg, self)
+                if callback:
+                    callback(msg)
+
+        self.gidCache[name] = gid
+
+        return gid
 
     def userName(self, uid):
         """
@@ -3004,12 +3011,20 @@ class SID:  # -> "BackupID" will be its new name
         Returns:
             configfile.ConfigFile:  snapshots information
         """
+        # DEBUG
+        import traceback
+        traceback.print_stack(limit=12)
+
         i = configfile.ConfigFile()
         i.load(self.path(self.INFO))
         return i
 
     @info.setter
     def info(self, i):
+        # DEBUG
+        import traceback
+        traceback.print_stack(limit=12)
+
         assert isinstance(i, configfile.ConfigFile), 'i is not configfile.ConfigFile type: {}'.format(i)
         i.save(self.path(self.INFO))
 

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -13,6 +13,7 @@
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
 from __future__ import annotations
 import os
+import json
 from pathlib import Path
 import stat
 import datetime
@@ -27,7 +28,6 @@ import time
 import re
 from tempfile import TemporaryDirectory
 import config
-import configfile
 import logger
 import tools
 import encode
@@ -511,9 +511,11 @@ class Snapshots:
                     %(', '.join(paths), restore_to),
                     self)
 
-        info = sid.info
+        info_dict = sid.load_from_info_file()
 
-        cmd_prefix = tools.rsyncPrefix(self.config, no_perms=False, use_mode=['ssh'])
+        cmd_prefix = tools.rsyncPrefix(
+            self.config, no_perms=False, use_mode=['ssh']
+        )
         cmd_prefix.extend(('-R', '-v'))
 
         if backup:
@@ -587,12 +589,12 @@ class Snapshots:
         self.restorePermissionFailed = False
         fileInfoDict = sid.fileInfo
 
-        # cache uids/gids
-        for uid, name in info.listValue('user', ('int:uid', 'str:name')):
-            self.uid(name.encode(), callback = callback, backup = uid)
-
-        for gid, name in info.listValue('group', ('int:gid', 'str:name')):
-            self.gid(name.encode(), callback = callback, backup = gid)
+        # cache uids
+        for uid, name in info_dict['users'].items():
+            self.uid(name, callback=callback, backup=uid)
+        # cache gids
+        for gid, name in info_dict['groups'].items():
+            self.gid(name, callback=callback, backup=gid)
 
         if fileInfoDict:
             # restore dir permissions after all files are done
@@ -1238,22 +1240,20 @@ class Snapshots:
         logger.debug(
             f'Create info file for snapshot "{sid.displayName}".', self)
 
-        machine = self.config.host()
-        user = getpass.getuser()
-        profile_id = self.config.currentProfile()
+        info_dict = {
+            'backup': {
+                'date': sid.withoutTag,
+                'machine': self.config.host(),
+                'profile_id': self.config.currentProfile(),
+                'tag': sid.tag,
+                'user': getpass.getuser(),
+            }
+        }
 
-        i = configfile.ConfigFile()
-        i.setStrValue('snapshot_date', sid.withoutTag)
-        i.setStrValue('snapshot_machine', machine)
-        i.setStrValue('snapshot_user', user)
-        i.setIntValue('snapshot_profile_id', profile_id)
-        i.setIntValue('snapshot_tag', sid.tag)
-        i.setListValue(
-            'user', ('int:uid', 'str:name'), list(self.userCache.items()))
-        i.setListValue(
-            'group', ('int:gid', 'str:name'), list(self.groupCache.items()))
+        info_dict['users'] = self.userCache
+        info_dict['groups'] = self.groupCache
 
-        sid.info = i
+        sid.store_to_info_file(info_dict)
 
     def backupPermissions(self, sid):
         """
@@ -1471,7 +1471,6 @@ class Snapshots:
             rsync_prefix.append('--link-dest=%s' % link_dest)
 
         # sync changed folders
-        # logger.info("Call rsync to create a backup", self)
         new_snapshot.saveToContinue = True
         cmd = rsync_prefix + rsync_suffix
 
@@ -2595,7 +2594,10 @@ class SID:  # -> "BackupID" will be its new name
     """
     __cValidSID = re.compile(r'^\d{8}-\d{6}(?:-\d{3})?$')
 
+    # An INI like file storing some meta data about a backup. Deprecated.
     INFO = 'info'
+    # Replacement for 'info'
+    INFO_JSON = 'info.json'
     NAME = 'name'
     FAILED = 'failed'
     FILEINFO = 'fileinfo.bz2'
@@ -2950,9 +2952,16 @@ class SID:  # -> "BackupID" will be its new name
         Returns:
             str:    date and time of last check (YYYY-MM-DD HH:MM:SS)
         """
-        info = self.path(self.INFO)
-        if os.path.exists(info):
-            return time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(os.path.getatime(info)))
+        fp = Path(self.path) / self.INFO
+        if not fp.exists():
+            fp = Path(self.path) / self.INFO_JSON
+
+        if fp.exists():
+            return time.strftime(
+                '%Y-%m-%d %H:%M:%S',
+                time.localtime(fp.stat().st_atime)
+            )
+
         return self.displayID
 
     # using @property.setter would be confusing here as there is no value to
@@ -2962,9 +2971,12 @@ class SID:  # -> "BackupID" will be its new name
         Set info files atime to current time to indicate this snapshot was
         checked against source without changes right now.
         """
-        info = self.path(self.INFO)
-        if os.path.exists(info):
-            os.utime(info, None)
+        fp = Path(self.path) / self.INFO
+        if not fp.exists():
+            fp = Path(self.path) / self.INFO_JSON
+
+        if fp.exists():
+            os.utime(fp, None)
 
     @property
     def failed(self):
@@ -2999,34 +3011,46 @@ class SID:  # -> "BackupID" will be its new name
         elif os.path.exists(failedFile):
             os.remove(failedFile)
 
-    @property
-    def info(self):
+    def load_from_info_file(self) -> dict:
         """
-        Load/save "info" file which contains additional information
-        about this snapshot (using configfile.ConfigFile)
+        Load "info" file which contains additional information
+        about this backup.
 
-        Args:
-            i (configfile.ConfigFile):  info that should be saved.
+        Two file formats are supported, the older one was INI like and the new
+        one is in JSON format.
 
-        Returns:
-            configfile.ConfigFile:  snapshots information
         """
-        # DEBUG
-        import traceback
-        traceback.print_stack(limit=12)
+        # Check if the "old" format is present
+        old_fp = Path(self.path()) / self.INFO
+        old_stat = None
 
-        i = configfile.ConfigFile()
-        i.load(self.path(self.INFO))
-        return i
+        if old_fp.exists():
+            # preserve the files timestamps
+            old_stat = old_fp.stat()
 
-    @info.setter
-    def info(self, i):
-        # DEBUG
-        import traceback
-        traceback.print_stack(limit=12)
+            info_dict = tools.convert_info_ini_file_to_dict(old_fp)
 
-        assert isinstance(i, configfile.ConfigFile), 'i is not configfile.ConfigFile type: {}'.format(i)
-        i.save(self.path(self.INFO))
+            # store into new file
+            self.store_to_info_file(info_dict)
+
+            # delete the old one
+            old_fp.unlink()
+
+        # load from new file
+        fp = Path(self.path()) / self.INFO_JSON
+
+        if old_stat:
+            # set back the old timestamps because BIT is using them
+            os.utime(fp, (old_stat.st_atime, old_stat.st_mtime))
+
+        info_dict = json.loads(fp.read_text(encoding='utf-8'))
+
+        return info_dict
+
+    def store_to_info_file(self, info_dict: dict):
+        """Saves the given info dict in the info file"""
+        fp = Path(self.path()) / self.INFO_JSON
+        fp.write_text(json.dumps(info_dict, indent=4), encoding='utf-8')
 
     @property
     def fileInfo(self) -> FileInfoDict:

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -792,18 +792,17 @@ class InfoIniToDict(unittest.TestCase):
             'tag': '240',
             'user': 'user',
         },
-       'users': [
-            {'uid': 0, 'name': 'root'},
-            {'uid': 1000, 'name': 'user'}
-        ],
-        'groups': [
-            {'gid': 0, 'name': 'root'},
-            {'gid': 1000, 'name': 'user'}
-        ],
+        'users': {
+            0: 'root',
+            1000: 'user'
+        },
+        'groups': {
+            0: 'root',
+            1000: 'user'
+        },
     }
 
     def test_info_ini_to_json(self):
         ini_content = StringIO(self.INI)
         result = tools.convert_info_ini_file_to_dict(ini_content)
-        print(result)
         self.assertEqual(result, self.DICT)

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -785,19 +785,21 @@ class InfoIniToDict(unittest.TestCase):
     ])
 
     DICT = {
+        'backup': {
+            'date': '20260620-113047',
+            'machine': 'TONNE',
+            'profile_id': '1',
+            'tag': '240',
+            'user': 'user',
+        },
+       'users': [
+            {'uid': 0, 'name': 'root'},
+            {'uid': 1000, 'name': 'user'}
+        ],
         'groups': [
             {'gid': 0, 'name': 'root'},
             {'gid': 1000, 'name': 'user'}
         ],
-        'users': [
-            {'uid': 0, 'name': 'root'},
-            {'uid': 1000, 'name': 'user'}
-        ],
-        'snapshot_date': '20260620-113047',
-        'snapshot_machine': 'TONNE',
-        'snapshot_profile_id': 1,
-        'snapshot_tag': 240,
-        'snapshot_user': 'user'
     }
 
     def test_info_ini_to_json(self):

--- a/common/test/test_tools.py
+++ b/common/test/test_tools.py
@@ -19,6 +19,7 @@ import pathlib
 import stat
 import signal
 import unittest
+from io import StringIO
 from datetime import datetime
 from time import sleep
 from unittest.mock import patch
@@ -762,3 +763,45 @@ class NestedDictUpdate(unittest.TestCase):
         self.assertDictEqual(
             tools.nested_dict_update(org, update),
             expect)
+
+
+class InfoIniToDict(unittest.TestCase):
+    INI = '\n'.join([
+        'group.1.gid=0',
+        'group.1.name=root',
+        'group.2.gid=1000',
+        'group.2.name=user',
+        'group.size=2',
+        'snapshot_date=20260620-113047',
+        'snapshot_machine=TONNE',
+        'snapshot_profile_id=1',
+        'snapshot_tag=240',
+        'snapshot_user=user',
+        'user.1.name=root',
+        'user.1.uid=0',
+        'user.2.name=user',
+        'user.2.uid=1000',
+        'user.size=2',
+    ])
+
+    DICT = {
+        'groups': [
+            {'gid': 0, 'name': 'root'},
+            {'gid': 1000, 'name': 'user'}
+        ],
+        'users': [
+            {'uid': 0, 'name': 'root'},
+            {'uid': 1000, 'name': 'user'}
+        ],
+        'snapshot_date': '20260620-113047',
+        'snapshot_machine': 'TONNE',
+        'snapshot_profile_id': 1,
+        'snapshot_tag': 240,
+        'snapshot_user': 'user'
+    }
+
+    def test_info_ini_to_json(self):
+        ini_content = StringIO(self.INI)
+        result = tools.convert_info_ini_file_to_dict(ini_content)
+        print(result)
+        self.assertEqual(result, self.DICT)

--- a/common/tools.py
+++ b/common/tools.py
@@ -2525,6 +2525,13 @@ def convert_info_ini_file_to_dict(buffer: Union[TextIOWrapper, StringIO]
     """Load the old 'info' file in INI format and convert its content
     to a regular dict.
 
+    The old INI like file format used `config.ConfigFile`. But this class was
+    dreprecated and planed to get removed (#1923). Because of that the format
+    of that file was transformed to JSON.
+
+    The old format still need to be supported because old backups contain this
+    file and will need to for restoring.
+
     Args:
         buffer: An open text-file handle or a string buffer ready to read.
     """
@@ -2540,4 +2547,46 @@ def convert_info_ini_file_to_dict(buffer: Union[TextIOWrapper, StringIO]
     config_parser.read_string(f'[{section}]\n{content}')
 
     # The one and only main section
-    return dict(config_parser[section])
+    result = dict(config_parser[section])
+
+
+    # extract "snapshot" items
+    prefix = 'snapshot_'
+    snapshot_keys = list(
+        filter(lambda key: key.startswith(prefix), result.keys())
+    )
+    result['backup'] = {}
+    for key in snapshot_keys:
+        result['backup'][key.replace(prefix, '')] = result[key]
+        del result[key]
+
+    # clean up not necessary keys
+    del result['user.size']
+    del result['group.size']
+
+    # extract "user" and "group" items
+    for item_name in ('user', 'group'):
+        prefix = f'{item_name}.'
+        item_keys = filter(lambda key: key.startswith(prefix), result.keys())
+        item_it = iter(sorted(item_keys))
+        pairs = list(zip(item_it, item_it))
+
+        result[f'{item_name}s'] = []
+
+        for key_pair in pairs:
+            pair_result = {}
+
+            for key in key_pair:
+                new_key = key.rsplit('.', 1)[1]
+                pair_result[new_key] = result[key]
+
+                if pair_result[new_key].isdigit():
+                    pair_result[new_key] = int(pair_result[new_key])
+
+                del result[key]
+
+            result[f'{item_name}s'].append(pair_result)
+
+    print(json.dumps(result, indent=4))
+
+    return result

--- a/common/tools.py
+++ b/common/tools.py
@@ -2526,7 +2526,7 @@ def convert_info_ini_file_to_dict(buffer: Union[TextIOWrapper, StringIO]
     to a regular dict.
 
     The old INI like file format used `config.ConfigFile`. But this class was
-    dreprecated and planed to get removed (#1923). Because of that the format
+    dreprecated and planned to get removed (#1923). Because of that the format
     of that file was transformed to JSON.
 
     The old format still need to be supported because old backups contain this

--- a/common/tools.py
+++ b/common/tools.py
@@ -26,6 +26,8 @@ import gettext
 import hashlib
 import shutil
 import json
+import configparser
+from io import StringIO, TextIOWrapper
 from datetime import datetime, timedelta
 from collections.abc import MutableMapping
 from packaging.version import Version
@@ -1554,6 +1556,9 @@ def envLoad(fp: pathlib.Path):
     Args:
         full path to file with environ variables
     """
+    if not fp.exists():
+        return
+
     env = os.environ.copy()
 
     content = json.loads(fp.read_text(encoding='utf-8'))
@@ -1563,7 +1568,7 @@ def envLoad(fp: pathlib.Path):
         if not value:
             continue
 
-        if not key in list(env.keys()):
+        if key not in list(env.keys()):
             os.environ[key] = value
 
 
@@ -2513,3 +2518,26 @@ class Execute:
         if self.pausable and self.currentProc:
             logger.info(f'Kill process "{self.printable_cmd}"', self.parent, 2)
             return self.currentProc.kill()
+
+
+def convert_info_ini_file_to_dict(buffer: Union[TextIOWrapper, StringIO]
+                                  ) -> dict:
+    """Load the old 'info' file in INI format and convert its content
+    to a regular dict.
+
+    Args:
+        buffer: An open text-file handle or a string buffer ready to read.
+    """
+
+    section = 'info-file-in-conversion'
+
+    # raw content
+    content = buffer.read()
+
+    config_parser = configparser.ConfigParser(interpolation=None)
+
+    # Add section header to make it a real INI file
+    config_parser.read_string(f'[{section}]\n{content}')
+
+    # The one and only main section
+    return dict(config_parser[section])

--- a/common/tools.py
+++ b/common/tools.py
@@ -2549,7 +2549,6 @@ def convert_info_ini_file_to_dict(buffer: Union[TextIOWrapper, StringIO]
     # The one and only main section
     result = dict(config_parser[section])
 
-
     # extract "snapshot" items
     prefix = 'snapshot_'
     snapshot_keys = list(
@@ -2566,12 +2565,13 @@ def convert_info_ini_file_to_dict(buffer: Union[TextIOWrapper, StringIO]
 
     # extract "user" and "group" items
     for item_name in ('user', 'group'):
+        id_name = {'user': 'uid', 'group': 'gid'}[item_name]
         prefix = f'{item_name}.'
         item_keys = filter(lambda key: key.startswith(prefix), result.keys())
         item_it = iter(sorted(item_keys))
         pairs = list(zip(item_it, item_it))
 
-        result[f'{item_name}s'] = []
+        result[f'{item_name}s'] = {}
 
         for key_pair in pairs:
             pair_result = {}
@@ -2585,8 +2585,6 @@ def convert_info_ini_file_to_dict(buffer: Union[TextIOWrapper, StringIO]
 
                 del result[key]
 
-            result[f'{item_name}s'].append(pair_result)
-
-    print(json.dumps(result, indent=4))
+            result[f'{item_name}s'][pair_result[id_name]] = pair_result['name']
 
     return result

--- a/qt/statedata.py
+++ b/qt/statedata.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 from datetime import datetime, timezone
 from copy import deepcopy
+from typing import Optional
 from qttools_path import register_backintime_path
 register_backintime_path('common')
 import singleton  # noqa: E402
@@ -148,7 +149,7 @@ class StateData(dict, metaclass=singleton.Singleton):
             cfg = ''
 
         fp = xdg_state / f'backintime-qt{cfg}.json'
-        logger.critical(f'State file path: {fp}')
+        logger.debug(f'State file path: {fp}')
 
         return fp
 


### PR DESCRIPTION
The snapshots.py module do not use the class `ConfigFile` anymore. This is needed in preparation for #1923 (new config management).

The "info" file was created and managed using that class. That file is part of the meta data of each backup and stored in its root directory. Its INI-like format now migrated into JSON.

The "info" file of backups created with version before 2.0.0 are converted into "info.json" without noticing the user. Both files will persist in the backup.

Backups created with version 2.0.0 or later will contain "info.json" only. This will cause issues when trying to use and restore such backups with older versions of Back In Time. Restoring it self is working but restoring ownership and permissions won't work correctly.