### PR TITLE
feat!: Remove CLI option --share-path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   ([PR#2493](https://github.com/bit-team/backintime/issues/2493))
 - Dependency: `encfs`
 - CLI:
+  - **Breaking**: CLI option `--share-path` which was deprecated earlier in `1.6.0` ([#2535](https://github.com/bit-team/backintime/issues/2535))
   - Switch `--keep-mount`
   - Command `decode` because of EncFS removal ([#1734](https://github.com/bit-team/backintime/issues/1734))
   - Command `benchmark-cipher` ([#2120](https://github.com/bit-team/backintime/issues/2120))

--- a/common/backintime.py
+++ b/common/backintime.py
@@ -43,9 +43,6 @@ def takeSnapshotAsync(cfg, checksum=False):
 
     cmd.extend(('--config', str(bitbase.context['--config'])))
 
-    # if cfg._LOCAL_DATA_FOLDER is not cfg._DEFAULT_LOCAL_DATA_FOLDER:
-    #     cmd.extend(('--share-path', cfg.DATA_FOLDER_ROOT))
-
     if logger.DEBUG:
         cmd.append('--debug')
 
@@ -132,7 +129,6 @@ def startApp(bin_name: str) -> config.Config | None:
     # This loads the real/new "Konfig"
     _real_konfig = cli.get_config_and_select_profile(
         config_path=bitbase.context['--config'],
-        # data_path=args.share_path,
         pid_or_name=args.profile,
         # Dev note (buhtz, 2025): There is not a default value in all cases,
         # because "--checksum" is exclusive to rsync-related commands.

--- a/common/cli.py
+++ b/common/cli.py
@@ -515,19 +515,13 @@ def _backup_and_remove_encfs_config(cfg: Konfig) -> bool:
 
 def get_config_and_select_profile(
         config_path: Path,
-        # data_path: str,
         pid_or_name: Union[str, int]
-        # checksum: Optional[bool] = None
-        # check: bool = True
 ) -> Konfig:
     """Load config and change to profile selected on commandline.
 
     Args:
         config_path: Path to config file.
-        data_path: Path to "share_path".
         pid_or_name: Name or ID of the profile.
-        checksum: Use checksum option.
-        check: If ``True`` check if config is valid.
 
     Returns:
         Current the config

--- a/common/cliarguments.py
+++ b/common/cliarguments.py
@@ -254,17 +254,6 @@ class ParserAgent:
         )
 
         parser.add_argument(
-            '--share-path',
-            metavar='PATH',
-            type=str,
-            action='store',
-            # Hide because deprecated (#2125)
-            help=argparse.SUPPRESS
-            # help='Write runtime data (locks, messages, log and '
-            #      'mountpoints) to %(metavar)s.'
-        )
-
-        parser.add_argument(
             '--quiet',
             action='store_true',
             help='be quiet and suppress messages on stdout')
@@ -912,9 +901,6 @@ def parse_arguments(args: Namespace,
     if args.profile_id:
         clicommands.show_deprecation_message('--profile-id')
         args.profile = str(args.profile_id)
-
-    if args.share_path:
-        clicommands.show_deprecation_message('--share-path')
 
     # Report unknown arguments but not if we run aliasParser next because we
     # will parse again in there.

--- a/common/clicommands.py
+++ b/common/clicommands.py
@@ -63,7 +63,6 @@ def show_deprecation_message(cmd_flag: str):
         'remove-and-do-not-ask-again':
             'Use "remove --skip-confirmation" instead.',
         '--profile-id': 'Use "--profile" instead.',
-        '--share-path': None,
     }[cmd_flag]
 
     msg = _deprecation_msg(cmd_flag, replacement)
@@ -78,7 +77,6 @@ def _get_config(args: argparse.Namespace) -> config.Config:
     # Crreate a Konfig instance
     cli.get_config_and_select_profile(
         config_path=bitbase.context['--config'],  # args.config,
-        # data_path=args.share_path,
         pid_or_name=args.profile
         # checksum=getattr(args, 'checksum', None)
     )

--- a/qt/plugins/systrayiconplugin.py
+++ b/qt/plugins/systrayiconplugin.py
@@ -12,7 +12,7 @@
 # Known open issues:
 # this script should get started and consider some cmd line arguments from BiT
 # (parsed via backintime.createParsers()) so that the same paths are used,
-# mainly "share-path" and "config" (path to the config file).
+# mainly "config" (path to the config file).
 # Otherwise e.g. unit tests or special user path settings may lead to
 # wrong status info in the systray icon!
 """Plugin starting the systray icon process


### PR DESCRIPTION
BREAKING CHANGE: CLI option "--share-path" removed.

Was deprecated earlier in version 1.6.0 (#2138).
Despite other deprecated CLI elements, this removal is earlier because it isn't supported by the new configuration management code (#1850)

Close #2535