### PR TITLE
fix: handle terminated backup process during signal forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Include SSH_AUTH_SOCK in cron environment to enable SSH agent access (Dan Kortschak, [@kortschak](https://github.com/kortschak), [#2506](https://github.com/bit-team/backintime/issues/2506))
 - Schedule mode "Repeatedly" using "Hourly" units is now consistent with other units ([#2507](https://github.com/bit-team/backintime/issues/2507))
 - Crash when use Btrfs-subvolume as backup destination (Daidalos [@D4id4los](https://github.com/D4id4los), [#2487](https://github.com/bit-team/backintime/issues/2487))
+- Guard pause/resume/stop actions in the GUI against ProcessLookupError when the backup process has already exited. ([#1604](https://github.com/bit-team/backintime/issues/1604))
 
 ## [1.6.1] (2026-02-10)
 

--- a/qt/app.py
+++ b/qt/app.py
@@ -501,11 +501,13 @@ class MainWindow(QMainWindow):
                 _('Use checksums for file change detection.')),
             'act_pause_take_snapshot': (
                 icon.PAUSE, _('Pause backup process'),
-                lambda: os.kill(self.snapshots.pid(), signal.SIGSTOP), None,
+                lambda: self._send_signal_to_backup_process(signal.SIGSTOP),
+                None,
                 None),
             'act_resume_take_snapshot': (
                 icon.RESUME, _('Resume backup process'),
-                lambda: os.kill(self.snapshots.pid(), signal.SIGCONT), None,
+                lambda: self._send_signal_to_backup_process(signal.SIGCONT),
+                None,
                 None),
             'act_stop_take_snapshot': (
                 icon.STOP, _('Stop backup process'),
@@ -1925,12 +1927,23 @@ class MainWindow(QMainWindow):
         backintime.takeSnapshotAsync(self.config, checksum=checksum)
         self._update_backup_status(True)
 
+    def _send_signal_to_backup_process(self, sig: signal.Signals) -> bool:
+
+        try:
+            os.kill(self.snapshots.pid(), sig)
+        except ProcessLookupError:
+            self._update_backup_status(True)
+            return False
+
+        return True
+
     def _slot_backup_stop(self):
-        os.kill(self.snapshots.pid(), signal.SIGKILL)
+        if self._send_signal_to_backup_process(signal.SIGKILL):
+            self.snapshots.setTakeSnapshotMessage(0, 'Backup terminated')
+
         self.act_stop_take_snapshot.setEnabled(False)
         self.act_pause_take_snapshot.setEnabled(False)
         self.act_resume_take_snapshot.setEnabled(False)
-        self.snapshots.setTakeSnapshotMessage(0, 'Backup terminated')
 
     # |---------|
     # | Restore |

--- a/qt/app.py
+++ b/qt/app.py
@@ -1164,7 +1164,6 @@ class MainWindow(QMainWindow):
 
             self.updateProfile()
 
-
     def raiseApplication(self):
         raiseCmd = self.appInstance.raiseCommand()
         if raiseCmd is None:
@@ -1928,11 +1927,22 @@ class MainWindow(QMainWindow):
         self._update_backup_status(True)
 
     def _send_signal_to_backup_process(self, sig: signal.Signals) -> bool:
+        """Send a POSIX signal to the backup process.
 
+        If the process has already terminated, the GUI state is refreshed and
+        ``False`` is returned instead of propagating ``ProcessLookupError``.
+
+        Returns:
+            ``True`` if the signal was sent successfully, otherwise
+                ``False``.
+
+        """
         try:
             os.kill(self.snapshots.pid(), sig)
+
         except ProcessLookupError:
             self._update_backup_status(True)
+
             return False
 
         return True


### PR DESCRIPTION
Update signal handling to correctly detect when the backup process has already terminated and update the backup status accordingly.

Fix #1604
Based on unfinished PR #2457 
