### PR TITLE
fix: prevent crash after polkit authentication timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Include SSH_AUTH_SOCK in cron environment to enable SSH agent access (Dan Kortschak, [@kortschak](https://github.com/kortschak), [#2506](https://github.com/bit-team/backintime/issues/2506))
 - Schedule mode "Repeatedly" using "Hourly" units is now consistent with other units ([#2507](https://github.com/bit-team/backintime/issues/2507))
 - Crash when use Btrfs-subvolume as backup destination (Daidalos [@D4id4los](https://github.com/D4id4los), [#2487](https://github.com/bit-team/backintime/issues/2487))
+- Crash when polkit authentication dialog times out while setting up udev scheduling ([#2375](https://github.com/bit-team/backintime/issues/2375))
 
 ## [1.6.1] (2026-02-10)
 

--- a/common/config.py
+++ b/common/config.py
@@ -46,7 +46,7 @@ import pluginmanager
 import schedule
 import core_events
 from storagesize import StorageSize
-from exceptions import PermissionDeniedByPolicy
+from exceptions import PermissionDeniedByPolicy, Timeout
 from konfig import Konfig
 
 
@@ -1853,11 +1853,15 @@ class Config:  # (configfile.ConfigFileWithProfiles):
             return
 
         for pid in profile_ids:
+
             backup_mode = self.snapshotsMode(pid)
+
             if backup_mode == 'local':
                 dest_path = self.snapshotsFullPath(pid)
+
             elif backup_mode == 'local_gocryptfs':
                 dest_path = self.localGocryptfsPath(pid)
+
             else:
                 logger.error(
                     f"Udev scheduling doesn't work with mode {backup_mode}",
@@ -1883,6 +1887,16 @@ class Config:  # (configfile.ConfigFileWithProfiles):
         except PermissionDeniedByPolicy as err:
             logger.error(str(err), self)
             core_events.event_error.notify(str(err))
+            return False
+
+        except Timeout:
+            logger.error(
+                'Time out while waiting for users dbus authentication'
+            )
+            core_events.event_error.notify(_(
+                'Authentication timed out. The udev scheduling setup was not '
+                'completed. Please try again.'
+            ))
             return False
 
     def _setup_schedule_based_automation(self):

--- a/common/tools.py
+++ b/common/tools.py
@@ -2293,12 +2293,16 @@ class SetupUdev:
             return self.iface.save()
 
         except dbus.exceptions.DBusException as err:
+            dbus_name = err.get_dbus_name()
 
-            if (err._dbus_error_name
+            if (dbus_name
                     == 'com.ubuntu.DeviceDriver.PermissionDeniedByPolicy'):
                 raise PermissionDeniedByPolicy(str(err)) from err
 
-            raise err
+            if dbus_name == 'org.freedesktop.DBus.Error.NoReply':
+                raise Timeout() from err
+
+            raise
 
     def clean(self):
         """Clean up remote cache.


### PR DESCRIPTION
Handle missing D-Bus replies from the udev setup helper when the polkit authentication dialog times out, e.g. if the user just waited to long.

Fix #2375
Based on previous but unfinished PR #2456