### PR TITLE
feat(diagnostics): detect and report coreutils variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   explanations ([#2507](https://github.com/bit-team/backintime/issues/2507))
 
 ### Added
+- Diagnostics: Detect and report coreutils variant (GNU, Rust/uutils,
+  BusyBox) in `--diagnostics` output
+  ([#2478](https://github.com/bit-team/backintime/issues/2478))
 - Gocryptfs for SSH encrypted profiles
   ([PR#2486](https://github.com/bit-team/backintime/pull/2486))
 - Dependencies:

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -178,6 +178,9 @@ def collect_diagnostics():
         result['external-programs']['shell-version'] \
             = shell_version.split('\n')[0]
 
+    # Coreutils (GNU, Rust/uutils, BusyBox, or unknown)
+    result['external-programs']['coreutils'] = _get_coreutils_info()
+
     result = _replace_username_paths(
         result=result,
         username=pwd.getpwuid(os.getuid()).pw_name
@@ -346,6 +349,45 @@ def _get_rsync_info():
                     f'{k}: {v}' for k, v in info[key].items())
 
     return info
+
+
+def _get_coreutils_info():
+    """Detect the installed coreutils variant (GNU, Rust/uutils, BusyBox).
+
+    Uses ``ls --version`` as a probe because ``ls`` is present on every
+    Unix-like system and each implementation produces a distinctive
+    version string.
+
+    Returns:
+        str: A human-readable description of the coreutils variant and
+        version, or an error string if detection fails.
+    """
+    output = _get_extern_versions(['ls', '--version'])
+
+    if output is None or output.startswith('(no ls)'):
+        return output if output else '(ls detection failed)'
+
+    first_line = output.split('\n')[0]
+
+    # GNU coreutils: "ls (GNU coreutils) 9.4"
+    if 'GNU coreutils' in output:
+        return first_line
+
+    # BusyBox: "BusyBox v1.36.1 (date) multi-call binary"
+    if 'BusyBox' in output:
+        return first_line
+
+    # Rust/uutils coreutils: "ls 0.0.27" (no "GNU coreutils" tag)
+    # Distinguish from other implementations by checking for the
+    # uutils project name which appears in the full --version output.
+    if 'uutils' in output:
+        return f'Rust/uutils coreutils - {first_line}'
+
+    # uutils sometimes prints just the version without the project name
+    # on older releases; the output is a bare version number with no
+    # "GNU" or "BusyBox" marker.
+    # In that ambiguous case, return the first line as-is.
+    return first_line
 
 
 def _get_os_release():

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -60,7 +60,8 @@ class General(unittest.TestCase):
 
         # 2nd level "external-programs"
         minimal_keys = [
-            'rsync', 'shell', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS']
+            'rsync', 'shell', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS',
+            'coreutils']
         for key in minimal_keys:
             self.assertIn(key, result['external-programs'], key)
 
@@ -111,3 +112,46 @@ class General(unittest.TestCase):
             diagnostics._replace_username_paths(d, 'user'),
             d
         )
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_gnu(self, mock_extern):
+        """Detect GNU coreutils from ls --version output."""
+        mock_extern.return_value = (
+            'ls (GNU coreutils) 9.4\n'
+            'Copyright (C) 2024 Free Software Foundation, Inc.'
+        )
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(result, 'ls (GNU coreutils) 9.4')
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_busybox(self, mock_extern):
+        """Detect BusyBox from ls --version output."""
+        mock_extern.return_value = (
+            'BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.'
+        )
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(
+            result,
+            'BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.'
+        )
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_uutils(self, mock_extern):
+        """Detect Rust/uutils coreutils from ls --version output."""
+        mock_extern.return_value = (
+            'ls 0.0.27\n'
+            'uutils coreutils - MIT license'
+        )
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(result, 'Rust/uutils coreutils - ls 0.0.27')
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_not_found(self, mock_extern):
+        """Handle missing ls gracefully."""
+        mock_extern.return_value = '(no ls)'
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(result, '(no ls)')


### PR DESCRIPTION
## First-time Contributor Introduction

Hi! I'm Andrian, a developer interested in contributing to backup and system tools. This is my first PR to Back In Time — happy to follow the contribution guidelines and learn the project's conventions.

---

## What

Add coreutils variant detection to the `--diagnostics` output. The diagnostics now probe `ls --version` and identify whether the system uses GNU coreutils, Rust/uutils, or BusyBox.

## Why

Closes #2478.

Different coreutils implementations (GNU, Rust/uutils, BusyBox) have behavioral differences that can affect rsync-based backups, path handling, and flag support. Knowing which variant is installed helps with issue triage and debugging.

## How

- New function `_get_coreutils_info()` in `common/diagnostics.py` that:
  1. Runs `ls --version` via the existing `_get_extern_versions()` helper
  2. Parses the output to identify the variant:
     - **GNU coreutils**: output contains `"GNU coreutils"` (e.g. `ls (GNU coreutils) 9.4`)
     - **BusyBox**: output contains `"BusyBox"` (e.g. `BusyBox v1.36.1 ...`)
     - **Rust/uutils**: output contains `"uutils"` (prefixed with `Rust/uutils coreutils -` for clarity)
     - **Unknown**: returns the first line as-is
  3. Handles missing `ls` gracefully (returns `(no ls)`)