### PR TITLE
fix(ssh): resolve hostname via ssh -G for known_hosts check

### DIFF
--- a/common/sshsetupvalidator.py
+++ b/common/sshsetupvalidator.py
@@ -348,15 +348,63 @@ class SSHSetupValidator:  # pylint: disable=too-few-public-methods
                 + _('Details:') + f'\n{err.strip()}'
             )
 
+    def _build_ssh_g_command(self) -> list[str]:
+        """Build ``ssh -G`` command mirroring connection options."""
+        cmd = self._build_ssh_command()
+        return [cmd[0], '-G', *cmd[1:]]
+
+    @staticmethod
+    def _parse_ssh_g_output(output: str) -> tuple[str | None, int | None]:
+        hostname = None
+        port = None
+
+        for line in output.splitlines():
+            key, _, value = line.partition(' ')
+            value = value.strip()
+
+            if key == 'hostname':
+                hostname = value
+            elif key == 'port':
+                try:
+                    port = int(value)
+                except ValueError:
+                    pass
+
+        return hostname, port
+
+    def _known_hosts_lookup_hosts(self) -> list[str]:
+        """Host names OpenSSH uses for known_hosts lookups."""
+        cmd = self._build_ssh_g_command()
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False
+        )
+
+        if proc.returncode != 0:
+            hostname = self.ssh_host.host
+            port = self.ssh_host.port
+        else:
+            resolved_hostname, resolved_port = self._parse_ssh_g_output(
+                proc.stdout
+            )
+            hostname = resolved_hostname or self.ssh_host.host
+            port = (
+                resolved_port
+                if resolved_port is not None
+                else self.ssh_host.port
+            )
+
+        return [
+            hostname,
+            f'[{hostname}]:{port}'
+        ]
+
     def _check_known_hosts(self):
         """Check if host is present in known_hosts file."""
 
-        hosts_to_check = [
-            self.ssh_host.host,
-            f'[{self.ssh_host.host}]:{self.ssh_host.port}'
-        ]
-
-        for host in hosts_to_check:
+        for host in self._known_hosts_lookup_hosts():
             proc = subprocess.run(
                 ['ssh-keygen', '-F', host],
                 capture_output=True,

--- a/common/test/test_lint.py
+++ b/common/test/test_lint.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Christian BUHTZ <c.buhtz@posteo.jp>
+﻿# SPDX-FileCopyrightText: Â© 2023 Christian BUHTZ <c.buhtz@posteo.jp>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -77,6 +77,7 @@ full_test_files = [_base_dir / fp for fp in (
     'test/test_lint.py',
     # 'test/test_mount.py',
     'test/test_singleton.py',
+    'test/test_sshsetupvalidator.py',
     'test/test_storagesize.py',
     # 'test/test_takesnapshotlog.py',
     'test/test_uniquenessset.py',

--- a/common/test/test_sshsetupvalidator.py
+++ b/common/test/test_sshsetupvalidator.py
@@ -1,0 +1,137 @@
+﻿# SPDX-FileCopyrightText: © 2026 Iqbalez
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This file is part of the program "Back In Time" which is released under GNU
+# General Public License v2 (GPLv2). See LICENSES directory or go to
+# <https://spdx.org/licenses/GPL-2.0-or-later.html>.
+"""Tests for sshsetupvalidator known_hosts handling."""
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import sshcore
+from sshsetupvalidator import SSHSetupValidator, SSHSetupError
+
+
+class _ValidatorHarness(SSHSetupValidator):
+    """Expose helpers without a full MountManager setup."""
+
+    def __init__(self, ssh_host: sshcore.SSHHost):
+        self.mnt = MagicMock()
+        self.ssh_host = ssh_host
+        self.cfg = MagicMock()
+        self._cleanup_commands = []
+
+
+class ParseSshGOutput(unittest.TestCase):
+    """Unit tests for parsing ``ssh -G`` output."""
+
+    def test_hostname_and_port(self):
+        output = 'hostname foobar\nport 2222\nuser backup\n'
+        hostname, port = SSHSetupValidator._parse_ssh_g_output(output)
+        self.assertEqual(hostname, 'foobar')
+        self.assertEqual(port, 2222)
+
+    def test_invalid_port_ignored(self):
+        output = 'hostname foo\nport not-a-number\n'
+        hostname, port = SSHSetupValidator._parse_ssh_g_output(output)
+        self.assertEqual(hostname, 'foo')
+        self.assertIsNone(port)
+
+
+class KnownHostsLookup(unittest.TestCase):
+    """known_hosts lookup uses OpenSSH-resolved host names."""
+
+    def setUp(self):
+        self.host = sshcore.SSHHost(host='FOOBAR', user='u', port=22)
+        self.validator = _ValidatorHarness(self.host)
+
+    @patch('sshsetupvalidator.subprocess.run')
+    def test_uses_resolved_hostname_for_keygen(self, mock_run):
+        def fake_run(cmd, **_kwargs):
+            proc = MagicMock()
+            proc.returncode = 1
+            proc.stdout = ''
+            if cmd[0] == 'ssh' and '-G' in cmd:
+                proc.returncode = 0
+                proc.stdout = 'hostname foobar\nport 22\n'
+            elif cmd[:2] == ['ssh-keygen', '-F']:
+                if cmd[2] == 'FOOBAR':
+                    proc.returncode = 1
+                elif cmd[2] == 'foobar':
+                    proc.returncode = 0
+            return proc
+
+        mock_run.side_effect = fake_run
+
+        self.validator._check_known_hosts()
+
+        keygen_hosts = [
+            args[0][2]
+            for args, _kwargs in mock_run.call_args_list
+            if args[0][:2] == ['ssh-keygen', '-F']
+        ]
+        self.assertIn('foobar', keygen_hosts)
+        self.assertNotIn('FOOBAR', keygen_hosts)
+
+    @patch('sshsetupvalidator.subprocess.run')
+    def test_raises_when_resolved_host_not_in_known_hosts(self, mock_run):
+        def fake_run(cmd, **_kwargs):
+            proc = MagicMock()
+            proc.returncode = 1
+            proc.stdout = ''
+            if cmd[0] == 'ssh' and '-G' in cmd:
+                proc.returncode = 0
+                proc.stdout = 'hostname foobar\nport 22\n'
+            return proc
+
+        mock_run.side_effect = fake_run
+
+        with self.assertRaises(SSHSetupError):
+            self.validator._check_known_hosts()
+
+    @patch('sshsetupvalidator.subprocess.run')
+    def test_fallback_when_ssh_g_fails(self, mock_run):
+        def fake_run(cmd, **_kwargs):
+            proc = MagicMock()
+            proc.returncode = 1
+            proc.stdout = ''
+            if cmd[0] == 'ssh' and '-G' in cmd:
+                proc.returncode = 127
+            elif cmd[:2] == ['ssh-keygen', '-F'] and cmd[2] == 'FOOBAR':
+                proc.returncode = 0
+            return proc
+
+        mock_run.side_effect = fake_run
+
+        self.validator._check_known_hosts()
+
+        keygen_hosts = [
+            args[0][2]
+            for args, _kwargs in mock_run.call_args_list
+            if args[0][:2] == ['ssh-keygen', '-F']
+        ]
+        self.assertEqual(keygen_hosts[0], 'FOOBAR')
+
+
+class BuildSshGCommand(unittest.TestCase):
+    """``ssh -G`` command mirrors regular SSH options."""
+
+    def test_inserts_g_flag(self):
+        host = sshcore.SSHHost(
+            host='example.com',
+            user='alice',
+            port=2222,
+            priv_key_file='/tmp/id_ed25519',
+        )
+        validator = _ValidatorHarness(host)
+        cmd = validator._build_ssh_g_command()
+        self.assertEqual(cmd[0], 'ssh')
+        self.assertEqual(cmd[1], '-G')
+        self.assertIn('-p', cmd)
+        self.assertIn('2222', cmd)
+        self.assertIn('alice@example.com', cmd)
+        self.assertIn('IdentityFile=/tmp/id_ed25519', cmd)


### PR DESCRIPTION
## Summary
- Resolve the effective SSH hostname with `ssh -G` (same options as profile SSH) before `ssh-keygen -F` known_hosts lookups
- Keeps bracket/port host forms using the resolved hostname and port
- Adds unit tests with mocked `subprocess.run` for alias/case handling, failure paths, and `ssh -G` command construction

Fixes #2550

## Test plan
- [x] `python -m unittest test.test_sshsetupvalidator` (Linux CI; not runnable on Windows due to `os.geteuid` / `syslog` dependencies)
- [ ] Manual: configure `Host FOOBAR` + `HostName foobar`, ensure known_hosts entry for `foobar` passes SSH setup validation

Made with [Cursor](https://cursor.com)