### PR TITLE
refactor: Decouple ConfigFile class from class ProgressFile and progress module

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -1270,15 +1270,15 @@ class Config(configfile.ConfigFileWithProfiles):
 
         return profile_id
 
-    def takeSnapshotLogFile(self, profile_id = None):
+    def takeSnapshotLogFile(self, profile_id=None):
         return os.path.join(self._LOCAL_DATA_FOLDER,
                             "takesnapshot_%s.log" % self.fileId(profile_id))
 
-    def takeSnapshotMessageFile(self, profile_id = None):
+    def takeSnapshotMessageFile(self, profile_id=None):
         return os.path.join(self._LOCAL_DATA_FOLDER,
                             "worker%s.message" % self.fileId(profile_id))
 
-    def takeSnapshotProgressFile(self, profile_id = None):
+    def takeSnapshotProgressFile(self, profile_id=None):
         return os.path.join(self._LOCAL_DATA_FOLDER,
                             "worker%s.progress" % self.fileId(profile_id))
 

--- a/common/progress.py
+++ b/common/progress.py
@@ -1,31 +1,46 @@
 # SPDX-FileCopyrightText: © 2012-2022 Germar Reitze
+# SPDX-FileCopyrightText: © 2026 Christian BUHTZ <c.buhtz@posteo.jp>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
 # This file is part of the program "Back In Time" which is released under GNU
 # General Public License v2 (GPLv2). See LICENSES directory or go to
 # <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+"""A file that is written and read by different processes to interchange
+information. Back IN Time is using it to communicate rsync progress from CLI
+to GUI.
+
+This will be replaced by proper IPC (#2260).
+"""
 import os
-import configfile
+import json
+from typing import Union
+from pathlib import Path
 
 
-class ProgressFile(configfile.ConfigFile):
+class ProgressFile():
 
     RSYNC = 50
 
-    def __init__(self, cfg, filename=None):
-        super(ProgressFile, self).__init__()
-        self.config = cfg
+    def __init__(self, filename: Union[Path, str]):
+        if isinstance(filename, str):
+            filename = Path(filename)
+
         self.filename = filename
 
-        if self.filename is None:
-            self.filename = self.config.takeSnapshotProgressFile()
+        self._data = None
+
+    def get_data(self) -> dict:
+        return self._data
+
+    def set_data(self, data: dict):
+        self._data = data
 
     def save(self):
-        return super(ProgressFile, self).save(self.filename)
+        self.filename.write_text(json.dumps(self._data), encoding='utf-8')
 
     def load(self):
-        return super(ProgressFile, self).load(self.filename)
+        self._data = json.loads(self.filename.read_text(encoding='utf-8'))
 
     def fileReadable(self):
         return os.access(self.filename, os.R_OK)

--- a/common/snapshots.py
+++ b/common/snapshots.py
@@ -1130,21 +1130,26 @@ class Snapshots:
                         ``line`` was a progress
         """
         ret = []
-        for l in line.split('\n'):
-            m = self.reRsyncProgress.match(l)
+
+        for part in line.split('\n'):
+            m = self.reRsyncProgress.match(part)
+
             if m:
-                # if m.group(5).strip():
-                #     return
-                pg = progress.ProgressFile(self.config)
-                pg.setIntValue('status', pg.RSYNC)
-                pg.setStrValue('sent', m.group(1))
-                pg.setIntValue('percent', int(m.group(2)))
-                pg.setStrValue('speed', m.group(3))
-                pg.setStrValue('eta', m.group(4))
+                pg = progress.ProgressFile(
+                    filename=self.config.takeSnapshotProgressFile()
+                )
+                pg.set_data({
+                    'status': progress.ProgressFile.RSYNC,
+                    'sent': m.group(1),
+                    'percent': int(m.group(2)),
+                    'speed': m.group(3),
+                    'eta': m.group(4)
+                })
                 pg.save()
-                del pg
+
             else:
-                ret.append(l)
+                ret.append(part)
+
         return '\n'.join(ret)
 
     def rsyncCallback(self, line, params):

--- a/qt/app.py
+++ b/qt/app.py
@@ -1322,20 +1322,25 @@ class MainWindow(QMainWindow):
         return message
 
     def _update_progress_bar(self, message: str):
-        pg = progress.ProgressFile(self.config)
 
-        if not pg.fileReadable():
+        pg = progress.ProgressFile(
+            filename=self.config.takeSnapshotProgressFile()
+        )
+
+        if not pg.fileReadable():  # Why not?
             self.status_bar.progress_hide()
             return
 
         self.status_bar.progress_show()
         pg.load()
-        self.status_bar.set_progress_value(pg.intValue('percent'))
-        message = ' | '.join(self.getProgressBarFormat(pg, message))
+        pg_data = pg.get_data()
+
+        self.status_bar.set_progress_value(pg_data['percent'])
+        message = ' | '.join(self.getProgressBarFormat(pg_data, message))
         self.status_bar.set_status_message(message)
 
     def getProgressBarFormat(self,
-                             pg: progress.ProgressFile,
+                             pg_data: dict,
                              message: str) -> Generator[str, None, None]:
         """Generates formatted components of a progress bar display.
 
@@ -1358,18 +1363,18 @@ class MainWindow(QMainWindow):
         d = (
             ('sent', _('Sent:')),
             ('speed', _('Speed:')),
-            ('eta',    _('ETA:'))
+            ('eta', _('ETA:'))
         )
 
-        yield '{}%'.format(pg.intValue('percent'))
+        yield f'{pg_data["percent"]}%'
 
         for key, txt in d:
-            value = pg.strValue(key, '')
+            value = pg_data.get(key, '')
 
             if not value:
                 continue
 
-            yield txt + ' ' + value
+            yield f'{txt} {value}'
 
         yield message
 

--- a/qt/qtsystrayicon.py
+++ b/qt/qtsystrayicon.py
@@ -251,10 +251,13 @@ class QtSysTrayIcon:
 
                 self.status_icon.setToolTip(message[1])
 
-        pg = progress.ProgressFile(self.config)
+        pg = progress.ProgressFile(
+            filename=self.config.takeSnapshotProgressFile()
+        )
 
         if pg.fileReadable():
             pg.load()
+            pg_data = pg.get_data()
             # percent = pg.intValue('percent')
             ## disable progressbar in icon until BiT has it's own icon
             ## fixes bug #902
@@ -266,14 +269,16 @@ class QtSysTrayIcon:
             #         flags=QWidget.RenderFlags(QWidget.DrawChildren))
             #     self.status_icon.setIcon(QIcon(self.pixmap))
 
-            self.menuProgress.setText(' | '.join(self.getMenuProgress(pg)))
+            self.menuProgress.setText(
+                ' | '.join(self.getMenuProgress(pg_data))
+            )
             self.menuProgress.setVisible(True)
 
         else:
             # self.status_icon.setIcon(self.icon.BIT_LOGO)
             self.menuProgress.setVisible(False)
 
-    def getMenuProgress(self, pg):
+    def getMenuProgress(self, pg_data):
         """See common/app.py::MainWindow.getProgressBarFormat().
 
         The code is a near duplicate.
@@ -281,16 +286,16 @@ class QtSysTrayIcon:
         data = (
             ('sent', _('Sent:')),
             ('speed', _('Speed:')),
-            ('eta',    _('ETA:'))
+            ('eta', _('ETA:'))
         )
 
         for key, txt in data:
-            value = pg.strValue(key, '')
+            value = pg_data.get(key, '')
 
             if not value:
                 continue
 
-            yield txt + ' ' + value
+            yield f'{txt} {value}'
 
     @trust_required
     def _slot_pause(self, *_args, **_kwargs):


### PR DESCRIPTION
The progress.py module do not use the class `ConfigFile` anymore. This is needed in preparation for #1923 (new config management).