### PR TITLE
fix(gui): Repair main windows last_path semantic

### DIFF
--- a/common/check_config.py
+++ b/common/check_config.py
@@ -110,19 +110,19 @@ class CheckConfigAgent:  # pylint: disable=too-few-public-methods
                 core_events.event_error.notify(
                     _('Profile: "{name}"').format(name=profile.name)
                     + '\n'
-                    + _('There is a conflict between two settings.')
+                    + _('Two settings conflict with each other.')
                     + '\n\n'
                     + _(
                         'The value for "Remove oldest backup if the '
                         'free space is less than" ({val_one}) must be '
-                        'less than or equal the threshold for "Warn if '
-                        'free disk space falls below" ({val_two}).'
+                        'less than or equal to the value for "Warn if '
+                        'the free disk space falls below" ({val_two}).'
                     ).format(val_one=min_free, val_two=warn)
                     + '\n'
                     + _(
-                        'Please adjust the settings so that the backup '
-                        'removal limit is not higher than the '
-                        'warning limit.'
+                        'Please adjust the settings so that the threshold '
+                        'for removing old backups does not exceed the free '
+                        'disk space warning threshold.'
                     )
                 )
                 return False

--- a/common/config.py
+++ b/common/config.py
@@ -1904,8 +1904,8 @@ class Config:  # (configfile.ConfigFileWithProfiles):
                 'Time out while waiting for users dbus authentication'
             )
             core_events.event_error.notify(_(
-                'Authentication timed out. The udev scheduling setup was not '
-                'completed. Please try again.'
+                'Authentication timed out. The setup of Udev-based '
+                'scheduling was not completed. Please try again.'
             ))
             return False
 

--- a/common/mount/_backends.py
+++ b/common/mount/_backends.py
@@ -287,7 +287,7 @@ class SSHBackend(Backend):
             (
                 ['test', '-x', path],
                 'Remote path is not accessible/searchable',
-                _('Access to the remote backup directory denied.')
+                _('Access to the remote backup directory was denied.')
             )
         ]
 

--- a/common/mount/_backends.py
+++ b/common/mount/_backends.py
@@ -282,14 +282,12 @@ class SSHBackend(Backend):
             (
                 ['test', '-w', path],
                 'Remote path is not writable',
-                _('Write access to the remote backup directory was '
-                  'denied (missing permissions).')
+                _('Write access to the remote backup directory was denied.')
             ),
             (
                 ['test', '-x', path],
                 'Remote path is not accessible/searchable',
-                _('Access to the remote backup directory denied '
-                  '(missing permissions).')
+                _('Access to the remote backup directory denied.')
             )
         ]
 

--- a/common/mount/_encryptors.py
+++ b/common/mount/_encryptors.py
@@ -281,9 +281,9 @@ class GoCryptFS(Encryptor):
             raise MountError(log_msg, gui_msg)
 
         if not self.path.exists():
-            log_msg = f'Mountpoint (as decrypted view) missing: {self.path}'
+            log_msg = f'Decrypted view mountpoint missing: {self.path}'
             gui_msg = _(
-                'Mountpoint as decrypted view is missing. Path: {path}'
+                'Decrypted view mountpoint is missing. Path: {path}'
             ).format(path=self.path)
             raise MountError(log_msg, gui_msg)
 

--- a/common/sshsetupvalidator.py
+++ b/common/sshsetupvalidator.py
@@ -351,7 +351,7 @@ class SSHSetupValidator:  # pylint: disable=too-few-public-methods
             raise SSHSetupError(
                 f'sshfs not usable: {proc.stderr}',
                 _(
-                    "Unexpected response from '{process}'"
+                    "Unexpected response from '{process}'."
                 ).format(process='sshfs')
                 + '\n\n'
                 + _('Details:') + f'\n{err.strip()}'

--- a/qt/app.py
+++ b/qt/app.py
@@ -222,7 +222,7 @@ class MainWindow(QMainWindow):
         # Current logical path in the backup tree shown in the files view.
         # This is not an absolute filesystem path. Resolve it with
         # self.sid.pathBackup(self.path). The value represents GUI navigation
-        # state and is kept when switching backups.
+        # state. self.path is independent from the selected backup.
         self.path = str(profile_state.last_path)
 
         self.widget_current_path.setText(self.path)
@@ -1164,11 +1164,8 @@ class MainWindow(QMainWindow):
             else:
                 self.places.set_sorting(sorting)
 
-            path = self.path
-            # self.config.setProfileStrValue(
-            #     'qt.last_path', self.path, old_profile_id)
-            # path = self.config.profileStrValue(
-            #     'qt.last_path', self.path, profile_id)
+            old_profile_state.last_path = pathlib.Path(self.path)
+            path = str(profile_state.last_path)
 
             if not path == self.path:
                 self.path = path
@@ -2108,11 +2105,9 @@ class MainWindow(QMainWindow):
         if self.is_now_selected():
             return
 
-        parent_path = self._get_parent_path_of_fileview_selection()
-
         confirm_dlg = ConfirmRestoreDialog(
             parent=self,
-            paths=(parent_path, ),
+            paths=(self.path, ),
             to_path=None,
             backup_on_restore=self.config.backupOnRestore(),
             backup_suffix=self.snapshots.backupSuffix()
@@ -2125,13 +2120,13 @@ class MainWindow(QMainWindow):
             opt = confirm_dlg.get_values_as_dict()
 
             if opt['delete'] and not self._restore_confirm_delete(
-                    warnRoot=parent_path == '/'):
+                    warnRoot=self.path == '/'):
                 return
 
         rd = RestoreDialog(
             self,
             self.selected_backup_id(),
-            parent_path,
+            self.path,
             **opt
         )
         rd.exec()
@@ -2141,23 +2136,7 @@ class MainWindow(QMainWindow):
         if self.is_now_selected():
             return
 
-        self._restore_to(
-            [self._get_parent_path_of_fileview_selection_or_root()]
-        )
-
-    def _get_parent_path_of_fileview_selection_or_root(self) -> str:
-        """Dev note (buhtz, 2026-08): Ugly workaround because of removing
-        self.path . I never understood the purpose of that allmity
-        object variable.
-
-        This workaround might cause unusual behavior. But I am on it. See
-        #2434.
-        """
-        path = self.filesView.get_current_path()
-        path = str(pathlib.Path(path).parent)
-
-        # use root dir by default
-        return path if path else '/'
+        self._restore_to([self.path])
 
     # |------------|
     # | Files View |

--- a/qt/app.py
+++ b/qt/app.py
@@ -211,8 +211,19 @@ class MainWindow(QMainWindow):
 
         self.snapshotsList = []
 
-        # ???
-        self.path = self.config.the_dict().get('qt.last_path', '/')
+        profile_state = state_data.profile(self.config.currentProfile())
+
+        # Dev note (buhtz, 2026-08): The purpose's of this variable were not
+        # clear not me in the beginning. There was not docu about it.
+        #
+        # It seems to be the current path shown in the files view and/or in the
+        # path-widget on top of the files view.
+        #
+        # Current logical path in the backup tree shown in the files view.
+        # This is not an absolute filesystem path. Resolve it with
+        # self.sid.pathBackup(self.path). The value represents GUI navigation
+        # state and is kept when switching backups.
+        self.path = str(profile_state.last_path)
 
         self.widget_current_path.setText(self.path)
         self.path_history = tools.PathHistory(self.path)
@@ -1002,13 +1013,14 @@ class MainWindow(QMainWindow):
 
         # Dev note (buhtz, 2025-04): Makes not much sense to me. Investigate.
         if self.shutdown.ask_before_quit():
-            msg = _('If this window is closed, Back In Time will not be able '
-                    'to shut down your system when the backup is finished.')
+            msg = _(
+                'If this window is closed, Back In Time will not be able '
+                'to shut down your system when the backup is finished.'
+            )
             msg = msg + '\n'
             msg = msg + _('Close the window anyway?')
 
-            answer = messagebox.question(text=msg,
-                                         widget_to_center_on=self)
+            answer = messagebox.question(text=msg, widget_to_center_on=self)
             if not answer:
                 return event.ignore()
 
@@ -2587,10 +2599,10 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
         # val = cfg.the_dict().get(f'profile{profile_id}.msg_shown_encfs', 0)
         # profile_state.msg_encfs = val
 
-        # # qt.last_path
-        # if cfg.hasProfileKey('qt.last_path', profile_id):
-        #     profile_state.last_path \
-        #         = cfg.profileStrValue('qt.last_path', None, profile_id)
+        # qt.last_path
+        key = 'profile' + profile_id + '.' + 'qt.last_path'
+        if key in cfg.the_dict():
+            profile_state.last_path = Path(cfg.the_dict()[key])
 
         # Places: sorting
         sorting = (
@@ -2657,8 +2669,9 @@ def load_state_data(cfg: config.Config) -> None:
         _get_state_data_from_config(cfg)
 
     except json.decoder.JSONDecodeError as exc:
-        logger.warning(f'Unable to read and decode state file "{fp}". '
-                       'Ignnoring it.')
+        logger.warning(
+            f'Unable to read and decode state file "{fp}". Ignnoring it.'
+        )
         logger.debug(f'{exc=}')
 
         try:

--- a/qt/app.py
+++ b/qt/app.py
@@ -1376,16 +1376,19 @@ class MainWindow(QMainWindow):
         self.act_name_snapshot.setEnabled(enable)
         self.act_remove_snapshot.setEnabled(enable)
         self.act_snapshot_logview.setEnabled(enable)
+        # self._enable_restore_ui_elements(enable)
 
     def is_now_selected(self) -> bool:
         """Workaround"""
         return self.timeline.is_now_selected()
 
     def _on_now_selected(self):
+        print('_on_NOW_selected()')  # DEBUG
         self._enable_snapshot_actions(False)
         self.updateFilesView(2)
 
     def _on_backup_selected(self, _sid):
+        print('_on_backup_selected()')  # DEBUG
         self._enable_snapshot_actions(True)
         self.updateFilesView(2)
 
@@ -1603,6 +1606,7 @@ class MainWindow(QMainWindow):
             self.filesView.show_hidden(self.showHiddenFiles)
             self.filesView.set_root_path(full_path)
             self.stackFilesView.setCurrentWidget(self.filesView)
+
         else:
             enable_flag = False
             self.stackFilesView.setCurrentWidget(
@@ -1634,6 +1638,7 @@ class MainWindow(QMainWindow):
         in the timeline all UI elements related to restoring should be
         disabled.
         """
+        print('restore enabled:', enable)
 
         # The whole sub-menu incl. its button/entry. The related UI elements
         # are the "Restore" entry in the main-menu and the toolbar button in
@@ -1644,6 +1649,18 @@ class MainWindow(QMainWindow):
         # the context menu of the files view.
         self.act_restore.setEnabled(enable)
         self.act_restore_to.setEnabled(enable)
+
+        print(
+            'menu:',
+            self.act_restore_menu.text(),
+            self.act_restore_menu.isEnabled()
+        )
+
+        print(
+            'restore:',
+            self.act_restore.isEnabled(),
+            self.act_restore_to.isEnabled()
+        )
 
         if path:
             self.act_restore_parent.setText(

--- a/qt/app.py
+++ b/qt/app.py
@@ -216,13 +216,14 @@ class MainWindow(QMainWindow):
         # Dev note (buhtz, 2026-08): The purpose's of this variable were not
         # clear not me in the beginning. There was not docu about it.
         #
-        # It seems to be the current path shown in the files view and/or in the
-        # path-widget on top of the files view.
+        # Current logical path shown in the files view.
         #
-        # Current logical path in the backup tree shown in the files view.
-        # This is not an absolute filesystem path. Resolve it with
-        # self.sid.pathBackup(self.path). The value represents GUI navigation
-        # state. self.path is independent from the selected backup.
+        # This is a path inside the backup tree, not an absolute filesystem
+        # path. The selected backup resolves this path to the real filesystem
+        # location.
+        #
+        # self.path represents GUI navigation state and is independent from
+        # the selected backup.
         self.path = str(profile_state.last_path)
 
         self.widget_current_path.setText(self.path)
@@ -2580,8 +2581,10 @@ def _get_state_data_from_config(cfg: config.Config) -> StateData:
 
         # qt.last_path
         key = 'profile' + profile_id + '.' + 'qt.last_path'
-        if key in cfg.the_dict():
-            profile_state.last_path = Path(cfg.the_dict()[key])
+        try:
+            profile_state.last_path = pathlib.Path(cfg.the_dict()[key])
+        except KeyError:
+            pass
 
         # Places: sorting
         sorting = (

--- a/qt/app.py
+++ b/qt/app.py
@@ -1612,7 +1612,8 @@ class MainWindow(QMainWindow):
         # the handler in mainwindow than should decide about enable or disable
         # all this other UI elements.
         if os.path.isdir(full_path):
-            enable_flag = True
+            enable_flag = not self.timeline.is_now_selected()
+
             self.filesView.show_hidden(self.showHiddenFiles)
             self.filesView.set_root_path(full_path)
             self.stackFilesView.setCurrentWidget(self.filesView)

--- a/qt/app.py
+++ b/qt/app.py
@@ -1386,19 +1386,16 @@ class MainWindow(QMainWindow):
         self.act_name_snapshot.setEnabled(enable)
         self.act_remove_snapshot.setEnabled(enable)
         self.act_snapshot_logview.setEnabled(enable)
-        # self._enable_restore_ui_elements(enable)
 
     def is_now_selected(self) -> bool:
         """Workaround"""
         return self.timeline.is_now_selected()
 
     def _on_now_selected(self):
-        print('_on_NOW_selected()')  # DEBUG
         self._enable_snapshot_actions(False)
         self.updateFilesView(2)
 
     def _on_backup_selected(self, _sid):
-        print('_on_backup_selected()')  # DEBUG
         self._enable_snapshot_actions(True)
         self.updateFilesView(2)
 
@@ -1649,7 +1646,6 @@ class MainWindow(QMainWindow):
         in the timeline all UI elements related to restoring should be
         disabled.
         """
-        print('restore enabled:', enable)
 
         # The whole sub-menu incl. its button/entry. The related UI elements
         # are the "Restore" entry in the main-menu and the toolbar button in
@@ -1660,18 +1656,6 @@ class MainWindow(QMainWindow):
         # the context menu of the files view.
         self.act_restore.setEnabled(enable)
         self.act_restore_to.setEnabled(enable)
-
-        print(
-            'menu:',
-            self.act_restore_menu.text(),
-            self.act_restore_menu.isEnabled()
-        )
-
-        print(
-            'restore:',
-            self.act_restore.isEnabled(),
-            self.act_restore_to.isEnabled()
-        )
 
         if path:
             self.act_restore_parent.setText(

--- a/qt/statedata.py
+++ b/qt/statedata.py
@@ -69,11 +69,13 @@ class StateData(dict, metaclass=singleton.Singleton):
         def last_path(self) -> Path:
             """Last path used in the GUI.
 
-            Raises:
-                KeyError
+            Default is Path('/').
             """
-            return Path(self._state['gui']['mainwindow'][
-                'last_path'][self._profile_id])
+            try:
+                return Path(self._state['gui']['mainwindow'][
+                    'last_path'][self._profile_id])
+            except KeyError:
+                return Path('/')
 
         @last_path.setter
         def last_path(self, path: Path) -> None:

--- a/qt/test/test_statedata.py
+++ b/qt/test/test_statedata.py
@@ -8,6 +8,7 @@
 """Tests about statefile module."""
 # pylint: disable=wrong-import-position,wrong-import-order
 import unittest
+from pathlib import Path
 from qttools_path import register_backintime_path
 register_backintime_path('common')
 import statedata  # noqa: E402
@@ -88,6 +89,12 @@ class Properties(unittest.TestCase):
             _useless = sut.logview_dims
             _useless = sut.files_view_col_widths
 
+    def test_last_path_default_is_root(self):
+        """The last_path is / by default"""
+        sut = statedata.StateData()
+        profile = sut.profile(42)
+        self.assertEqual(profile.last_path, Path('/'))
+
     def test_profile_not_exist(self):
         """Profile does not exists."""
         sut = statedata.StateData()
@@ -95,4 +102,4 @@ class Properties(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             # pylint: disable=pointless-statement
-            _useless = profile.last_path
+            _useless = profile.include_sorting


### PR DESCRIPTION
Restore the original purpose of `MainWindow.path` as logical navigation state in the files view.

This also repairs the enable/disable behavior of the Restore menu.
Additionally some minor adjustments to translatable source strings.

The "last path semantic" was broken while refactoring some commits in the past because the purpose of this variable wasn't clear. It seems the last release (1.6.1) is not affected by this.