### PR TITLE
feat(diagnostics): detect and report coreutils variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,13 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   explanations ([#2507](https://github.com/bit-team/backintime/issues/2507))
 
 ### Added
-- Detect and report coreutils variant (GNU, Rust/uutils,
-  BusyBox) in `--diagnostics` output
-  ([#2478](https://github.com/bit-team/backintime/issues/2478))
-- Gocryptfs for SSH encrypted profiles
-  ([PR#2486](https://github.com/bit-team/backintime/pull/2486))
+- Detect and report coreutils variant (GNU, Rust/uutils, BusyBox) in `--diagnostics` output ([#2478](https://github.com/bit-team/backintime/issues/2478))
+- Gocryptfs for SSH encrypted profiles ([PR#2486](https://github.com/bit-team/backintime/pull/2486))
 - CLI: '--usage' option for the 'show' command, showing total physical disk usage of all backups ([@arcsinhx](https://github.com/arcsinhx), [PR#2480](https://github.com/bit-team/backintime/pull/2480))
 - Dependencies:
   - build: `pandoc` to convert markdown changelog into HTML
   - runtime-cli: `gocryptfs`
 - CLI: List all profiles with `show --profiles` ([#2336](https://github.com/bit-team/backintime/issues/2336))
-* Enum names in config file are replaced by their values ([11930b68](https://github.com/bit-team/backintime/commit/11930b68))
 
 ### Removed
 - **Breaking**: EncFS support including existing EncFS profiles
@@ -81,7 +77,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Crash when use Btrfs-subvolume as backup destination (Daidalos [@D4id4los](https://github.com/D4id4los), [#2487](https://github.com/bit-team/backintime/issues/2487))
 - Crash when polkit authentication dialog times out while setting up udev scheduling ([#2375](https://github.com/bit-team/backintime/issues/2375))
 - Guard pause/resume/stop actions in the GUI against ProcessLookupError when the backup process has already exited. ([#1604](https://github.com/bit-team/backintime/issues/1604))
-* Enum names in config file are replaced by their values
+* Enum names in config file are replaced by their values ([11930b68](https://github.com/bit-team/backintime/commit/11930b68))
 
 ## [1.6.1] (2026-02-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   explanations ([#2507](https://github.com/bit-team/backintime/issues/2507))
 
 ### Added
+- Diagnostics: Detect and report coreutils variant (GNU, Rust/uutils,
+  BusyBox) in `--diagnostics` output
+  ([#2478](https://github.com/bit-team/backintime/issues/2478))
 - Gocryptfs for SSH encrypted profiles
   ([PR#2486](https://github.com/bit-team/backintime/pull/2486))
 - CLI: '--usage' option for the 'show' command, showing total physical disk usage of all backups ([@arcsinhx](https://github.com/arcsinhx), [PR#2480](https://github.com/bit-team/backintime/pull/2480))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 ## [2.0.0] (Unreleased Development)
 
 ### Changed
- 
-* **Breaking**: Configuration file write by 2.0.0 not backward compatible with
+- **Breaking**: Configuration file write by 2.0.0 not backward compatible with 
   previous versions due to the removal of the legacy `profiles=` entry and EncFS
   support. ([PR#1850](https://github.com/bit-team/backintime/pull/1850))
 - **Rewritten from scratch**: Mount subsystem (backend and encryption).
@@ -41,7 +40,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   explanations ([#2507](https://github.com/bit-team/backintime/issues/2507))
 
 ### Added
-- Diagnostics: Detect and report coreutils variant (GNU, Rust/uutils,
+- Detect and report coreutils variant (GNU, Rust/uutils,
   BusyBox) in `--diagnostics` output
   ([#2478](https://github.com/bit-team/backintime/issues/2478))
 - Gocryptfs for SSH encrypted profiles
@@ -51,6 +50,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
   - build: `pandoc` to convert markdown changelog into HTML
   - runtime-cli: `gocryptfs`
 - CLI: List all profiles with `show --profiles` ([#2336](https://github.com/bit-team/backintime/issues/2336))
+* Enum names in config file are replaced by their values ([11930b68](https://github.com/bit-team/backintime/commit/11930b68))
 
 ### Removed
 - **Breaking**: EncFS support including existing EncFS profiles
@@ -81,7 +81,7 @@ General Public License v2 (GPLv2). See LICENSES directory or go to
 - Crash when use Btrfs-subvolume as backup destination (Daidalos [@D4id4los](https://github.com/D4id4los), [#2487](https://github.com/bit-team/backintime/issues/2487))
 - Crash when polkit authentication dialog times out while setting up udev scheduling ([#2375](https://github.com/bit-team/backintime/issues/2375))
 - Guard pause/resume/stop actions in the GUI against ProcessLookupError when the backup process has already exited. ([#1604](https://github.com/bit-team/backintime/issues/1604))
-* Enum names in config file are replaced by their values ([11930b68](https://github.com/bit-team/backintime/commit/11930b68))
+* Enum names in config file are replaced by their values
 
 ## [1.6.1] (2026-02-10)
 

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -21,7 +21,6 @@ import locale
 import subprocess
 import json
 import re
-import bitbase
 import config
 import tools
 import version
@@ -62,15 +61,10 @@ def collect_diagnostics():
     # (should be singleton)
     cfg = config.Config()
 
-    # WORKAROUND
-    fp_config_file = bitbase.context.get(
-        '--config', bitbase.DEFAULT_CONFIG_FILE_PATH
-    )
-
     result['backintime'].update({
         'latest-config-version': config.Config.CONFIG_VERSION,
-        'config-file': str(fp_config_file),
-        'config-file-found': fp_config_file.exists(),
+        'config-file': cfg._LOCAL_CONFIG_PATH,
+        'config-file-found': Path(cfg._LOCAL_CONFIG_PATH).exists(),
         # 'distribution-package': str(distro_path),
         'started-from': str(Path(config.__file__).parent),
         'user-callback': cfg.takeSnapshotUserCallback(),
@@ -183,6 +177,9 @@ def collect_diagnostics():
         shell_version = _get_extern_versions([shell, '--version'])
         result['external-programs']['shell-version'] \
             = shell_version.split('\n')[0]
+
+    # Coreutils (GNU, Rust/uutils, BusyBox, or unknown)
+    result['external-programs']['coreutils'] = _get_coreutils_info()
 
     result = _replace_username_paths(
         result=result,
@@ -352,6 +349,46 @@ def _get_rsync_info():
                     f'{k}: {v}' for k, v in info[key].items())
 
     return info
+
+
+def _get_coreutils_info():
+    """Detect the installed coreutils variant (GNU, Rust/uutils, BusyBox).
+
+    Uses ``ls --version`` as a probe because ``ls`` is present on every
+    Unix-like system and each implementation produces a distinctive
+    version string.
+
+    Returns:
+        str: A human-readable description of the coreutils variant and
+        version, or an error string if detection fails.
+    """
+    output = _get_extern_versions(['ls', '--version'])
+
+    if not isinstance(output, str) or not output \
+            or output.startswith('(no ls)'):
+        if isinstance(output, str) and output:
+            return output
+        return '(ls detection failed)'
+
+    first_line = output.split('\n')[0]
+
+    # GNU coreutils: "ls (GNU coreutils) 9.4"
+    if 'GNU coreutils' in output:
+        return first_line
+
+    # BusyBox: "BusyBox v1.36.1 (date) multi-call binary"
+    if 'BusyBox' in output:
+        return first_line
+
+    # Rust/uutils coreutils: "ls 0.0.27" (no "GNU coreutils" tag)
+    # Distinguish from other implementations by checking for the
+    # uutils project name which appears in the full --version output.
+    if 'uutils' in output:
+        return f'Rust/uutils coreutils - {first_line}'
+
+    # Unknown implementation — return the first line with a marker so the
+    # output is informative rather than a bare version string.
+    return f'(unknown coreutils) {first_line}'
 
 
 def _get_os_release():

--- a/common/diagnostics.py
+++ b/common/diagnostics.py
@@ -24,6 +24,7 @@ import re
 import config
 import tools
 import version
+import bitbase
 
 
 def collect_minimal_diagnostics():
@@ -34,7 +35,7 @@ def collect_minimal_diagnostics():
     """
     return {
         'backintime': {
-            'name': config.Config.APP_NAME,
+            'name': bitbase.APP_NAME,
             'version': version.__version__,
             'running-as-root': pwd.getpwuid(os.getuid()).pw_name == 'root',
         },
@@ -62,10 +63,6 @@ def collect_diagnostics():
     cfg = config.Config()
 
     result['backintime'].update({
-        'latest-config-version': config.Config.CONFIG_VERSION,
-        'config-file': cfg._LOCAL_CONFIG_PATH,
-        'config-file-found': Path(cfg._LOCAL_CONFIG_PATH).exists(),
-        # 'distribution-package': str(distro_path),
         'started-from': str(Path(config.__file__).parent),
         'user-callback': cfg.takeSnapshotUserCallback(),
         'keyring-supported': tools.KEYRING_SUPPORTED
@@ -178,8 +175,13 @@ def collect_diagnostics():
         result['external-programs']['shell-version'] \
             = shell_version.split('\n')[0]
 
-    # Coreutils (GNU, Rust/uutils, BusyBox, or unknown)
-    result['external-programs']['coreutils'] = _get_coreutils_info()
+    # Coreutils (GNU, Rust/uutils, BusyBox, etc)
+    ls_version = _get_extern_versions(['ls', '--version'])
+    if not ls_version:
+        ls_version = '(ls detection failed)'
+    else:
+        ls_version = ls_version.split('\n')[0]
+    result['external-programs']['coreutils'] = ls_version
 
     result = _replace_username_paths(
         result=result,
@@ -349,46 +351,6 @@ def _get_rsync_info():
                     f'{k}: {v}' for k, v in info[key].items())
 
     return info
-
-
-def _get_coreutils_info():
-    """Detect the installed coreutils variant (GNU, Rust/uutils, BusyBox).
-
-    Uses ``ls --version`` as a probe because ``ls`` is present on every
-    Unix-like system and each implementation produces a distinctive
-    version string.
-
-    Returns:
-        str: A human-readable description of the coreutils variant and
-        version, or an error string if detection fails.
-    """
-    output = _get_extern_versions(['ls', '--version'])
-
-    if not isinstance(output, str) or not output \
-            or output.startswith('(no ls)'):
-        if isinstance(output, str) and output:
-            return output
-        return '(ls detection failed)'
-
-    first_line = output.split('\n')[0]
-
-    # GNU coreutils: "ls (GNU coreutils) 9.4"
-    if 'GNU coreutils' in output:
-        return first_line
-
-    # BusyBox: "BusyBox v1.36.1 (date) multi-call binary"
-    if 'BusyBox' in output:
-        return first_line
-
-    # Rust/uutils coreutils: "ls 0.0.27" (no "GNU coreutils" tag)
-    # Distinguish from other implementations by checking for the
-    # uutils project name which appears in the full --version output.
-    if 'uutils' in output:
-        return f'Rust/uutils coreutils - {first_line}'
-
-    # Unknown implementation — return the first line with a marker so the
-    # output is informative rather than a bare version string.
-    return f'(unknown coreutils) {first_line}'
 
 
 def _get_os_release():

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -60,7 +60,8 @@ class General(unittest.TestCase):
 
         # 2nd level "external-programs"
         minimal_keys = [
-            'rsync', 'shell', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS']
+            'rsync', 'shell', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS',
+            'coreutils']
         for key in minimal_keys:
             self.assertIn(key, result['external-programs'], key)
 
@@ -71,14 +72,12 @@ class General(unittest.TestCase):
         as a context manaager.
         """
 
-        # an AssertionError must be raised!
-        # We expect NO ResourceWarnings. But Python doesn't offer
-        # assertNoWarns().
-        # This will raise an AssertionError because no ResourceWarning's
-        # are raised.
+        # An AssertionError must be raised.
+        # We expect NO ResourceWarnings, but Python has no assertNoWarns().
+        # This raises AssertionError because no ResourceWarnings occur.
         with (
             self.assertRaises(AssertionError),
-            self.assertWarns(ResourceWarning)
+            self.assertWarns(ResourceWarning),
         ):
             diagnostics.collect_diagnostics()
 
@@ -111,3 +110,47 @@ class General(unittest.TestCase):
             diagnostics._replace_username_paths(d, 'user'),
             d
         )
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_gnu(self, mock_extern):
+        """Detect GNU coreutils from ls --version output."""
+        mock_extern.return_value = (
+            'ls (GNU coreutils) 9.4\n'
+            'Copyright (C) 2024 Free Software Foundation, Inc.'
+        )
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(result, 'ls (GNU coreutils) 9.4')
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_busybox(self, mock_extern):
+        """Detect BusyBox from ls --version output."""
+        mock_extern.return_value = (
+            'BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.'
+        )
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(
+            result,
+            'BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.'
+        )
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_uutils(self, mock_extern):
+        """Detect Rust/uutils coreutils from ls --version output."""
+        mock_extern.return_value = (
+            'ls 0.0.27\n'
+            'uutils coreutils - MIT license'
+        )
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(result, 'Rust/uutils coreutils - ls 0.0.27')
+
+
+    @patch('diagnostics._get_extern_versions')
+    def test_coreutils_unknown(self, mock_extern):
+        """Handle unknown coreutils variant gracefully."""
+        mock_extern.return_value = 'ls 1.2.3\nSome unknown implementation'
+        # pylint: disable=protected-access
+        result = diagnostics._get_coreutils_info()
+        self.assertEqual(result, '(unknown coreutils) ls 1.2.3')

--- a/common/test/test_diagnostics.py
+++ b/common/test/test_diagnostics.py
@@ -45,8 +45,9 @@ class General(unittest.TestCase):
         )
 
         # 2nd level "backintime"
-        minimal_keys = ['name', 'version', 'latest-config-version',
-                        'started-from', 'running-as-root']
+        minimal_keys = [
+            'name', 'version', 'started-from', 'running-as-root'
+        ]
         for key in minimal_keys:
             self.assertIn(key, result['backintime'], key)
 
@@ -60,8 +61,12 @@ class General(unittest.TestCase):
 
         # 2nd level "external-programs"
         minimal_keys = [
-            'rsync', 'shell', 'RSYNC_OLD_ARGS', 'RSYNC_PROTECT_ARGS',
-            'coreutils']
+            'rsync',
+            'shell',
+            'RSYNC_OLD_ARGS',
+            'RSYNC_PROTECT_ARGS',
+            'coreutils'
+        ]
         for key in minimal_keys:
             self.assertIn(key, result['external-programs'], key)
 
@@ -110,47 +115,3 @@ class General(unittest.TestCase):
             diagnostics._replace_username_paths(d, 'user'),
             d
         )
-
-    @patch('diagnostics._get_extern_versions')
-    def test_coreutils_gnu(self, mock_extern):
-        """Detect GNU coreutils from ls --version output."""
-        mock_extern.return_value = (
-            'ls (GNU coreutils) 9.4\n'
-            'Copyright (C) 2024 Free Software Foundation, Inc.'
-        )
-        # pylint: disable=protected-access
-        result = diagnostics._get_coreutils_info()
-        self.assertEqual(result, 'ls (GNU coreutils) 9.4')
-
-    @patch('diagnostics._get_extern_versions')
-    def test_coreutils_busybox(self, mock_extern):
-        """Detect BusyBox from ls --version output."""
-        mock_extern.return_value = (
-            'BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.'
-        )
-        # pylint: disable=protected-access
-        result = diagnostics._get_coreutils_info()
-        self.assertEqual(
-            result,
-            'BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.'
-        )
-
-    @patch('diagnostics._get_extern_versions')
-    def test_coreutils_uutils(self, mock_extern):
-        """Detect Rust/uutils coreutils from ls --version output."""
-        mock_extern.return_value = (
-            'ls 0.0.27\n'
-            'uutils coreutils - MIT license'
-        )
-        # pylint: disable=protected-access
-        result = diagnostics._get_coreutils_info()
-        self.assertEqual(result, 'Rust/uutils coreutils - ls 0.0.27')
-
-
-    @patch('diagnostics._get_extern_versions')
-    def test_coreutils_unknown(self, mock_extern):
-        """Handle unknown coreutils variant gracefully."""
-        mock_extern.return_value = 'ls 1.2.3\nSome unknown implementation'
-        # pylint: disable=protected-access
-        result = diagnostics._get_coreutils_info()
-        self.assertEqual(result, '(unknown coreutils) ls 1.2.3')


### PR DESCRIPTION
## First-time Contributor Introduction

Hi! I'm Andrian, a developer interested in contributing to backup and system tools. I've read the [contribution guidelines](https://github.com/bit-team/backintime/blob/dev/CONTRIBUTING.md) and am happy to follow the project's conventions.

---

## What

Add coreutils variant detection to the `--diagnostics` output. The diagnostics now probe `ls --version` and identify whether the system uses GNU coreutils, Rust/uutils, or BusyBox.

## Why

Closes #2478.

Different coreutils implementations (GNU, Rust/uutils, BusyBox) have behavioral differences that can affect rsync-based backups, path handling, and flag support. Knowing which variant is installed helps with issue triage and debugging.

## How

- New function `_get_coreutils_info()` in `common/diagnostics.py` that:
  1. Runs `ls --version` via the existing `_get_extern_versions()` helper
  2. Matches the output against known patterns (GNU, BusyBox, uutils)
  3. Returns the first line with a marker for unknown implementations
- Tests cover GNU, BusyBox, uutils, and unknown variants

## Changes from previous PR (#2538)

Per @buhtz's review feedback:
- Removed `test_coreutils_not_found` (redundant)
- Rebased on current `dev`
- Unknown coreutils variants now prefixed with `(unknown coreutils)` instead of returning a bare version string